### PR TITLE
👷‍♀️FIX: expanded switch on Resource View

### DIFF
--- a/src/shared/components/Resources/ResourceDetails.tsx
+++ b/src/shared/components/Resources/ResourceDetails.tsx
@@ -46,10 +46,21 @@ const ResourceDetails: React.FunctionComponent<ResourceViewProps> = props => {
     fetchResource,
   } = props;
   const [busy, setFormBusy] = React.useState(isFetching);
+  const [expanded, setExpanded] = React.useState(false);
+
+  React.useEffect(() => {
+    if (resource && expanded && !resource.expanded) {
+      fetchResource(expanded);
+    }
+  }, [expanded]);
 
   // TODO move NexusFileType constant to sdk
   const isFile =
     resource && resource.type && resource.type.includes(NEXUS_FILE_TYPE);
+
+  const handleFormatChange = () => {
+    setExpanded(!expanded);
+  };
 
   const handleSubmit = async (value: any) => {
     if (resource) {
@@ -91,9 +102,14 @@ const ResourceDetails: React.FunctionComponent<ResourceViewProps> = props => {
             <Tabs defaultActiveKey="1">
               <TabPane tab="JSON" key="1">
                 <ResourceEditor
+                  expanded={expanded}
                   editable={!(isFile || resource.expanded)}
-                  rawData={resource.expanded || resource.raw}
-                  onFormatChange={fetchResource}
+                  rawData={
+                    expanded && resource.expanded
+                      ? resource.expanded
+                      : resource.raw
+                  }
+                  onFormatChange={handleFormatChange}
                   onSubmit={handleSubmit}
                 />
               </TabPane>

--- a/src/shared/components/Resources/ResourceEditor.tsx
+++ b/src/shared/components/Resources/ResourceEditor.tsx
@@ -15,10 +15,17 @@ export interface ResourceEditorProps {
   onFormatChange?(expanded: boolean): void;
   editable: boolean;
   editing?: boolean;
+  expanded?: boolean;
 }
 
 const ResourceEditor: React.FunctionComponent<ResourceEditorProps> = props => {
-  const { rawData, onSubmit, editable, editing = false } = props;
+  const {
+    rawData,
+    onSubmit,
+    editable,
+    editing = false,
+    expanded = false,
+  } = props;
   const [isEditing, setEditing] = React.useState(editing);
   const [valid, setValid] = React.useState(true);
   const [value, setValue] = React.useState(rawData);
@@ -74,6 +81,7 @@ const ResourceEditor: React.FunctionComponent<ResourceEditorProps> = props => {
             <Switch
               checkedChildren="expanded"
               unCheckedChildren="expand"
+              checked={expanded}
               onChange={props.onFormatChange}
             />
           )}


### PR DESCRIPTION
Fixes UI state by fetching then displaying the expanded Resource payload in the Resource Details View only when the user has toggled the expanded button, even if the `resource.expanded` payload is already available. 

The problem was most obvious when clicking to the "Links" tab, which would fetch the expanded state, and the back to the JSON payload view where it would show that expanded state instead of the regular payload even when the user didn't ask for that. 

resolves issue https://github.com/BlueBrain/nexus/issues/585