### PR TITLE
deploy_to_dev Fixes BlueBrain/nexus#495

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ String commitId = env.GIT_COMMIT
 Boolean isRelease = version ==~ /v\d+\.\d+\.\d+.*/
 Boolean isPR = env.CHANGE_ID != null
 Boolean isMaster = version == 'master'
-Boolean isManualBuild = currentBuild.rawBuild.getCauses()[0].toString().contains('UserIdCause')
+Boolean isManualBuild = currentBuild.rawBuild.getCause(hudson.model.Cause$UserIdCause).properties.toString().contains('UserIdCause')
 
 pipeline {
     agent any

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,7 +61,7 @@ pipeline {
 
         stage('Build Image') {
             when {
-                // We build a new image we want to deploy to dev OR if we are merging back to master
+                // We build a new image only if we want to deploy to dev OR if we are merging back to master
                 expression { isDeployToDev || (isMaster && !isRelease && !isPR) }
             }
             steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,7 +83,7 @@ pipeline {
                 expression { isMaster && !isRelease && !isPR }
             }
             steps {
-                openshiftTag srcStream: imageStream, srcTag: 'latest', destStream: imageStream, destTag: "staging,${GIT_COMMIT.substring(0,7)}", verbose: 'false'
+                openshiftTag srcStream: imageStream, srcTag: 'latest', destStream: imageStream, destTag: 'staging', verbose: 'false'
             }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ Boolean isRelease = version ==~ /v\d+\.\d+\.\d+.*/
 Boolean isPR = env.CHANGE_ID != null
 Boolean isMaster = version == 'master'
 // Boolean isManualBuild = currentBuild.getBuildCauses()[0].toString().contains('UserIdCause')
-Boolean isManualBuild = false
+Boolean isDeployToDev = env.CHANGE_TITLE.contains('deploy_to_dev')
 
 pipeline {
     agent any
@@ -19,7 +19,6 @@ pipeline {
             steps{
                 sh 'echo "Pipeline starting with environment:"'
                 sh 'printenv'
-                sh 'echo "CAUSE ${currentBuild.rawBuild.getCause(hudson.model.Cause$UserIdCause).properties}"'
             }
         }
 
@@ -73,7 +72,7 @@ pipeline {
 
         stage('Promote to dev') {
             when {
-                expression { isManualBuild }
+                expression { isDeployToDev }
             }
             steps {
                 openshiftTag srcStream: imageStream, srcTag: 'latest', destStream: imageStream, destTag: 'dev', verbose: 'false'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,8 @@ String commitId = env.GIT_COMMIT
 Boolean isRelease = version ==~ /v\d+\.\d+\.\d+.*/
 Boolean isPR = env.CHANGE_ID != null
 Boolean isMaster = version == 'master'
-Boolean isManualBuild = currentBuild.getBuildCauses()[0].toString().contains('UserIdCause')
+// Boolean isManualBuild = currentBuild.getBuildCauses()[0].toString().contains('UserIdCause')
+Boolean isManualBuild = false
 
 pipeline {
     agent any
@@ -18,6 +19,7 @@ pipeline {
             steps{
                 sh 'echo "Pipeline starting with environment:"'
                 sh 'printenv'
+                sh 'echo "CAUSE ${currentBuild.rawBuild.getCause(hudson.model.Cause$UserIdCause).properties}"'
             }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,6 @@ String commitId = env.GIT_COMMIT
 Boolean isRelease = version ==~ /v\d+\.\d+\.\d+.*/
 Boolean isPR = env.CHANGE_ID != null
 Boolean isMaster = version == 'master'
-// Boolean isManualBuild = currentBuild.getBuildCauses()[0].toString().contains('UserIdCause')
 Boolean isDeployToDev = env.CHANGE_TITLE.contains('deploy_to_dev')
 
 pipeline {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ String commitId = env.GIT_COMMIT
 Boolean isRelease = version ==~ /v\d+\.\d+\.\d+.*/
 Boolean isPR = env.CHANGE_ID != null
 Boolean isMaster = version == 'master'
-Boolean isManualBuild = currentBuild.rawBuild.getCause(hudson.model.Cause$UserIdCause).properties.toString().contains('UserIdCause')
+Boolean isManualBuild = currentBuild.getBuildCauses()[0].toString().contains('UserIdCause')
 
 pipeline {
     agent any

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,8 +61,8 @@ pipeline {
 
         stage('Build Image') {
             when {
-                // We build a new image it is a manually triggerred build, or we we are merging back to master
-                expression { isManualBuild || (isMaster && !isRelease && !isPR) }
+                // We build a new image we want to deploy to dev OR if we are merging back to master
+                expression { isDeployToDev || (isMaster && !isRelease && !isPR) }
             }
             steps {
                 sh "oc start-build ${imageBuildName} --follow"


### PR DESCRIPTION
If the PR's title contains `deploy_to_dev` (like this one) then it will be deployed to Dev

![Screenshot from 2019-03-12 16-43-12](https://user-images.githubusercontent.com/4364154/54214384-6b9b0880-44e6-11e9-8f00-749d4eefa63b.png)

I also disabled the tagging the docker image with the git commit ID as we don't use this and our registry is getting massive