### PR TITLE
👷‍♀️ FIX: add sparql view queries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8506,8 +8506,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -8528,14 +8527,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8550,20 +8547,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8680,8 +8674,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8693,7 +8686,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8708,7 +8700,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -8716,14 +8707,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -8742,7 +8731,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -8823,8 +8811,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8836,7 +8823,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8922,8 +8908,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -8959,7 +8944,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -8979,7 +8963,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -9023,14 +9006,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/src/shared/components/RawQueryView/RawSparqlQueryView.tsx
+++ b/src/shared/components/RawQueryView/RawSparqlQueryView.tsx
@@ -25,9 +25,14 @@ export interface RawSparqlQueryViewProps {
   response: SparqlViewQueryResponse;
   wantedOrg: any;
   wantedProject: any;
+  wantedView?: string;
   error: RequestError | null;
-  executeRawQuery(orgName: string, projectName: string, query: string): void;
-  reset: VoidFunction;
+  executeRawQuery(
+    orgName: string,
+    projectName: string,
+    viewID: string | undefined,
+    query: string
+  ): void;
 }
 
 const FormItem = Form.Item;
@@ -40,6 +45,7 @@ const RawSparqlQueryView: React.FunctionComponent<RawSparqlQueryViewProps> = ({
   executeRawQuery,
   wantedOrg,
   wantedProject,
+  wantedView,
   error,
   reset,
 }): JSX.Element => {
@@ -103,7 +109,7 @@ const RawSparqlQueryView: React.FunctionComponent<RawSparqlQueryViewProps> = ({
       <Form
         onSubmit={e => {
           e.preventDefault();
-          executeRawQuery(wantedOrg, wantedProject, query);
+          executeRawQuery(wantedOrg, wantedProject, wantedView, query);
         }}
       >
         <div style={{ maxHeight: 600, overflow: 'scroll' }}>
@@ -168,9 +174,9 @@ const mapDispatchToProps = (dispatch: any) => ({
   executeRawQuery: (
     orgName: string,
     projectName: string,
+    viewId: string | undefined,
     query: string
-  ): void => dispatch(executeRawQuery(orgName, projectName, query)),
-  reset: () => dispatch(resetQueryAction()),
+  ): void => dispatch(executeRawQuery(orgName, projectName, viewId, query)),
 });
 
 export default connect(

--- a/src/shared/components/RawQueryView/RawSparqlQueryView.tsx
+++ b/src/shared/components/RawQueryView/RawSparqlQueryView.tsx
@@ -33,6 +33,7 @@ export interface RawSparqlQueryViewProps {
     viewID: string | undefined,
     query: string
   ): void;
+  reset: VoidFunction;
 }
 
 const FormItem = Form.Item;

--- a/src/shared/routes.tsx
+++ b/src/shared/routes.tsx
@@ -81,7 +81,7 @@ const routes: RouteWithData[] = [
     component: RawElasticSearchQuery,
   },
   {
-    path: '/:org/:project/graph/sparql',
+    path: '/:org/:project/:view/sparql',
     component: RawSparqlQuery,
   },
   {

--- a/src/shared/store/actions/rawQuery.ts
+++ b/src/shared/store/actions/rawQuery.ts
@@ -59,6 +59,7 @@ export type RawQueryActions =
 export const executeRawQuery: ActionCreator<ThunkAction> = (
   orgName: string,
   projectName: string,
+  viewId: string | undefined,
   query: string
 ) => {
   return async (
@@ -68,9 +69,7 @@ export const executeRawQuery: ActionCreator<ThunkAction> = (
   ): Promise<RawQueryActionSuccess | RawQueryActionFailure> => {
     dispatch(rawQueryAction(query));
     try {
-      const Project = nexus.Project;
-      const project = await Project.get(orgName, projectName);
-      const sparqlView = await project.getSparqlView();
+      const sparqlView = await SparqlView.get(orgName, projectName, viewId);
       const response = await sparqlView.query(query);
       const results: SparqlViewQueryResponse = response;
       return dispatch(rawQuerySuccessAction(results));

--- a/src/shared/views/RawQuery.tsx
+++ b/src/shared/views/RawQuery.tsx
@@ -66,6 +66,7 @@ const RawSparqlQueryComponent: React.FunctionComponent<RawQueryProps> = ({
     <RawSparqlQueryView
       wantedOrg={match.params.org}
       wantedProject={match.params.project}
+      wantedView={match.params.view}
     />
   );
 };


### PR DESCRIPTION
Can now directly query `ElasticSearchView`s and `SparqlView`s directly from the url path and from the query link. 

resolves https://github.com/BlueBrain/nexus/issues/634