### PR TITLE
✨FEAT: show deprecated resources toggle

### DIFF
--- a/src/shared/components/Workspace/Queries/QueriesContainer.tsx
+++ b/src/shared/components/Workspace/Queries/QueriesContainer.tsx
@@ -19,11 +19,8 @@ import {
   createList,
 } from '../../../store/actions/lists';
 import QueriesBoard from './QueriesBoard';
-import {
-  queryResources,
-  FilterQuery,
-  makeESQuery,
-} from '../../../store/actions/queryResource';
+import { queryResources } from '../../../store/actions/queryResource';
+import { makeESQuery } from '../../../store/actions/utils/makeESQuery';
 
 export interface QueriesContainerProps {
   org: Organization;
@@ -41,7 +38,7 @@ export interface QueriesContainerProps {
   queryResources: (
     id: string,
     paginationSettings: PaginationSettings,
-    query?: FilterQuery
+    query?: List['query']
   ) => void;
 }
 
@@ -109,7 +106,7 @@ const mapDispatchToProps = (
   queryResources: (
     id: string,
     paginationSettings: PaginationSettings,
-    query?: FilterQuery
+    query?: List['query']
   ) => dispatch(queryResources(id, org, project, paginationSettings, query)),
 });
 

--- a/src/shared/components/Workspace/Queries/Query/QueryComponent.tsx
+++ b/src/shared/components/Workspace/Queries/Query/QueryComponent.tsx
@@ -1,13 +1,10 @@
 import * as React from 'react';
-import { List } from '../../../../store/reducers/lists';
+import { List, DEFAULT_LIST } from '../../../../store/reducers/lists';
 import './query-component.less';
 import InfiniteScroll from '../../../Animations/InfiniteScroll';
-import ListItem from '../../../Animations/ListItem';
 import { FetchableState } from '../../../../store/reducers/utils';
 import { PaginatedList, Resource, NexusFile } from '@bbp/nexus-sdk';
-import ResourceMetadataCard from '../../../Resources/MetadataCard';
-import { Popover, Icon, Tooltip, Button, Spin } from 'antd';
-import TypesIconList from '../../../Types/TypesIcon';
+import { Icon, Tooltip, Button, Spin, Switch } from 'antd';
 import RenameableItem from '../../../Renameable';
 import FullTextSearch from './Search';
 import TypesFilter from './Types';
@@ -68,11 +65,22 @@ const QueryComponent: React.FunctionComponent<QueryComponentProps> = props => {
     // and the textQuery
     updateList({
       ...props.list,
+      query: DEFAULT_LIST.query,
+    });
+  };
+  const handleToggleDeprecated = () => {
+    updateList({
+      ...props.list,
       query: {
-        filters: {},
+        ...props.list.query,
+        filters: {
+          ...props.list.query.filters,
+          _deprecated: !props.list.query.filters._deprecated,
+        },
       },
     });
   };
+  const showDeprecated = props.list.query.filters._deprecated;
 
   const handleCloneList = () => {
     cloneList({ ...props.list });
@@ -139,6 +147,19 @@ const QueryComponent: React.FunctionComponent<QueryComponentProps> = props => {
           schemas={data && data.schemas}
           onChange={handleFilterChange}
         />
+        <Tooltip
+          title={
+            showDeprecated
+              ? 'Displaying deprecated resources'
+              : 'Not showing deprecated resources'
+          }
+        >
+          <Switch
+            size="small"
+            onChange={handleToggleDeprecated}
+            checked={showDeprecated}
+          />
+        </Tooltip>
       </div>
       <Spin spinning={showSpinner}>
         <InfiniteScroll

--- a/src/shared/components/Workspace/Queries/Query/index.tsx
+++ b/src/shared/components/Workspace/Queries/Query/index.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { PaginationSettings, Resource, NexusFile } from '@bbp/nexus-sdk';
-import { FilterQuery } from '../../../../store/actions/queryResource';
 import { List } from '../../../../store/reducers/lists';
 import QueryComponent from './QueryComponent';
 
@@ -16,7 +15,7 @@ interface QueryContainerProps {
   queryResources: (
     id: string,
     paginationSettings: PaginationSettings,
-    query?: FilterQuery
+    query?: List['query']
   ) => void;
 }
 

--- a/src/shared/store/actions/queryResource.ts
+++ b/src/shared/store/actions/queryResource.ts
@@ -94,17 +94,12 @@ const queryResourcesFailedAction: ActionCreator<FailedQueryAction> = (
   type: QueryResourcesActionTypes.FAILED,
 });
 
-export interface FilterQuery {
-  filters: {};
-  textQuery?: string;
-}
-
 export const queryResources: ActionCreator<ThunkAction> = (
   id: string,
   org: Organization,
   project: Project,
   paginationSettings: PaginationSettings,
-  query?: FilterQuery
+  query?: List['query']
 ) => {
   return async (
     dispatch: Dispatch<any>,

--- a/src/shared/store/actions/queryResource.ts
+++ b/src/shared/store/actions/queryResource.ts
@@ -13,6 +13,7 @@ import { RootState } from '../reducers';
 import { updateList, makeOrgProjectFilterKey } from './lists';
 import { ElasticSearchViewAggregationResponse } from '@bbp/nexus-sdk/lib/View/ElasticSearchView/types';
 import { List } from '../reducers/lists';
+import { makeESQuery } from './utils/makeESQuery';
 
 export const queryResourcesActionPrefix = 'QUERY';
 
@@ -92,47 +93,6 @@ const queryResourcesFailedAction: ActionCreator<FailedQueryAction> = (
   error,
   type: QueryResourcesActionTypes.FAILED,
 });
-
-// TODO break out into library
-export const makeESQuery = (query?: { filters: any; textQuery?: string }) => {
-  if (query) {
-    const must = [];
-    if (Object.keys(query.filters).length) {
-      Object.keys(query.filters)
-        .filter(key => !!query.filters[key])
-        .forEach(key => {
-          must.push({
-            term: { [key]: query.filters[key] },
-          });
-        });
-    }
-    if (query.textQuery) {
-      must.push({
-        query_string: {
-          query: `${query.textQuery}~`,
-        },
-      });
-    }
-    if (must.length > 1) {
-      return {
-        query: {
-          bool: {
-            must,
-          },
-        },
-      };
-    }
-    if (must.length === 0) {
-      return {};
-    }
-    return {
-      query: {
-        ...must[0],
-      },
-    };
-  }
-  return {};
-};
 
 export interface FilterQuery {
   filters: {};

--- a/src/shared/store/actions/utils/__tests__/__snapshots__/makeESQuery.spec.ts.snap
+++ b/src/shared/store/actions/utils/__tests__/__snapshots__/makeESQuery.spec.ts.snap
@@ -1,0 +1,75 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`makeESQuery @type should return a must clause with a term query for both _deprecated and @types 1`] = `
+Object {
+  "query": Object {
+    "bool": Object {
+      "must": Array [
+        Object {
+          "term": Object {
+            "@type": "myType",
+          },
+        },
+        Object {
+          "term": Object {
+            "_deprecated": true,
+          },
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`makeESQuery _constrainedBy should return a must clause with a term query for both _deprecated and _constrainedBy 1`] = `
+Object {
+  "query": Object {
+    "term": Object {
+      "_constrainedBy": "mySchema",
+    },
+  },
+}
+`;
+
+exports[`makeESQuery deprecated should return a must clause with just the term query 1`] = `Object {}`;
+
+exports[`makeESQuery everything at once should return a must clause with the kitchen sink 1`] = `
+Object {
+  "query": Object {
+    "bool": Object {
+      "must": Array [
+        Object {
+          "term": Object {
+            "@type": "myType",
+          },
+        },
+        Object {
+          "term": Object {
+            "_constrainedBy": "mySchemas",
+          },
+        },
+        Object {
+          "term": Object {
+            "_deprecated": true,
+          },
+        },
+        Object {
+          "query_string": Object {
+            "query": "Banana~",
+          },
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`makeESQuery text query should return a must clause with a query string 1`] = `
+Object {
+  "query": Object {
+    "query_string": Object {
+      "query": "banana~",
+    },
+  },
+}
+`;

--- a/src/shared/store/actions/utils/__tests__/makeESQuery.spec.ts
+++ b/src/shared/store/actions/utils/__tests__/makeESQuery.spec.ts
@@ -1,0 +1,73 @@
+import { makeESQuery } from '../makeESQuery';
+
+describe('makeESQuery', () => {
+  it('should return an empty object if no query prop is provided', () => {
+    expect(makeESQuery()).toEqual({});
+  });
+
+  describe('text query', () => {
+    it('should return a must clause with a query string', () => {
+      expect(
+        makeESQuery({
+          filters: {
+            _deprecated: false,
+          },
+          textQuery: 'banana',
+        })
+      ).toMatchSnapshot();
+    });
+  });
+
+  describe('deprecated', () => {
+    it('should return a must clause with just the term query', () => {
+      expect(
+        makeESQuery({
+          filters: {
+            _deprecated: false,
+          },
+        })
+      ).toMatchSnapshot();
+    });
+  });
+
+  describe('_constrainedBy', () => {
+    it('should return a must clause with a term query for both _deprecated and _constrainedBy', () => {
+      expect(
+        makeESQuery({
+          filters: {
+            _constrainedBy: 'mySchema',
+            _deprecated: false,
+          },
+        })
+      ).toMatchSnapshot();
+    });
+  });
+
+  describe('@type', () => {
+    it('should return a must clause with a term query for both _deprecated and @types', () => {
+      expect(
+        makeESQuery({
+          filters: {
+            '@type': 'myType',
+            _deprecated: true,
+          },
+        })
+      ).toMatchSnapshot();
+    });
+  });
+
+  describe('everything at once', () => {
+    it('should return a must clause with the kitchen sink', () => {
+      expect(
+        makeESQuery({
+          filters: {
+            '@type': 'myType',
+            _constrainedBy: 'mySchemas',
+            _deprecated: true,
+          },
+          textQuery: 'Banana',
+        })
+      ).toMatchSnapshot();
+    });
+  });
+});

--- a/src/shared/store/actions/utils/makeESQuery.ts
+++ b/src/shared/store/actions/utils/makeESQuery.ts
@@ -1,0 +1,42 @@
+import { List } from '../../reducers/lists';
+
+// TODO break out into library
+export const makeESQuery = (query?: List['query']) => {
+  if (query) {
+    const must = [];
+    if (Object.keys(query.filters).length) {
+      Object.keys(query.filters)
+        .filter(key => !!query.filters[key])
+        .forEach(key => {
+          must.push({
+            term: { [key]: query.filters[key] },
+          });
+        });
+    }
+    if (query.textQuery) {
+      must.push({
+        query_string: {
+          query: `${query.textQuery}~`,
+        },
+      });
+    }
+    if (must.length > 1) {
+      return {
+        query: {
+          bool: {
+            must,
+          },
+        },
+      };
+    }
+    if (must.length === 0) {
+      return {};
+    }
+    return {
+      query: {
+        ...must[0],
+      },
+    };
+  }
+  return {};
+};

--- a/src/shared/store/reducers/lists.ts
+++ b/src/shared/store/reducers/lists.ts
@@ -30,6 +30,7 @@ export interface List {
       _constrainedBy?: string;
       '@type'?: string;
       _deprecated: boolean;
+      [key: string]: any;
     };
     textQuery?: string;
   };

--- a/src/shared/store/reducers/lists.ts
+++ b/src/shared/store/reducers/lists.ts
@@ -27,7 +27,9 @@ export interface List {
   id: string;
   query: {
     filters: {
-      [filterKey: string]: string;
+      _constrainedBy?: string;
+      '@type'?: string;
+      _deprecated: boolean;
     };
     textQuery?: string;
   };
@@ -44,12 +46,14 @@ export interface List {
 // then we should update the URL with a serialised array of queries
 export type ListState = List[];
 
-const DEFAULT_LIST: List = {
+export const DEFAULT_LIST: List = {
   name: 'Default Query',
   view: DEFAULT_VIEW,
   id: uuidv4(),
   query: {
-    filters: {},
+    filters: {
+      _deprecated: false,
+    },
   },
   results: {
     isFetching: false,
@@ -77,7 +81,7 @@ export function listsReducer(
     case ListActionTypes.CREATE:
       const newList = {
         ...DEFAULT_LIST,
-        name: `New Query ${state.length + 1}`,
+        name: `New Query`,
         id: action.payload.id,
       };
       return [...state, newList];


### PR DESCRIPTION
# NEW
Resource Lists now display only non-deprecated resources by default. 

You can toggle a little button at the top left to show only the deprecated resources. 

Currently there's not a way to show both non deprecated resources and deprecated resources at the same time via the UI, but this should help people in the meanwhile. 

![Screenshot 2019-05-02 at 16 17 41](https://user-images.githubusercontent.com/5485824/57082050-42347700-6cf6-11e9-89e4-2f4197349b41.png)
