### PR TITLE
Fix/display identity details

### DIFF
--- a/src/shared/components/ACLs/IdentityBadge.tsx
+++ b/src/shared/components/ACLs/IdentityBadge.tsx
@@ -1,30 +1,45 @@
 import * as React from 'react';
+import { Icon, Tooltip } from 'antd';
 import { Identity } from '@bbp/nexus-sdk/lib/ACL/types';
 
 import './ACLs.less';
-import { Icon } from 'antd';
 
-const getIcon = (
-  activePermission: Identity['@type']
-): React.ReactElement<any> => {
-  switch (activePermission) {
+const getTitle = (identity: Identity): React.ReactElement<any> => {
+  switch (identity['@type']) {
     case 'Anonymous':
-      return <Icon type="global" />;
+      return (
+        <Tooltip title="Anyone with the internet">
+          <Icon type="global" />
+        </Tooltip>
+      );
     case 'Authenticated':
-      return <Icon type="crown" />;
+      return (
+        <Tooltip title={identity.realm}>
+          <Icon type="crown" />
+        </Tooltip>
+      );
     case 'Group':
-      return <Icon type="team" />;
+      return (
+        <Tooltip title={identity.group}>
+          <Icon type="team" />
+        </Tooltip>
+      );
     case 'User':
-      return <Icon type="user" />;
+      return (
+        <Tooltip title={identity.subject}>
+          <Icon type="user" />
+        </Tooltip>
+      );
     default:
       return <Icon />;
   }
 };
+
 const IdentityBadge: React.FunctionComponent<Identity> = props => {
   return (
     <div className="Identity-badge">
       <h3>
-        {getIcon(props['@type'])} {props['@type']}
+        {getTitle(props)} {props['@type']}
       </h3>
     </div>
   );

--- a/src/shared/components/Resources/__tests__/__snapshots__/MetadataCard.spec.tsx.snap
+++ b/src/shared/components/Resources/__tests__/__snapshots__/MetadataCard.spec.tsx.snap
@@ -71,7 +71,7 @@ exports[`MetadataCard component should render with Set username 1`] = `
                 </Tooltip>
                 <span>
                   , last updated 
-                  4 hours ago
+                  a day ago
                 </span>
               </div>
               <div>
@@ -3092,7 +3092,7 @@ exports[`MetadataCard component should render with Set username 1`] = `
                     </Tooltip>
                     <span>
                       , last updated 
-                      4 hours ago
+                      a day ago
                     </span>
                   </div>
                   <div>
@@ -3187,7 +3187,7 @@ exports[`MetadataCard component should render with Unknown username 1`] = `
                 </Tooltip>
                 <span>
                   , last updated 
-                  4 hours ago
+                  a day ago
                 </span>
               </div>
               <div>
@@ -6208,7 +6208,7 @@ exports[`MetadataCard component should render with Unknown username 1`] = `
                     </Tooltip>
                     <span>
                       , last updated 
-                      4 hours ago
+                      a day ago
                     </span>
                   </div>
                   <div>
@@ -6303,7 +6303,7 @@ exports[`MetadataCard component should render with an extracted username 1`] = `
                 </Tooltip>
                 <span>
                   , last updated 
-                  4 hours ago
+                  a day ago
                 </span>
               </div>
               <div>
@@ -9324,7 +9324,7 @@ exports[`MetadataCard component should render with an extracted username 1`] = `
                     </Tooltip>
                     <span>
                       , last updated 
-                      4 hours ago
+                      a day ago
                     </span>
                   </div>
                   <div>

--- a/src/shared/components/Workspace/Menu.tsx
+++ b/src/shared/components/Workspace/Menu.tsx
@@ -85,7 +85,7 @@ const Menu: React.FunctionComponent<MenuProps> = ({
             ElasticSearch Query Editor
           </Link>
           <Link to={`/${orgLabel}/${projectLabel}/_settings/acls`}>
-            View Project ACLs
+            View Project's permissions
           </Link>
         </div>
         <Divider />


### PR DESCRIPTION
Changes link's name + display identity details in tooltip

![Screenshot from 2019-03-21 09-16-21](https://user-images.githubusercontent.com/4364154/54740080-93f7c680-4bba-11e9-9dad-c3d08bca2c82.png)
![Screenshot from 2019-03-21 09-16-47](https://user-images.githubusercontent.com/4364154/54740082-94905d00-4bba-11e9-9b75-47f29adaf7c3.png)
![Screenshot from 2019-03-21 09-17-03](https://user-images.githubusercontent.com/4364154/54740084-94905d00-4bba-11e9-9b1e-5c60ce5ac254.png)
