### PR TITLE
👷‍♀️FIX: naughty package upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5278,9 +5278,9 @@
       }
     },
     "connected-react-router": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/connected-react-router/-/connected-react-router-6.3.1.tgz",
-      "integrity": "sha512-nhuQiLOAQlCgkCypGSUhycgaqqTh2IUwVFvzw2y13v8JqB92yTk3yeAKG6X1b0IcD7S4gQizYbjgejf7DJjbyw==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/connected-react-router/-/connected-react-router-6.3.2.tgz",
+      "integrity": "sha512-YxrAfMExl/OBsi+ojA4ywZeC7cmQ52MnZ4bhzqLhhjuOiXcQogC4kW0kodouXAXrXDovb2l3yEhDfpH99/wYcw==",
       "requires": {
         "immutable": "^3.8.1",
         "seamless-immutable": "^7.1.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5278,9 +5278,9 @@
       }
     },
     "connected-react-router": {
-      "version": "6.3.2",
-      "resolved": "https://registry.npmjs.org/connected-react-router/-/connected-react-router-6.3.2.tgz",
-      "integrity": "sha512-YxrAfMExl/OBsi+ojA4ywZeC7cmQ52MnZ4bhzqLhhjuOiXcQogC4kW0kodouXAXrXDovb2l3yEhDfpH99/wYcw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/connected-react-router/-/connected-react-router-6.3.1.tgz",
+      "integrity": "sha512-nhuQiLOAQlCgkCypGSUhycgaqqTh2IUwVFvzw2y13v8JqB92yTk3yeAKG6X1b0IcD7S4gQizYbjgejf7DJjbyw==",
       "requires": {
         "immutable": "^3.8.1",
         "seamless-immutable": "^7.1.3"
@@ -6359,7 +6359,7 @@
       "dependencies": {
         "immutable": {
           "version": "3.7.6",
-          "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
+          "resolved": "http://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
           "integrity": "sha1-E7TTyxK++hVIKib+Gy665kAHHks="
         }
       }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@bbp/nexus-sdk": "1.0.0-beta.12",
     "antd": "^3.15.0",
     "codemirror": "^5.44.0",
-    "connected-react-router": "6.3.1",
+    "connected-react-router": "^6.3.2",
     "cookie-parser": "^1.4.4",
     "d3": "^5.9.1",
     "d3-force": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@bbp/nexus-sdk": "1.0.0-beta.12",
     "antd": "^3.15.0",
     "codemirror": "^5.44.0",
-    "connected-react-router": "^6.3.2",
+    "connected-react-router": "6.3.1",
     "cookie-parser": "^1.4.4",
     "d3": "^5.9.1",
     "d3-force": "^2.0.0",

--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -126,9 +126,28 @@ app.get('*', async (req: express.Request, res: express.Response) => {
     }
   }
 
+  // Compute path without base path, since MemoryHistory does not
+  // support it.
+  // Code taken from react-router StaticRouter component's private methods.
+  function addLeadingSlash(path: string) {
+    return path.charAt(0) === "/" ? path : `/${path}`;
+  }
+
+  function stripBasename(basename: string, path: string) {
+    if (!basename) return path;
+
+    const base = addLeadingSlash(basename);
+
+    if (path.indexOf(base) !== 0) return path;
+
+    return path.substr(base.length);
+  }
+
+  const path: string = stripBasename(base, req.url);
+
   // Setup history server-side
   const memoryHistory = createMemoryHistory({
-    initialEntries: [req.url],
+    initialEntries: [path],
   });
 
   // Compute pre-loaded state

--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -22,6 +22,7 @@ import {
   HTTP_STATUSES,
   HTTP_STATUS_TYPE_KEYS,
 } from '../shared/store/actions/utils/statusCodes';
+import { stripBasename } from '../shared/utils';
 
 const isSecure = !!process.env.SECURE;
 const cookieName = isSecure ? '__Secure-nexusAuth' : '_Secure-nexusAuth';
@@ -124,23 +125,6 @@ app.get('*', async (req: express.Request, res: express.Response) => {
       // TODO: add proper logger
       // fail silently
     }
-  }
-
-  // Compute path without base path, since MemoryHistory does not
-  // support it.
-  // Code taken from react-router StaticRouter component's private methods.
-  function addLeadingSlash(path: string) {
-    return path.charAt(0) === "/" ? path : `/${path}`;
-  }
-
-  function stripBasename(basename: string, path: string) {
-    if (!basename) return path;
-
-    const base = addLeadingSlash(basename);
-
-    if (path.indexOf(base) !== 0) return path;
-
-    return path.substr(base.length);
   }
 
   const path: string = stripBasename(base, req.url);

--- a/src/shared/utils/__tests__/index.spec.ts
+++ b/src/shared/utils/__tests__/index.spec.ts
@@ -1,4 +1,4 @@
-import { getUserList, getOrderedPermissions } from '..';
+import { getUserList, getOrderedPermissions, addLeadingSlash, stripBasename } from '..';
 import { Identity } from '@bbp/nexus-sdk/lib/ACL/types';
 
 const identities: Identity[] = [
@@ -65,6 +65,34 @@ describe('utils functions', () => {
         'User',
         'Unknown',
       ]);
+    });
+  });
+  describe('stripBasename()', () => {
+    it('should keep the path intact when the basename is empty', () => {
+      const basename = '';
+      const path = '/this-is-a-path';
+      expect(stripBasename(basename, path)).toEqual(path);
+    });
+    it('should keep the path intact when the basename is not at the beginning of the path', () => {
+      const basename = 'my-app';  // no leading slash, should be added automatically
+      const path = '/fragment/my-app/this-is-a-path';
+      expect(stripBasename(basename, path)).toEqual(path);
+    });
+    it('should strip the basename from a path starting with it', () => {
+      const basename = '/my-app';
+      const justPath = '/this-is-a-path';
+      const path = `${basename}${justPath}`;
+      expect(stripBasename(basename, path)).toEqual(justPath);
+    });
+  });
+  describe('addLeadingSlash()', () => {
+    it('should keep the path intact if it starts with a slash', () => {
+      const path = '/this-is-a-path';
+      expect(addLeadingSlash(path)).toEqual(path);
+    });
+    it('should add a leading slash when the first character is not a slash', () => {
+      const path = 'this-is-a-path';
+      expect(addLeadingSlash(path)).toEqual(`/${path}`);
     });
   });
 });

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -105,3 +105,27 @@ export const getOrderedPermissions = (
 export const asyncTimeout = (timeInMilliseconds: number): Promise<void> => {
   return new Promise(resolve => setTimeout(resolve, timeInMilliseconds));
 };
+
+/**
+ * Ensure a path fragment has a leading slash, to compute routes.
+ */
+export const addLeadingSlash = (path: string) => {
+  return path.charAt(0) === "/" ? path : `/${path}`;
+};
+
+/**
+ * Compute route path without base path.
+ *
+ * Useful when using MemoryHistory which does not support `basename`.
+ *
+ * Code taken from react-router StaticRouter component's private methods.
+ */
+export const stripBasename = (basename: string, path: string) => {
+  if (!basename) return path;
+
+  const base = addLeadingSlash(basename);
+
+  if (path.indexOf(base) !== 0) return path;
+
+  return path.substr(base.length);
+};


### PR DESCRIPTION
There's strange behavior when navigating to the app when there is a BASE_PATH env var. It doubles the base path whenever the app is hydrated. 

It seems like it's a problem with the new version of connected-react-router. I've downgraded to the last working version