### PR TITLE
👷‍♀️FIX: Query Errors

### DIFF
--- a/src/shared/components/Resources/MetadataCard.tsx
+++ b/src/shared/components/Resources/MetadataCard.tsx
@@ -53,11 +53,27 @@ const ResourceMetadataCard: React.FunctionComponent<
                 render={(copySuccess, triggerCopy) => (
                   <Tooltip title={copySuccess ? 'Copied!' : 'Copy @id'}>
                     <Button
+                      style={{ margin: '0 1em' }}
                       size="small"
                       icon={copySuccess ? 'check' : 'copy'}
                       onClick={() => triggerCopy()}
                     >
-                      ID
+                      @id
+                    </Button>
+                  </Tooltip>
+                )}
+              />
+
+              <Copy
+                textToCopy={self}
+                render={(copySuccess, triggerCopy) => (
+                  <Tooltip title={copySuccess ? 'Copied!' : 'Copy _self'}>
+                    <Button
+                      size="small"
+                      icon={copySuccess ? 'check' : 'copy'}
+                      onClick={() => triggerCopy()}
+                    >
+                      _self
                     </Button>
                   </Tooltip>
                 )}

--- a/src/shared/store/actions/rawQuery.ts
+++ b/src/shared/store/actions/rawQuery.ts
@@ -8,6 +8,7 @@ import {
 import { ElasticSearchHit } from '@bbp/nexus-sdk/lib/View/ElasticSearchView/types';
 import { SparqlViewQueryResponse } from '@bbp/nexus-sdk/lib/View/SparqlView/types';
 import { ThunkAction } from '..';
+import { formatError, RequestError } from './utils/errors';
 
 //
 // Action types
@@ -23,6 +24,7 @@ interface RawQueryActionSuccess extends Action {
 }
 interface RawQueryActionFailure extends Action {
   type: '@@rawQuery/QUERYING_FAILURE';
+  error: RequestError;
 }
 
 const rawQueryAction: ActionCreator<RawQueryAction> = (
@@ -40,7 +42,7 @@ const rawQuerySuccessAction: ActionCreator<RawQueryActionSuccess> = (
   payload: results,
 });
 const rawQueryFailureAction: ActionCreator<RawQueryActionFailure> = (
-  error: any
+  error: RequestError
 ) => ({
   error,
   type: '@@rawQuery/QUERYING_FAILURE',
@@ -68,7 +70,7 @@ export const executeRawQuery: ActionCreator<ThunkAction> = (
       const results: SparqlViewQueryResponse = response;
       return dispatch(rawQuerySuccessAction(results));
     } catch (e) {
-      return dispatch(rawQueryFailureAction(e));
+      return dispatch(rawQueryFailureAction(formatError(e)));
     }
   };
 };
@@ -95,7 +97,7 @@ export const executeRawElasticSearchQuery: ActionCreator<ThunkAction> = (
       const results: PaginatedList<ElasticSearchHit> = response;
       return dispatch(rawQuerySuccessAction(results));
     } catch (e) {
-      return dispatch(rawQueryFailureAction(e));
+      return dispatch(rawQueryFailureAction(formatError(e)));
     }
   };
 };

--- a/src/shared/store/reducers/rawQuery.ts
+++ b/src/shared/store/reducers/rawQuery.ts
@@ -2,12 +2,14 @@ import { RawQueryActions } from '../actions/rawQuery';
 import { PaginatedList, PaginationSettings } from '@bbp/nexus-sdk';
 import { ElasticSearchHit } from '@bbp/nexus-sdk/lib/View/ElasticSearchView/types';
 import { SparqlViewQueryResponse } from '@bbp/nexus-sdk/lib/View/SparqlView/types';
+import { RequestError } from '../actions/utils/errors';
 
 const DEFAULT_PAGINATION_SIZE = 20;
 
 export interface RawQueryState {
   fetching: boolean;
   response: SparqlViewQueryResponse;
+  error: RequestError | null;
 }
 
 export interface RawElasticSearchQueryState {
@@ -19,6 +21,7 @@ export interface RawElasticSearchQueryState {
 
 const initialState: RawQueryState = {
   fetching: false,
+  error: null,
   response: {
     head: {
       vars: [],
@@ -61,6 +64,7 @@ export function rawElasticSearchQueryReducer(
         ...state,
         fetching: true,
         query: action.query,
+        error: null,
         paginationSettings:
           state.query === action.query
             ? action.paginationSettings
@@ -70,10 +74,16 @@ export function rawElasticSearchQueryReducer(
       return {
         ...state,
         fetching: false,
+        error: action.error,
         paginationSettings: initialElasticSearchState.paginationSettings,
       };
     case '@@rawQuery/QUERYING_SUCCESS':
-      return { ...state, fetching: false, response: action.payload };
+      return {
+        ...state,
+        fetching: false,
+        response: action.payload,
+        error: null,
+      };
     default:
       return state;
   }
@@ -85,11 +95,16 @@ export default function rawQueryReducer(
 ) {
   switch (action.type) {
     case '@@rawQuery/QUERYING':
-      return { ...state, fetching: true };
+      return { ...state, fetching: true, error: null };
     case '@@rawQuery/QUERYING_FAILURE':
-      return { ...state, fetching: false };
+      return { ...state, fetching: false, error: action.error };
     case '@@rawQuery/QUERYING_SUCCESS':
-      return { ...state, fetching: false, response: action.payload };
+      return {
+        ...state,
+        fetching: false,
+        response: action.payload,
+        error: null,
+      };
     default:
       return state;
   }


### PR DESCRIPTION
# NEW

- make sure that ES and Sparql query errors are caught and displayed on UI
- return "no value" in Sparql Query Editor instead of crashing the app when there's an empty column
- add copy `_self` button to `MetaDataCard` for convenience (I needed it a lot when playing with queries)

![Screenshot 2019-03-11 at 11 17 23](https://user-images.githubusercontent.com/5485824/54118170-b76c8580-43f2-11e9-9069-1d25d093d8ec.png)

![Screenshot 2019-03-11 at 11 41 00](https://user-images.githubusercontent.com/5485824/54118172-b9cedf80-43f2-11e9-9829-b327e3610db5.png)

![Screenshot 2019-03-11 at 11 38 13](https://user-images.githubusercontent.com/5485824/54118179-bc313980-43f2-11e9-8f7b-49bbf78cc16d.png)
