### PR TITLE
Set fix path

### DIFF
--- a/src/client/userManager.ts
+++ b/src/client/userManager.ts
@@ -3,7 +3,9 @@ import { CookieStorage } from 'cookie-storage';
 import { RootState } from '../shared/store/reducers';
 import { Realm } from '@bbp/nexus-sdk';
 
-const cookieStorage = new CookieStorage();
+const cookieStorage = new CookieStorage({
+  path: '/',
+});
 
 const getUserManager = (state: RootState): UserManager | undefined => {
   const {


### PR DESCRIPTION
Cookie Storage set the cookie path to the current active path, which creates multiple cookies for for the one site. Fixed by setting fixed path

The problem
![Screenshot from 2019-04-01 15-05-20](https://user-images.githubusercontent.com/4364154/55329788-c2fe1a00-548f-11e9-8219-cd4a15553735.png)
