### PR TITLE
👷‍♀️FIX: Infinite Scroll - only fetch until the end of the list

### DIFF
--- a/src/shared/components/Animations/InfiniteScroll.tsx
+++ b/src/shared/components/Animations/InfiniteScroll.tsx
@@ -103,7 +103,9 @@ const InfiniteScroll: React.FunctionComponent<InfiniteScrollProps> = props => {
   const [bind] = useInfiniteScroll(
     loadNextPage,
     isFetching,
-    loadAtPercentRevealed
+    loadAtPercentRevealed,
+    itemsList.length,
+    (data && data.total) || 0
   );
   React.useEffect(() => {
     // Reset results if we're on the first paginated page

--- a/src/shared/components/hooks/useInfiniteScroll.ts
+++ b/src/shared/components/hooks/useInfiniteScroll.ts
@@ -5,7 +5,9 @@ import { isBrowser } from '../../utils';
 const useInfiniteScroll = (
   callback: VoidFunction,
   isFetching: boolean,
-  loadAtPercentRevealed: number
+  loadAtPercentRevealed: number,
+  currentTotal: number,
+  total: number
 ) => {
   const ref = React.useRef<HTMLDivElement>(null);
   if (!isBrowser) {
@@ -30,7 +32,8 @@ const useInfiniteScroll = (
     if (
       !isFetching &&
       ref.current.offsetHeight + ref.current.scrollTop >=
-        ref.current.scrollHeight * loadAtPercentRevealed
+        ref.current.scrollHeight * loadAtPercentRevealed &&
+      currentTotal !== total
     ) {
       callback();
     }


### PR DESCRIPTION
stops useInfiniteScroll callback from being fired when you've already reached the end of the list according to the paginatedList props