### PR TITLE
👷‍♀️FIX: falsey filters

### DIFF
--- a/src/shared/store/actions/utils/__tests__/__snapshots__/makeESQuery.spec.ts.snap
+++ b/src/shared/store/actions/utils/__tests__/__snapshots__/makeESQuery.spec.ts.snap
@@ -24,14 +24,33 @@ Object {
 exports[`makeESQuery _constrainedBy should return a must clause with a term query for both _deprecated and _constrainedBy 1`] = `
 Object {
   "query": Object {
-    "term": Object {
-      "_constrainedBy": "mySchema",
+    "bool": Object {
+      "must": Array [
+        Object {
+          "term": Object {
+            "_constrainedBy": "mySchema",
+          },
+        },
+        Object {
+          "term": Object {
+            "_deprecated": false,
+          },
+        },
+      ],
     },
   },
 }
 `;
 
-exports[`makeESQuery deprecated should return a must clause with just the term query 1`] = `Object {}`;
+exports[`makeESQuery deprecated should return a must clause with just the term query 1`] = `
+Object {
+  "query": Object {
+    "term": Object {
+      "_deprecated": false,
+    },
+  },
+}
+`;
 
 exports[`makeESQuery everything at once should return a must clause with the kitchen sink 1`] = `
 Object {
@@ -67,8 +86,19 @@ Object {
 exports[`makeESQuery text query should return a must clause with a query string 1`] = `
 Object {
   "query": Object {
-    "query_string": Object {
-      "query": "banana~",
+    "bool": Object {
+      "must": Array [
+        Object {
+          "term": Object {
+            "_deprecated": false,
+          },
+        },
+        Object {
+          "query_string": Object {
+            "query": "banana~",
+          },
+        },
+      ],
     },
   },
 }

--- a/src/shared/store/actions/utils/makeESQuery.ts
+++ b/src/shared/store/actions/utils/makeESQuery.ts
@@ -5,13 +5,11 @@ export const makeESQuery = (query?: List['query']) => {
   if (query) {
     const must = [];
     if (Object.keys(query.filters).length) {
-      Object.keys(query.filters)
-        .filter(key => !!query.filters[key])
-        .forEach(key => {
-          must.push({
-            term: { [key]: query.filters[key] },
-          });
+      Object.keys(query.filters).forEach(key => {
+        must.push({
+          term: { [key]: query.filters[key] },
         });
+      });
     }
     if (query.textQuery) {
       must.push({


### PR DESCRIPTION
fixes a 🐛 where filters that have falsey values would be removed from the ElasticSearch query builder, which would prevent deprecated resources from being filtered out, for example. 