### PR TITLE
Resource Details Page

### DIFF
--- a/src/shared/components/Lists/ListItem.tsx
+++ b/src/shared/components/Lists/ListItem.tsx
@@ -137,7 +137,6 @@ const ListItemContainer: React.FunctionComponent<ListItemContainerProps> = ({
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          minHeight: '50%',
         }}
       >
         {!data && (

--- a/src/shared/components/Lists/ListItem.tsx
+++ b/src/shared/components/Lists/ListItem.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { PaginationSettings } from '@bbp/nexus-sdk';
+import { PaginationSettings, Resource } from '@bbp/nexus-sdk';
 import { connect } from 'react-redux';
 import { List } from '../../store/reducers/lists';
 import Renameable from '../Renameable';
@@ -9,7 +9,7 @@ import ResourceList from '../Resources/ResourceList';
 import { updateList, deleteList, cloneList } from '../../store/actions/lists';
 import { queryResources, makeESQuery } from '../../store/actions/queryResource';
 import ListControlPanel from './ListControlPanel';
-
+import { push } from 'connected-react-router';
 interface ListItemContainerProps {
   list: List;
   listIndex: number;
@@ -20,6 +20,7 @@ interface ListItemContainerProps {
   updateList: (listIndex: number, list: List) => void;
   deleteList: (listIndex: number) => void;
   cloneList: () => void;
+  goToResource: (resource: Resource) => void;
   queryResources: (paginationSettings: PaginationSettings, query?: any) => void;
 }
 
@@ -33,6 +34,7 @@ const ListItemContainer: React.FunctionComponent<ListItemContainerProps> = ({
   projectLabel,
   queryResources,
   displayPerPage,
+  goToResource,
 }) => {
   const DEFAULT_PAGINATION_SETTINGS = {
     from: 0,
@@ -157,6 +159,7 @@ const ListItemContainer: React.FunctionComponent<ListItemContainerProps> = ({
             }}
             paginationChange={handlePaginationChange}
             resources={data.resources}
+            goToResource={goToResource}
           />
         )}
       </div>
@@ -172,6 +175,14 @@ const mapDispatchToProps = (
   dispatch: any,
   { orgProjectFilterKey, orgLabel, projectLabel, listIndex, list }: any
 ) => ({
+  goToResource: (resource: Resource) =>
+    dispatch(
+      push(
+        `/${orgLabel}/${projectLabel}/resources/${encodeURIComponent(
+          resource.id
+        )}`
+      )
+    ),
   updateList: (listIndex: number, list: List) =>
     dispatch(updateList(orgProjectFilterKey, listIndex, list)),
   deleteList: (listIndex: number) =>

--- a/src/shared/components/Resources/ResourceDetails.less
+++ b/src/shared/components/Resources/ResourceDetails.less
@@ -1,0 +1,2 @@
+.resource-details {
+}

--- a/src/shared/components/Resources/ResourceDetails.less
+++ b/src/shared/components/Resources/ResourceDetails.less
@@ -1,2 +1,0 @@
-.resource-details {
-}

--- a/src/shared/components/Resources/ResourceDetails.tsx
+++ b/src/shared/components/Resources/ResourceDetails.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import { Resource } from '@bbp/nexus-sdk';
+import { Spin, Button, notification, Icon } from 'antd';
+import './ResourceDetails.less';
+import ResourceEditor from './ResourceEditor';
+
+export interface ResourceViewProps {
+  resource: Resource | null;
+  error: Error | null;
+  isFetching: boolean | false;
+  onSuccess: VoidFunction;
+}
+
+const ResourceDetails: React.FunctionComponent<ResourceViewProps> = props => {
+  const { resource, error, isFetching, onSuccess } = props;
+  const [editing, setEditing] = React.useState(false);
+  const [busy, setFormBusy] = React.useState(isFetching);
+
+  const handleSubmit = async (value: any) => {
+    if (resource) {
+      try {
+        setFormBusy(true);
+        console.log(resource);
+        await resource.update({
+          context: resource.context,
+          ...value,
+        });
+        notification.success({
+          message: 'Resource saved',
+          description: resource.name,
+          duration: 2,
+        });
+        onSuccess();
+        setFormBusy(false);
+        setEditing(false);
+      } catch (error) {
+        notification.error({
+          message: 'An unknown error occurred',
+          description: error.message,
+          duration: 0,
+        });
+        setFormBusy(false);
+      }
+    }
+  };
+
+  return (
+    <div className="resource-details" style={{ width: '100%' }}>
+      <Spin spinning={busy} style={{ width: '100%' }}>
+        {!!resource && (
+          <ResourceEditor
+            rawData={{
+              context: resource.context,
+              type: resource.type,
+              ...resource.data,
+            }}
+            onSubmit={handleSubmit}
+            editing={editing}
+          />
+        )}
+      </Spin>
+    </div>
+  );
+};
+
+export default ResourceDetails;

--- a/src/shared/components/Resources/ResourceDetails.tsx
+++ b/src/shared/components/Resources/ResourceDetails.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { Resource } from '@bbp/nexus-sdk';
-import { Spin, Button, notification, Icon } from 'antd';
-import './ResourceDetails.less';
+import { Spin, notification } from 'antd';
 import ResourceEditor from './ResourceEditor';
 
 export interface ResourceViewProps {
@@ -20,7 +19,6 @@ const ResourceDetails: React.FunctionComponent<ResourceViewProps> = props => {
     if (resource) {
       try {
         setFormBusy(true);
-        console.log(resource);
         await resource.update({
           context: resource.context,
           ...value,

--- a/src/shared/components/Resources/ResourceEditor.less
+++ b/src/shared/components/Resources/ResourceEditor.less
@@ -2,6 +2,26 @@
 @import '../../../../node_modules/codemirror/lib/codemirror.css';
 @import '../../../../node_modules/codemirror/theme/base16-light.css';
 
+// codemirror styling
+.cm-s-base16-light span.cm-string {
+  // string values
+}
+.cm-s-base16-light span.cm-string.cm-property {
+  color: @link-color;
+}
+.CodeMirror {
+  height: auto;
+  pre {
+    color: @text-color;
+  }
+}
+.sm-string .cm-property {
+  color: @text-color;
+}
+.cm-s-base16-light.CodeMirror {
+  background-color: white;
+}
+
 .resource-editor {
   border: 1px solid #e8e8e8;
   transition: all 300 ease;

--- a/src/shared/components/Resources/ResourceEditor.tsx
+++ b/src/shared/components/Resources/ResourceEditor.tsx
@@ -12,11 +12,12 @@ if (typeof window !== 'undefined') {
 export interface ResourceEditorProps {
   rawData: { [key: string]: any }; // any object
   onSubmit: (rawData: { [key: string]: any }) => void;
+  editing?: boolean;
 }
 
 const ResourceEditor: React.FunctionComponent<ResourceEditorProps> = props => {
-  const { rawData, onSubmit } = props;
-  const [editing, setEditing] = React.useState(false);
+  const { rawData, onSubmit, editing = false } = props;
+  const [isEditing, setEditing] = React.useState(editing);
   const [valid, setValid] = React.useState(true);
   const [value, setValue] = React.useState(rawData);
 
@@ -41,24 +42,24 @@ const ResourceEditor: React.FunctionComponent<ResourceEditorProps> = props => {
     <div className={valid ? 'resource-editor' : 'resource-editor _invalid'}>
       <div className="control-panel">
         <div>
-          {!editing && (
+          {!isEditing && (
             <div className="feedback">
               <Icon type="info-circle" /> Directly edit this resource
             </div>
           )}
-          {editing && valid && (
+          {isEditing && valid && (
             <div className="feedback _positive">
               <Icon type="check-circle" /> Valid
             </div>
           )}
-          {editing && !valid && (
+          {isEditing && !valid && (
             <div className="feedback _negative">
               <Icon type="exclamation-circle" /> Invalid JSON-LD
             </div>
           )}
         </div>
         <div className="controls">
-          {editing && valid && (
+          {isEditing && valid && (
             <Button
               icon="save"
               type="primary"

--- a/src/shared/components/Resources/ResourceList.tsx
+++ b/src/shared/components/Resources/ResourceList.tsx
@@ -1,14 +1,8 @@
 import * as React from 'react';
-import { Drawer } from 'antd';
-import { PaginatedList, Resource, PaginationSettings } from '@bbp/nexus-sdk';
-import ResourceItem, { ResourceItemProps } from './ResourceItem';
+import { PaginatedList, Resource } from '@bbp/nexus-sdk';
+import ResourceItem from './ResourceItem';
 import './Resources.less';
 import AnimatedList from '../Animations/AnimatedList';
-
-let ReactJson: any;
-if (typeof window !== 'undefined') {
-  ReactJson = require('react-json-view').default;
-}
 
 export interface ResourceListProps {
   header?: React.ReactNode;
@@ -16,6 +10,7 @@ export interface ResourceListProps {
   paginationChange: any;
   paginationSettings: { total: number; from: number; pageSize: number };
   loading?: boolean;
+  goToResource: (resource: Resource) => void;
 }
 
 const ResourceList: React.FunctionComponent<ResourceListProps> = ({
@@ -24,43 +19,28 @@ const ResourceList: React.FunctionComponent<ResourceListProps> = ({
   paginationChange,
   paginationSettings,
   loading = false,
+  goToResource,
 }) => {
   const { total, results } = resources;
-  const [selectedResource, setSelectedResource] = React.useState(
-    null as Resource | null
-  );
   return (
-    <>
-      <AnimatedList
-        header={header}
-        itemComponent={(resource: Resource, index: number) => (
-          <ResourceItem
-            index={index}
-            key={resource.id}
-            name={resource.name}
-            {...resource}
-            onClick={() => setSelectedResource(resource)}
-          />
-        )}
-        itemName="Resource"
-        results={results}
-        total={total}
-        onPaginationChange={paginationChange}
-        paginationSettings={paginationSettings}
-        loading={loading}
-      />
-      {typeof window !== 'undefined' && selectedResource && (
-        <Drawer
-          width={640}
-          placement="right"
-          onClose={() => setSelectedResource(null)}
-          visible={!!selectedResource}
-          title={selectedResource.name}
-        >
-          <ReactJson src={selectedResource.raw} name={null} />
-        </Drawer>
+    <AnimatedList
+      header={header}
+      itemComponent={(resource: Resource, index: number) => (
+        <ResourceItem
+          index={index}
+          key={resource.id}
+          name={resource.name}
+          {...resource}
+          onClick={() => goToResource(resource)}
+        />
       )}
-    </>
+      itemName="Resource"
+      results={results}
+      total={total}
+      onPaginationChange={paginationChange}
+      paginationSettings={paginationSettings}
+      loading={loading}
+    />
   );
 };
 

--- a/src/shared/components/Types/Types.less
+++ b/src/shared/components/Types/Types.less
@@ -10,7 +10,6 @@
   list-style: none;
   position: relative;
   display: inline-block;
-  margin-right: 2em;
   padding: 0;
   & > .ellipsis {
     display: inline-block;

--- a/src/shared/routes.tsx
+++ b/src/shared/routes.tsx
@@ -4,10 +4,12 @@ import Landing from './views/Landing';
 import Home from './views/Home';
 import Login from './views/Login';
 import Project from './views/Project';
+import Resource from './views/Resource';
 import { fetchOrgs } from './store/actions/nexus/orgs';
 import { fetchOrg } from './store/actions/nexus/activeOrg';
 import { RawElasticSearchQuery, RawSparqlQuery } from './views/RawQuery';
 import { fetchAndAssignProject } from './store/actions/nexus/projects';
+import { fetchAndAssignResource } from './store/actions/nexus/resource';
 import { ThunkAction } from './store';
 import { RootState } from './store/reducers';
 import {
@@ -16,6 +18,7 @@ import {
   OrgBreadcrumbLabel,
   LoginBreadcrumbLabel,
   RawQueryBreadcrumbLabel,
+  ResourceBreadcrumbLabel,
 } from './views/breadcrumbs/BreadcrumbLabels';
 
 export interface RouteWithData extends RouteProps {
@@ -57,6 +60,27 @@ const routes: RouteWithData[] = [
       await fetchAndAssignProject(
         match && match.params && (match.params as any)['org'],
         match && match.params && (match.params as any)['project']
+      )(dispatch, getState, state);
+    },
+  },
+  {
+    path: '/:org/:project/resources/:resourceId',
+    component: Resource,
+    breadcrumbLabel: ResourceBreadcrumbLabel,
+    loadData: (state, match) => async (dispatch, getState, state) => {
+      await fetchOrg(match && match.params && (match.params as any)['org'])(
+        dispatch,
+        getState,
+        state
+      );
+      await fetchAndAssignProject(
+        match && match.params && (match.params as any)['org'],
+        match && match.params && (match.params as any)['project']
+      )(dispatch, getState, state);
+      await fetchAndAssignResource(
+        match && match.params && (match.params as any)['org'],
+        match && match.params && (match.params as any)['project'],
+        match && match.params && (match.params as any)['resourceId']
       )(dispatch, getState, state);
     },
   },

--- a/src/shared/store/actions/nexus/resource.ts
+++ b/src/shared/store/actions/nexus/resource.ts
@@ -1,0 +1,64 @@
+import { ActionCreator, Dispatch } from 'redux';
+import { Project, Resource } from '@bbp/nexus-sdk';
+import { ThunkAction } from '../..';
+import { FetchAction, FetchFulfilledAction, FetchFailedAction } from '../utils';
+
+enum ResourceActionTypes {
+  FETCHING = '@@nexus/RESOURCE_FETCHING',
+  FULFILLED = '@@nexus/RESOURCE_FETHCING_FULFILLED',
+  FAILED = '@@nexus/RESOURCE_FETCHING_FAILED',
+}
+
+export const actionTypes = {
+  FETCHING: ResourceActionTypes.FETCHING,
+  FULFILLED: ResourceActionTypes.FULFILLED,
+  FAILED: ResourceActionTypes.FAILED,
+};
+
+const fetchResourceAction: ActionCreator<
+  FetchAction<ResourceActionTypes.FETCHING>
+> = () => ({
+  type: ResourceActionTypes.FETCHING,
+});
+
+const fetchResourceFulfilledAction: ActionCreator<
+  FetchFulfilledAction<ResourceActionTypes.FULFILLED, Resource>
+> = (resource: Resource) => ({
+  type: ResourceActionTypes.FULFILLED,
+  payload: resource,
+});
+
+const fetchResourceFailedAction: ActionCreator<
+  FetchFailedAction<ResourceActionTypes.FAILED>
+> = (error: Error) => ({
+  error,
+  type: ResourceActionTypes.FAILED,
+});
+
+export type ResourceActions =
+  | FetchAction<ResourceActionTypes.FETCHING>
+  | FetchFulfilledAction<ResourceActionTypes.FULFILLED, Resource>
+  | FetchFailedAction<ResourceActionTypes.FAILED>;
+
+export const fetchAndAssignResource: ActionCreator<ThunkAction> = (
+  orgLabel: string,
+  projectLabel: string,
+  resourceId: string
+) => {
+  return async (
+    dispatch: Dispatch<any>
+  ): Promise<
+    | FetchFulfilledAction<ResourceActionTypes.FULFILLED, Resource>
+    | FetchFailedAction<ResourceActionTypes.FAILED>
+  > => {
+    dispatch(fetchResourceAction());
+    try {
+      const project: Project = await Project.get(orgLabel, projectLabel);
+      const resource = await project.getResource(resourceId);
+      return dispatch(fetchResourceFulfilledAction(resource));
+    } catch (e) {
+      console.error(e);
+      return dispatch(fetchResourceFailedAction(e));
+    }
+  };
+};

--- a/src/shared/store/reducers/nexus.ts
+++ b/src/shared/store/reducers/nexus.ts
@@ -1,4 +1,4 @@
-import { Organization, Project, PaginatedList } from '@bbp/nexus-sdk';
+import { Organization, Project, PaginatedList, Resource } from '@bbp/nexus-sdk';
 import {
   actionTypes as activeOrgActionTypes,
   ActiveOrgActions,
@@ -11,6 +11,10 @@ import {
   actionTypes as projectActionTypes,
   ProjectActions,
 } from '../actions/nexus/projects';
+import {
+  actionTypes as resourceActionTypes,
+  ResourceActions,
+} from '../actions/nexus/resource';
 import { FetchableState, createFetchReducer } from './utils';
 
 export interface NexusState {
@@ -20,6 +24,7 @@ export interface NexusState {
     projects: PaginatedList<Project>;
   }>;
   activeProject?: FetchableState<Project>;
+  activeResource?: FetchableState<Resource>;
 }
 
 const initialState: NexusState = {
@@ -33,10 +38,11 @@ const initialState: NexusState = {
 const activeOrgReducer = createFetchReducer(activeOrgActionTypes);
 const orgsReducer = createFetchReducer(orgsActionTypes, []);
 const projectReducer = createFetchReducer(projectActionTypes);
+const resourceReducer = createFetchReducer(resourceActionTypes);
 
 export default function nexusReducer(
   state: NexusState = initialState,
-  action: ActiveOrgActions | OrgsActions | ProjectActions
+  action: ActiveOrgActions | OrgsActions | ProjectActions | ResourceActions
 ) {
   if (action.type.startsWith('@@nexus/PROJECT_')) {
     return {
@@ -44,11 +50,15 @@ export default function nexusReducer(
       activeProject: projectReducer(state.activeProject, action),
     };
   }
-
+  if (action.type.startsWith('@@nexus/RESOURCE_')) {
+    return {
+      ...state,
+      activeResource: resourceReducer(state.activeResource, action),
+    };
+  }
   if (action.type.startsWith('@@nexus/ORG_')) {
     return { ...state, activeOrg: activeOrgReducer(state.activeOrg, action) };
   }
-
   if (action.type.startsWith('@@nexus/ORGS_')) {
     return { ...state, orgs: orgsReducer(state.orgs, action) };
   }

--- a/src/shared/views/Resource.tsx
+++ b/src/shared/views/Resource.tsx
@@ -1,0 +1,79 @@
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { RootState } from '../store/reducers';
+import { fetchAndAssignResource } from '../store/actions/nexus/resource';
+import { Resource } from '@bbp/nexus-sdk';
+import ResourceView from '../components/Resources/ResourceDetails';
+import Helmet from 'react-helmet';
+
+interface ResourceViewProps {
+  match: any;
+  resource: Resource | null;
+  error: Error | null;
+  isFetching: boolean | false;
+  fetchResource: (
+    orgLabel: string,
+    projectLabel: string,
+    resourceId: string
+  ) => void;
+}
+
+const ResourceViewPage: React.FunctionComponent<ResourceViewProps> = props => {
+  const { match, resource, error, isFetching, fetchResource } = props;
+  const fetch = () => {
+    fetchResource(
+      match.params.org,
+      match.params.project,
+      match.params.resourceId
+    );
+  };
+  React.useEffect(
+    () => {
+      fetch();
+    },
+    [match.params.resourceId]
+  );
+
+  return (
+    <>
+      {!!resource && <Helmet title={resource.name} />}
+      <ResourceView
+        onSuccess={fetch}
+        resource={resource}
+        error={error}
+        isFetching={isFetching}
+      />
+    </>
+  );
+};
+
+const mapStateToProps = (state: RootState) => ({
+  resource:
+    (state.nexus &&
+      state.nexus.activeResource &&
+      state.nexus.activeResource.data &&
+      state.nexus.activeResource.data) ||
+    null,
+  error:
+    (state.nexus &&
+      state.nexus.activeResource &&
+      state.nexus.activeResource.error) ||
+    null,
+  isFetching:
+    (state.nexus &&
+      state.nexus.activeResource &&
+      state.nexus.activeResource.isFetching) ||
+    false,
+});
+const mapDispatchToProps = (dispatch: any) => {
+  return {
+    fetchResource: (orgLabel: string, projectLabel: string, id: string) => {
+      dispatch(fetchAndAssignResource(orgLabel, projectLabel, id));
+    },
+  };
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(ResourceViewPage);

--- a/src/shared/views/breadcrumbs/BreadcrumbLabels.tsx
+++ b/src/shared/views/breadcrumbs/BreadcrumbLabels.tsx
@@ -71,6 +71,33 @@ export const ProjectBreadcrumbLabel = (state: RootState) => {
   );
 };
 
+export const ResourceBreadcrumbLabel = (state: RootState) => {
+  if (
+    state.nexus &&
+    state.nexus.activeResource &&
+    state.nexus.activeResource &&
+    state.nexus.activeResource.isFetching
+  ) {
+    return (
+      <span>
+        <Icon type="profile" /> <Icon type="loading" />
+      </span>
+    );
+  }
+  // TODO what should be the behavior if nothing is found?
+  const activeResourceLabel =
+    (state.nexus &&
+      state.nexus.activeResource &&
+      state.nexus.activeResource.data &&
+      state.nexus.activeResource.data.name) ||
+    'resource';
+  return (
+    <span>
+      <Icon type="profile" /> {activeResourceLabel}
+    </span>
+  );
+};
+
 export const RawQueryBreadcrumbLabel = () => {
   return (
     <span>


### PR DESCRIPTION
# Resource Pages!
> as part of "project dismantle https://github.com/BlueBrain/nexus-web/pull/112"

## NEW
- viewing/editing resources
- resource details page (somewhat sparse)
- links from the resource list

## Caveats
- It's missing the metaData, which will be added in a subsequent PR. 
- Because the pinterest route is hard to implement, the resource view will not appear in a modal until I make another PR for that. 
- You cannot edit things like views or schemas. I'm not sure why, I think the API has changed? This must be fixed at the SDK level