### PR TITLE
Image Previews

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -991,9 +991,9 @@
       }
     },
     "@bbp/nexus-sdk": {
-      "version": "1.0.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@bbp/nexus-sdk/-/nexus-sdk-1.0.0-beta.8.tgz",
-      "integrity": "sha512-FD6CnYGxXjhQCuFPVindHOCSPl2vnVEJ9qX1qF3hipSsXYvJwu8LzQcFHuuVhxgtLSeUP8urCrEPjT5Z9kZByg==",
+      "version": "1.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/@bbp/nexus-sdk/-/nexus-sdk-1.0.0-beta.9.tgz",
+      "integrity": "sha512-r+usuU7BfnqEsUh/rO2jE8cNY4WGufCl/C/G1mUp/Zl+OVUWY6IZ6AVD3aQeZ5UFkrIZS6pE0Nv0+fzV+i28rA==",
       "requires": {
         "cross-fetch": "^3.0.0",
         "eventsource": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build:storybook": "build-storybook"
   },
   "dependencies": {
-    "@bbp/nexus-sdk": "1.0.0-beta.8",
+    "@bbp/nexus-sdk": "1.0.0-beta.9",
     "antd": "^3.10.9",
     "codemirror": "^5.43.0",
     "connected-react-router": "^5.0.1",

--- a/src/shared/components/Resources/ResourceItem.tsx
+++ b/src/shared/components/Resources/ResourceItem.tsx
@@ -5,7 +5,7 @@ import TypesIcon from '../Types/TypesIcon';
 import './Resources.less';
 import ResourceMetadataCard from './MetadataCard';
 import { Resource } from '@bbp/nexus-sdk';
-import ResourcePreview from './ResourcePreview';
+import ResourcePreview, { hasDisplayableImage } from './ResourcePreview';
 
 const MOUSE_ENTER_DELAY = 0.5;
 
@@ -20,17 +20,9 @@ const ResourceListItem: React.FunctionComponent<ResourceItemProps> = props => {
   const { resource, index, onClick = () => {} } = props;
   const containerRef = React.createRef<HTMLDivElement>();
 
-  let Preview = null;
-  if (
-    resource.type &&
-    resource.type.includes('File') &&
-    (resource.data as any)['_mediaType'] &&
-    (resource.data as any)['_mediaType'].includes('image') &&
-    // Don't download preview if filesize is > than 1MB
-    (resource.data as any)['_bytes'] <= 1000000
-  ) {
-    Preview = <ResourcePreview resource={resource} />;
-  }
+  const Preview = hasDisplayableImage(resource) ? (
+    <ResourcePreview resource={resource} />
+  ) : null;
 
   const handleKeyPress = (e: any) => {
     const code = e.keyCode || e.which;

--- a/src/shared/components/Resources/ResourceItem.tsx
+++ b/src/shared/components/Resources/ResourceItem.tsx
@@ -25,7 +25,9 @@ const ResourceListItem: React.FunctionComponent<ResourceItemProps> = props => {
     resource.type &&
     resource.type.includes('File') &&
     (resource.data as any)['_mediaType'] &&
-    (resource.data as any)['_mediaType'].includes('image')
+    (resource.data as any)['_mediaType'].includes('image') &&
+    // Don't download preview if filesize is > than 1MB
+    (resource.data as any)['_bytes'] <= 1000000
   ) {
     Preview = <ResourcePreview resource={resource} />;
   }

--- a/src/shared/components/Resources/ResourceItem.tsx
+++ b/src/shared/components/Resources/ResourceItem.tsx
@@ -5,6 +5,7 @@ import TypesIcon from '../Types/TypesIcon';
 import './Resources.less';
 import ResourceMetadataCard from './MetadataCard';
 import { Resource } from '@bbp/nexus-sdk';
+import ResourcePreview from './ResourcePreview';
 
 const MOUSE_ENTER_DELAY = 0.5;
 
@@ -18,6 +19,16 @@ export interface ResourceItemProps {
 const ResourceListItem: React.FunctionComponent<ResourceItemProps> = props => {
   const { resource, index, onClick = () => {} } = props;
   const containerRef = React.createRef<HTMLDivElement>();
+
+  let Preview = null;
+  if (
+    resource.type &&
+    resource.type.includes('File') &&
+    (resource.data as any)['_mediaType'] &&
+    (resource.data as any)['_mediaType'].includes('image')
+  ) {
+    Preview = <ResourcePreview resource={resource} />;
+  }
 
   const handleKeyPress = (e: any) => {
     const code = e.keyCode || e.which;
@@ -41,7 +52,7 @@ const ResourceListItem: React.FunctionComponent<ResourceItemProps> = props => {
         onKeyPress={handleKeyPress}
         tabIndex={index + 1}
       >
-        {/* {Preview} */}
+        {Preview}
         <div className="name">
           <em>{resource.name}</em>
         </div>

--- a/src/shared/components/Resources/ResourcePreview.tsx
+++ b/src/shared/components/Resources/ResourcePreview.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Popover, Avatar } from 'antd';
+import { Popover, Avatar, notification } from 'antd';
 import './Resources.less';
 import { Resource, NexusFile } from '@bbp/nexus-sdk';
 
@@ -7,6 +7,17 @@ const MOUSE_ENTER_DELAY = 0.5;
 
 export interface ResourcePreviewProps {
   resource: Resource;
+}
+
+export function hasDisplayableImage(resource: Resource): boolean {
+  return (
+    resource.type &&
+    resource.type.includes('File') &&
+    (resource.data as any)['_mediaType'] &&
+    (resource.data as any)['_mediaType'].includes('image') &&
+    // Don't download preview if filesize is > than 1MB
+    (resource.data as any)['_bytes'] <= 1000000
+  );
 }
 
 const ResourcePreview: React.FunctionComponent<
@@ -28,6 +39,13 @@ const ResourcePreview: React.FunctionComponent<
       })
       .catch((error: Error) => {
         // Handle error?
+        notification.error({
+          message: 'A file loading error occured',
+          description: error.message,
+          duration: 0,
+        });
+        // @ts-ignore
+        console.error(error);
       });
   }
 

--- a/src/shared/components/Resources/ResourcePreview.tsx
+++ b/src/shared/components/Resources/ResourcePreview.tsx
@@ -16,7 +16,7 @@ export function hasDisplayableImage(resource: Resource): boolean {
     (resource.data as any)['_mediaType'] &&
     (resource.data as any)['_mediaType'].includes('image') &&
     // Don't download preview if filesize is > than 1MB
-    (resource.data as any)['_bytes'] <= 1000000
+    (resource.data as any)['_bytes'] <= 1e6
   );
 }
 
@@ -44,7 +44,7 @@ const ResourcePreview: React.FunctionComponent<
           description: error.message,
           duration: 0,
         });
-        // @ts-ignore
+        // tslint:disable-next-line:no-console
         console.error(error);
       });
   }

--- a/src/shared/components/Resources/ResourcePreview.tsx
+++ b/src/shared/components/Resources/ResourcePreview.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { Popover, Avatar } from 'antd';
+import './Resources.less';
+import { Resource, NexusFile } from '@bbp/nexus-sdk';
+
+const MOUSE_ENTER_DELAY = 0.5;
+
+export interface ResourcePreviewProps {
+  resource: Resource;
+}
+
+const ResourcePreview: React.FunctionComponent<
+  ResourcePreviewProps
+> = props => {
+  const { resource } = props;
+  const [file, setFile] = React.useState<NexusFile | null>(null);
+
+  if (!file) {
+    // TODO: Refactor after ES Lists are fetched by Type
+    NexusFile.getSelf(
+      resource.self,
+      resource.orgLabel,
+      resource.projectLabel,
+      true
+    )
+      .then((nexusFile: NexusFile) => {
+        setFile(nexusFile);
+      })
+      .catch((error: Error) => {
+        console.error(error);
+      });
+  }
+
+  return (
+    <Popover content={'hello'} mouseEnterDelay={MOUSE_ENTER_DELAY}>
+      {file ? (
+        <Avatar
+          shape="square"
+          src={`data:${file.mediaType};base64,${file.rawFile as string}`}
+        />
+      ) : (
+        <Avatar shape="square" icon="picture" />
+      )}
+    </Popover>
+  );
+};
+
+export default ResourcePreview;

--- a/src/shared/components/Resources/ResourcePreview.tsx
+++ b/src/shared/components/Resources/ResourcePreview.tsx
@@ -27,7 +27,7 @@ const ResourcePreview: React.FunctionComponent<
         setFile(nexusFile);
       })
       .catch((error: Error) => {
-        console.error(error);
+        // Handle error?
       });
   }
 

--- a/src/shared/components/Resources/ResourcePreview.tsx
+++ b/src/shared/components/Resources/ResourcePreview.tsx
@@ -38,7 +38,6 @@ const ResourcePreview: React.FunctionComponent<
         setFile(nexusFile);
       })
       .catch((error: Error) => {
-        // Handle error?
         notification.error({
           message: 'A file loading error occured',
           description: error.message,

--- a/src/shared/components/Resources/Resources.less
+++ b/src/shared/components/Resources/Resources.less
@@ -50,6 +50,10 @@
     text-overflow: ellipsis;
     overflow-x: hidden;
     white-space: nowrap;
+    flex-grow: 1;
+  }
+  & > .ant-avatar {
+    margin-right: 1em;
   }
 }
 

--- a/src/shared/store/actions/project.ts
+++ b/src/shared/store/actions/project.ts
@@ -291,7 +291,7 @@ export const makeProjectPublic: ActionCreator<ThunkAction> = (
                 },
               ],
             },
-            false
+            { useBase: false }
           );
           return true;
         } catch (e) {


### PR DESCRIPTION
# image preview support in lists

- Adds a component to demonstrate `NexusFile` class

![screenshot 2019-02-25 at 16 25 16](https://user-images.githubusercontent.com/5485824/53350283-145e3b00-391f-11e9-8eaf-9a9bccac3a1d.png)

## Caveat 
I'm thinking we'll need to move the PaginatedList Resource responses, for example from the ElasticSearchView response, to create the proper classes instead of just Resource, so we can better use typing and instances to switch between specialised components / views. 