### PR TITLE
fix: error in realm selection logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nexus-web",
-  "version": "1.1.0-beta.2",
+  "version": "1.1.0-beta.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexus-web",
   "description": "The interface of Blue Brain Nexus, the open-source knowledge graph for data-driven science.",
-  "version": "1.1.0-beta.2",
+  "version": "1.1.0-beta.3",
   "author": "Blue Brain project",
   "license": "Apache-2.0",
   "main": "dist/server.js",

--- a/src/shared/store/actions/config.ts
+++ b/src/shared/store/actions/config.ts
@@ -37,7 +37,7 @@ function setPreferredRealm(name: string) {
     preferredRealmData.realmKey = `nexus__user:${preferredRealmData.realmKey}`;
     cookieStorage.setItem('nexus__realm', JSON.stringify(preferredRealmData));
     return dispatch({
-      name,
+      name: preferredRealmData.label,
       type: '@@nexus/CONFIG_SET_REALM',
     });
   };


### PR DESCRIPTION
Use the realm label (eg: "bbp") rather than the name (eg: "BlueBrain Project") so that UserManager is able to find the right realm 🐛 