### PR TITLE
469 project creation delay

### DIFF
--- a/src/shared/components/Projects/ProjectForm.tsx
+++ b/src/shared/components/Projects/ProjectForm.tsx
@@ -88,7 +88,7 @@ export interface ProjectFormProps {
   form: WrappedFormUtils;
   project?: {
     label: string;
-    rev: number,
+    rev: number;
     description?: string;
     base?: string;
     vocab?: string;
@@ -241,7 +241,10 @@ const ProjectForm: React.FunctionComponent<ProjectFormProps> = ({
     )
   );
   return (
-    <Spin spinning={busy}>
+    <Spin
+      spinning={busy}
+      tip="Please be patient while the project is scaffolded."
+    >
       <Form onSubmit={handleSubmit}>
         <Form.Item label="Label" {...formItemLayout}>
           {getFieldDecorator('label', {
@@ -303,11 +306,9 @@ const ProjectForm: React.FunctionComponent<ProjectFormProps> = ({
               >
                 Deprecate
               </Button>
-              <Button
-                onClick={confirmMakePublic}
-                style={{float: 'right' }}
-              >
-                <Icon type="global" />Make public
+              <Button onClick={confirmMakePublic} style={{ float: 'right' }}>
+                <Icon type="global" />
+                Make public
               </Button>
             </>
           )}

--- a/src/shared/components/Projects/__tests__/__snapshots__/ProjectForm.spec.tsx.snap
+++ b/src/shared/components/Projects/__tests__/__snapshots__/ProjectForm.spec.tsx.snap
@@ -30,6 +30,7 @@ exports[`Project Form component should render correctly 1`] = `
     <Spin
       size="default"
       spinning={false}
+      tip="Please be patient while the project is scaffolded."
       wrapperClassName=""
     >
       <div

--- a/src/shared/store/actions/project.ts
+++ b/src/shared/store/actions/project.ts
@@ -166,7 +166,7 @@ const pollProjectCreated = async (
       if (iterations >= shortCircuitIterationCount) {
         projectReady = true;
         notification.warning({
-          message: 'Project is taking a long time to set up',
+          message: `Project ${projectLabel} is taking a long time to set up`,
           description:
             'This process is taking longer than usual. You might have to grab a coffee and come back later.',
           duration: 0,

--- a/src/shared/store/actions/project.ts
+++ b/src/shared/store/actions/project.ts
@@ -6,9 +6,6 @@ import { httpGet, httpPut } from '@bbp/nexus-sdk/lib/utils/http';
 import { IdentityResponse, Identity } from '@bbp/nexus-sdk/lib/ACL/types';
 import { asyncTimeout } from '../../utils';
 import { notification } from 'antd';
-
-const DEFAULT_ELASTIC_SEARCH_INDEX_ID = 'nxv:defaultElasticSearchIndex';
-
 //
 // Action Types
 //
@@ -142,31 +139,27 @@ const pollProjectCreated = async (
   projectLabel: string
 ): Promise<void> => {
   let projectReady = false;
+  let iterations = 0;
   const pollingTimeInMilliseconds = 500;
   const shortCircuitIterationCount = 60; // 30 seconds
-  let iterations = 0;
   while (!projectReady) {
     try {
-      const esView = await ElasticSearchView.get(
-        orgLabel,
-        projectLabel,
-        DEFAULT_ELASTIC_SEARCH_INDEX_ID
-      );
+      const esView = await ElasticSearchView.get(orgLabel, projectLabel);
       // Even if the view is created, it will take some time until we can query,
       // to make sure we have data in the project, we should make some query here.
-      const { results, total } = await esView.query({});
+      const { total } = await esView.query({});
       if (!total) {
         throw new Error('project not yet ready');
       }
       projectReady = true;
     } catch (error) {
-      // TODO do something if not 404
+      // TODO: maybe do something if not 404?
       await asyncTimeout(pollingTimeInMilliseconds);
       iterations += 1;
       if (iterations >= shortCircuitIterationCount) {
         projectReady = true;
         notification.warning({
-          message: `Project ${projectLabel} is taking a long time to set up`,
+          message: `Project ${projectLabel} is taking too long to set up`,
           description:
             'This process is taking longer than usual. You might have to grab a coffee and come back later.',
           duration: 0,

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -101,3 +101,7 @@ export const getOrderedPermissions = (
 
   return [...new Set(sorted)];
 };
+
+export const asyncTimeout = (timeInMilliseconds: number): Promise<void> => {
+  return new Promise(resolve => setTimeout(resolve, timeInMilliseconds));
+};


### PR DESCRIPTION
# Improved Project Creation Flow ⛲️

> Solving issue: https://github.com/BlueBrain/nexus/issues/469

On project creation, the app will try to query that project's default ES view every .5s. If there's content there, the project is ready and the user will be redirected .

![projectscaffolding](https://user-images.githubusercontent.com/5485824/53953214-0a80c880-40d3-11e9-9f42-12991f7f6d50.gif)

This polling process will last 30 seconds. If still we didn't find that the project is ready, we will redirect to the project landing page anyways with a nice warning that thing's aren't quite read yet, but won't freeze any user actions. 

![projectistakingtoolong](https://user-images.githubusercontent.com/5485824/53953265-2e440e80-40d3-11e9-8c68-34f62b6d05ff.gif)
