### PR TITLE
✨ FEAT: 623 filter management resources

### DIFF
--- a/src/shared/components/Workspace/Queries/Query/QueryComponent.tsx
+++ b/src/shared/components/Workspace/Queries/Query/QueryComponent.tsx
@@ -83,6 +83,21 @@ const QueryComponent: React.FunctionComponent<QueryComponentProps> = props => {
     });
   };
   const showDeprecated = props.list.query.filters._deprecated;
+  const handleToggleDisplayManagementResources = () => {
+    updateList({
+      ...props.list,
+      query: {
+        ...props.list.query,
+        filters: {
+          ...props.list.query.filters,
+          showManagementResources: !props.list.query.filters
+            .showManagementResources,
+        },
+      },
+    });
+  };
+  const showManagementResources =
+    props.list.query.filters.showManagementResources;
 
   const handleCloneList = () => {
     cloneList({ ...props.list });
@@ -149,19 +164,38 @@ const QueryComponent: React.FunctionComponent<QueryComponentProps> = props => {
           schemas={data && data.schemas}
           onChange={handleFilterChange}
         />
-        <Tooltip
-          title={
-            showDeprecated
-              ? 'Displaying deprecated resources'
-              : 'Not showing deprecated resources'
-          }
-        >
-          <Switch
-            size="small"
-            onChange={handleToggleDeprecated}
-            checked={showDeprecated}
-          />
-        </Tooltip>
+        <div className="switches">
+          <Tooltip
+            title={
+              showDeprecated
+                ? 'Displaying deprecated resources only'
+                : 'Not showing deprecated resources'
+            }
+          >
+            <Switch
+              // size="small"
+              onChange={handleToggleDeprecated}
+              checked={showDeprecated}
+              checkedChildren={<Icon type="delete" />}
+              unCheckedChildren={<Icon type="delete" />}
+            />
+          </Tooltip>
+          <Tooltip
+            title={
+              showManagementResources
+                ? 'Displaying management resources only'
+                : 'Showing regular resources only'
+            }
+          >
+            <Switch
+              // size="small"
+              onChange={handleToggleDisplayManagementResources}
+              checked={showManagementResources}
+              checkedChildren={<Icon type="setting" />}
+              unCheckedChildren={<Icon type="setting" />}
+            />
+          </Tooltip>
+        </div>
       </div>
       <Spin spinning={showSpinner}>
         <InfiniteScroll

--- a/src/shared/components/Workspace/Queries/Query/query-component.less
+++ b/src/shared/components/Workspace/Queries/Query/query-component.less
@@ -59,6 +59,14 @@
     width: calc(50% - 2px);
     margin: 0.5em 0;
   }
+  & > .controls > .switches {
+    width: 100%;
+    display: flex;
+    justify-content: flex-end;
+  }
+  & > .controls > .switches > .ant-switch {
+    margin-left: @default-pad;
+  }
   & > .infinite-scroll > .list .list-item {
     margin: 0.5em 0;
   }

--- a/src/shared/store/actions/utils/__tests__/__snapshots__/makeESQuery.spec.ts.snap
+++ b/src/shared/store/actions/utils/__tests__/__snapshots__/makeESQuery.spec.ts.snap
@@ -16,6 +16,29 @@ Object {
           },
         },
       ],
+      "must_not": Array [
+        Object {
+          "bool": Object {
+            "should": Array [
+              Object {
+                "term": Object {
+                  "_constrainedBy": "https://bluebrain.github.io/nexus/schemas/resolver.json",
+                },
+              },
+              Object {
+                "term": Object {
+                  "_constrainedBy": "https://bluebrain.github.io/nexus/schemas/storage.json",
+                },
+              },
+              Object {
+                "term": Object {
+                  "_constrainedBy": "https://bluebrain.github.io/nexus/schemas/view.json",
+                },
+              },
+            ],
+          },
+        },
+      ],
     },
   },
 }
@@ -37,6 +60,29 @@ Object {
           },
         },
       ],
+      "must_not": Array [
+        Object {
+          "bool": Object {
+            "should": Array [
+              Object {
+                "term": Object {
+                  "_constrainedBy": "https://bluebrain.github.io/nexus/schemas/resolver.json",
+                },
+              },
+              Object {
+                "term": Object {
+                  "_constrainedBy": "https://bluebrain.github.io/nexus/schemas/storage.json",
+                },
+              },
+              Object {
+                "term": Object {
+                  "_constrainedBy": "https://bluebrain.github.io/nexus/schemas/view.json",
+                },
+              },
+            ],
+          },
+        },
+      ],
     },
   },
 }
@@ -45,8 +91,37 @@ Object {
 exports[`makeESQuery deprecated should return a must clause with just the term query 1`] = `
 Object {
   "query": Object {
-    "term": Object {
-      "_deprecated": false,
+    "bool": Object {
+      "must": Array [
+        Object {
+          "term": Object {
+            "_deprecated": false,
+          },
+        },
+      ],
+      "must_not": Array [
+        Object {
+          "bool": Object {
+            "should": Array [
+              Object {
+                "term": Object {
+                  "_constrainedBy": "https://bluebrain.github.io/nexus/schemas/resolver.json",
+                },
+              },
+              Object {
+                "term": Object {
+                  "_constrainedBy": "https://bluebrain.github.io/nexus/schemas/storage.json",
+                },
+              },
+              Object {
+                "term": Object {
+                  "_constrainedBy": "https://bluebrain.github.io/nexus/schemas/view.json",
+                },
+              },
+            ],
+          },
+        },
+      ],
     },
   },
 }
@@ -78,6 +153,29 @@ Object {
           },
         },
       ],
+      "must_not": Array [
+        Object {
+          "bool": Object {
+            "should": Array [
+              Object {
+                "term": Object {
+                  "_constrainedBy": "https://bluebrain.github.io/nexus/schemas/resolver.json",
+                },
+              },
+              Object {
+                "term": Object {
+                  "_constrainedBy": "https://bluebrain.github.io/nexus/schemas/storage.json",
+                },
+              },
+              Object {
+                "term": Object {
+                  "_constrainedBy": "https://bluebrain.github.io/nexus/schemas/view.json",
+                },
+              },
+            ],
+          },
+        },
+      ],
     },
   },
 }
@@ -96,6 +194,29 @@ Object {
         Object {
           "query_string": Object {
             "query": "banana~",
+          },
+        },
+      ],
+      "must_not": Array [
+        Object {
+          "bool": Object {
+            "should": Array [
+              Object {
+                "term": Object {
+                  "_constrainedBy": "https://bluebrain.github.io/nexus/schemas/resolver.json",
+                },
+              },
+              Object {
+                "term": Object {
+                  "_constrainedBy": "https://bluebrain.github.io/nexus/schemas/storage.json",
+                },
+              },
+              Object {
+                "term": Object {
+                  "_constrainedBy": "https://bluebrain.github.io/nexus/schemas/view.json",
+                },
+              },
+            ],
           },
         },
       ],

--- a/src/shared/store/actions/utils/__tests__/makeESQuery.spec.ts
+++ b/src/shared/store/actions/utils/__tests__/makeESQuery.spec.ts
@@ -11,6 +11,7 @@ describe('makeESQuery', () => {
         makeESQuery({
           filters: {
             _deprecated: false,
+            showManagementResources: false,
           },
           textQuery: 'banana',
         })
@@ -24,6 +25,7 @@ describe('makeESQuery', () => {
         makeESQuery({
           filters: {
             _deprecated: false,
+            showManagementResources: false,
           },
         })
       ).toMatchSnapshot();
@@ -37,6 +39,7 @@ describe('makeESQuery', () => {
           filters: {
             _constrainedBy: 'mySchema',
             _deprecated: false,
+            showManagementResources: false,
           },
         })
       ).toMatchSnapshot();
@@ -50,6 +53,7 @@ describe('makeESQuery', () => {
           filters: {
             '@type': 'myType',
             _deprecated: true,
+            showManagementResources: false,
           },
         })
       ).toMatchSnapshot();
@@ -64,6 +68,7 @@ describe('makeESQuery', () => {
             '@type': 'myType',
             _constrainedBy: 'mySchemas',
             _deprecated: true,
+            showManagementResources: false,
           },
           textQuery: 'Banana',
         })

--- a/src/shared/store/actions/utils/makeESQuery.ts
+++ b/src/shared/store/actions/utils/makeESQuery.ts
@@ -1,11 +1,54 @@
 import { List } from '../../reducers/lists';
 
+const managementSchemas = [
+  'https://bluebrain.github.io/nexus/schemas/resolver.json',
+  'https://bluebrain.github.io/nexus/schemas/storage.json',
+  'https://bluebrain.github.io/nexus/schemas/view.json',
+];
+
+interface TermFilter {
+  term: { [termKey: string]: string };
+}
+
 // TODO break out into library
 export const makeESQuery = (query?: List['query']) => {
   if (query) {
     const must = [];
+    const mustNot: any[] = []; // too lazy to type all of the possible query types!
     if (Object.keys(query.filters).length) {
       Object.keys(query.filters).forEach(key => {
+        // exception to make filtering easier
+        // because management resources are many
+        if (key === 'showManagementResources') {
+          const should: TermFilter[] = []; // OR === Should
+          managementSchemas.forEach(schema => {
+            should.push({
+              term: { _constrainedBy: schema },
+            });
+          });
+          if (!!query.filters[key]) {
+            // showManagementResoruces is true, add them as
+            // a must match to the filter
+            must.push({
+              bool: {
+                should,
+              },
+            });
+          } else {
+            // otherwise add as mustNot match to filter them out
+            mustNot.push({
+              bool: {
+                should,
+              },
+            });
+          }
+          // Otherwise we ignore this value, as it's
+          // not a real filterable value
+          // just a convenience label
+          return;
+        }
+        // any other keys inside the filter object
+        // are legitimate filterable keys
         must.push({
           term: { [key]: query.filters[key] },
         });
@@ -18,11 +61,15 @@ export const makeESQuery = (query?: List['query']) => {
         },
       });
     }
-    if (must.length > 1) {
+
+    console.log({ must, mustNot });
+
+    if (must.length >= 1 || mustNot.length >= 1) {
       return {
         query: {
           bool: {
             must,
+            must_not: mustNot,
           },
         },
       };

--- a/src/shared/store/actions/utils/makeESQuery.ts
+++ b/src/shared/store/actions/utils/makeESQuery.ts
@@ -62,8 +62,6 @@ export const makeESQuery = (query?: List['query']) => {
       });
     }
 
-    console.log({ must, mustNot });
-
     if (must.length >= 1 || mustNot.length >= 1) {
       return {
         query: {

--- a/src/shared/store/reducers/lists.ts
+++ b/src/shared/store/reducers/lists.ts
@@ -30,6 +30,7 @@ export interface List {
       _constrainedBy?: string;
       '@type'?: string;
       _deprecated: boolean;
+      showManagementResources: boolean;
       [key: string]: any;
     };
     textQuery?: string;
@@ -53,6 +54,7 @@ export const DEFAULT_LIST: List = {
   id: uuidv4(),
   query: {
     filters: {
+      showManagementResources: false,
       _deprecated: false,
     },
   },


### PR DESCRIPTION

![Screenshot 2019-05-23 at 11 19 59](https://user-images.githubusercontent.com/5485824/58241671-bd190c80-7d4d-11e9-8384-fb174703792e.png)

# NEW
- Resource query lists now have a "filter by management resources" switch. It shows a little gear (to represent "system stuff")
- Query lists have management resources filtered out by default, so a new project will show an empty list unless the user adds stuff or toggles the management filter
- The deprecated toggle filter switch also works together with the management filter switch, so you can display only deprecated management resources. 

## What is a management resource?
These are resources specific to the operating of the platform in a system or administrative way, and don't represent actual datasets. Notable here is the absence of the Schema schema, which I've decided is the exception to this category. 
```
const managementSchemas = [
  'https://bluebrain.github.io/nexus/schemas/resolver.json',
  'https://bluebrain.github.io/nexus/schemas/storage.json',
  'https://bluebrain.github.io/nexus/schemas/view.json',
];
```

resolves https://github.com/BlueBrain/nexus/issues/623