### PR TITLE
👷‍♀️FIX: links improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1104,9 +1104,9 @@
       }
     },
     "@bbp/nexus-sdk": {
-      "version": "1.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@bbp/nexus-sdk/-/nexus-sdk-1.0.0-beta.17.tgz",
-      "integrity": "sha512-fHnqT+Otf+C6CVdXsD/M5WVdJihzxwRSJybvJLsnS3WRHUAl68YtQ5MQDAcOgKDPdafJqI34bO/pafCPTz9coQ==",
+      "version": "1.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@bbp/nexus-sdk/-/nexus-sdk-1.0.0-beta.18.tgz",
+      "integrity": "sha512-hJRM6ru5Tr71chQAH+TPYdux7NzgXTROoPpOf+6Y6ClCVxy73tk7aNv/JK/uWlQJWCsa4djpJcaP0WfP5NqzRw==",
       "requires": {
         "cross-fetch": "^3.0.1",
         "eventsource": "^1.0.7",
@@ -7495,8 +7495,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7517,14 +7516,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7539,20 +7536,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7669,8 +7663,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7682,7 +7675,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7697,7 +7689,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7705,14 +7696,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7731,7 +7720,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7812,8 +7800,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7825,7 +7812,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7911,8 +7897,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7948,7 +7933,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7968,7 +7952,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -8012,14 +7995,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "antd": "^3.15.0",
-    "@bbp/nexus-sdk": "1.0.0-beta.17",
+    "@bbp/nexus-sdk": "1.0.0-beta.18",
     "codemirror": "^5.44.0",
     "connected-react-router": "^6.3.2",
     "cookie-parser": "^1.4.4",

--- a/src/shared/components/Resources/Links.tsx
+++ b/src/shared/components/Resources/Links.tsx
@@ -77,9 +77,7 @@ const LinksList: React.FunctionComponent<LinksListProps> = props => {
                 <div className="predicate">{predicate}</div>
                 <div className="label">
                   <div className="name">
-                    <em>
-                      {resourceLink.link as string} <Icon type="export" />
-                    </em>
+                    {resourceLink.link as string} <Icon type="export" />
                   </div>
                 </div>
               </a>

--- a/src/shared/components/Resources/Links.tsx
+++ b/src/shared/components/Resources/Links.tsx
@@ -77,7 +77,7 @@ const LinksList: React.FunctionComponent<LinksListProps> = props => {
                 <div className="predicate">{predicate}</div>
                 <div className="label">
                   <div className="name">
-                    {resourceLink.link as string} <Icon type="export" />
+                    <Icon type="export" /> {resourceLink.link as string}
                   </div>
                 </div>
               </a>

--- a/src/shared/components/Resources/ResourceItem.tsx
+++ b/src/shared/components/Resources/ResourceItem.tsx
@@ -57,9 +57,7 @@ const ResourceListItem: React.FunctionComponent<ResourceItemProps> = props => {
         {predicate && <div className="predicate">{predicate}</div>}
         <div className="label">
           {Preview}
-          <div className="name">
-            <em>{resource.name}</em>
-          </div>
+          <div className="name">{resource.name}</div>
           {resource.type && resource.type.length && (
             <TypesIcon type={resource.type} />
           )}

--- a/src/shared/components/Resources/__tests__/__snapshots__/MetadataCard.spec.tsx.snap
+++ b/src/shared/components/Resources/__tests__/__snapshots__/MetadataCard.spec.tsx.snap
@@ -71,7 +71,7 @@ exports[`MetadataCard component should render with Set username 1`] = `
                 </Tooltip>
                 <span>
                   , last updated 
-                  a day ago
+                  5 days ago
                 </span>
               </div>
               <div>
@@ -3092,7 +3092,7 @@ exports[`MetadataCard component should render with Set username 1`] = `
                     </Tooltip>
                     <span>
                       , last updated 
-                      a day ago
+                      5 days ago
                     </span>
                   </div>
                   <div>
@@ -3187,7 +3187,7 @@ exports[`MetadataCard component should render with Unknown username 1`] = `
                 </Tooltip>
                 <span>
                   , last updated 
-                  a day ago
+                  5 days ago
                 </span>
               </div>
               <div>
@@ -6208,7 +6208,7 @@ exports[`MetadataCard component should render with Unknown username 1`] = `
                     </Tooltip>
                     <span>
                       , last updated 
-                      a day ago
+                      5 days ago
                     </span>
                   </div>
                   <div>
@@ -6303,7 +6303,7 @@ exports[`MetadataCard component should render with an extracted username 1`] = `
                 </Tooltip>
                 <span>
                   , last updated 
-                  a day ago
+                  5 days ago
                 </span>
               </div>
               <div>
@@ -9324,7 +9324,7 @@ exports[`MetadataCard component should render with an extracted username 1`] = `
                     </Tooltip>
                     <span>
                       , last updated 
-                      a day ago
+                      5 days ago
                     </span>
                   </div>
                   <div>

--- a/src/shared/components/Resources/resource-item.less
+++ b/src/shared/components/Resources/resource-item.less
@@ -22,6 +22,7 @@
       overflow-x: hidden;
       white-space: nowrap;
       flex-grow: 1;
+      margin-right: 1em;
     }
     & > .ant-avatar {
       margin-right: 1em;

--- a/src/shared/components/Types/Types.less
+++ b/src/shared/components/Types/Types.less
@@ -9,7 +9,8 @@
   position: relative;
   list-style: none;
   position: relative;
-  display: inline-block;
+  display: flex;
+  width: auto;
   padding: 0;
   & > .ellipsis {
     display: inline-block;


### PR DESCRIPTION
Improves resources links so that
- types "tags" will try to stay on one line
- long names will take up all available space, then go to ellipsis 
(https://github.com/BlueBrain/nexus/issues/550)
- external links will show the "external" icon before the name (or else would disappear in ellipsis)

Improves incoming/outgoing links so that 
- `_self` will not appear as incoming link
- outgoing links will appear even if they are nested deeply
![Screenshot 2019-03-25 at 15 56 06](https://user-images.githubusercontent.com/5485824/54930320-5dea7780-4f17-11e9-9440-0c25b044595c.png)

![better-link-nav](https://user-images.githubusercontent.com/5485824/54930275-4ad7a780-4f17-11e9-874f-fcb51fbc57ae.gif)

