### PR TITLE
👷‍♀️FIX: #509 flashing logo

### DIFF
--- a/src/shared/components/Header/__tests__/__snapshots__/Header.test.tsx.snap
+++ b/src/shared/components/Header/__tests__/__snapshots__/Header.test.tsx.snap
@@ -17,6 +17,12 @@ exports[`Header component Should render correctly 1`] = `
       <img
         alt="Nexus"
         src="/mock/path"
+        style={
+          Object {
+            "height": "2em",
+            "width": "2em",
+          }
+        }
       />
       <h1>
         Nexus

--- a/src/shared/components/Header/index.tsx
+++ b/src/shared/components/Header/index.tsx
@@ -35,7 +35,11 @@ const Header: React.FunctionComponent<HeaderProps> = ({
       <div className="selectors">{children}</div>
       <div className="logo-block">
         <a className="logo" href="">
-          <img src={logo} alt="Nexus" />
+          {
+            // must add inline styling to prevent this big svg from
+            // flashing the screen on dev mode before styles are loaded
+          }
+          <img style={{ height: '2em', width: '2em' }} src={logo} alt="Nexus" />
           <h1>Nexus</h1>
         </a>
       </div>


### PR DESCRIPTION
> https://github.com/BlueBrain/nexus/issues/509
Fixes a problem in dev mode where ssr doesn't add styling yet to the big size of the nexus logo svg