### PR TITLE
👷‍♀️FIX: #536 alphabetize list order

### DIFF
--- a/src/shared/components/Types/TypesIcon.tsx
+++ b/src/shared/components/Types/TypesIcon.tsx
@@ -41,11 +41,25 @@ const TypesIconList: React.SFC<TypesIconListProps> = ({
   type,
   full = false,
 }) => {
+  // sort types alphabetically for consistency
+  // because the graph database isn't aware of order
+  // and otherwise they would just be all over the place!
+  type.sort((a, b) => {
+    if (a < b) {
+      return -1;
+    }
+    if (a > b) {
+      return 1;
+    }
+    return 0;
+  });
+
   let typesToDisplay = type;
   const tooManyTypes = !full && type.length > 3;
   if (tooManyTypes) {
     typesToDisplay = [...type].slice(0, 3);
   }
+
   return (
     <ul className="types-list">
       {typesToDisplay.map((type: string) => (


### PR DESCRIPTION
Alphabetizes `@type`'s in the type list component for consistency 

addressed https://github.com/BlueBrain/nexus/issues/536

![Screenshot 2019-03-15 at 16 04 40](https://user-images.githubusercontent.com/5485824/54441015-1bb57f00-473c-11e9-8b6a-380665830726.png)
