### PR TITLE
👷‍♀️FIX: scaffold project on creation

### DIFF
--- a/src/shared/store/actions/project.ts
+++ b/src/shared/store/actions/project.ts
@@ -134,14 +134,17 @@ const makeProjectPublicFailureAction: ActionCreator<
   type: '@@nexus/PROJECT_MAKING_PUBLIC_FAILURE',
 });
 
-const pollProjectCreated = async (project: Project): Promise<void> => {
+const pollProjectCreated = async (
+  orgLabel: string,
+  projectLabel: string
+): Promise<void> => {
   let projectReady = false;
   let iterations = 0;
   const pollingTimeInMilliseconds = 500;
   const shortCircuitIterationCount = 60; // 30 seconds
   while (!projectReady) {
     try {
-      const esView = await project.getElasticSearchView();
+      const esView = await ElasticSearchView.get(orgLabel, projectLabel);
       // Even if the view is created, it will take some time until we can query,
       // to make sure we have data in the project, we should make some query here.
       const { total } = await esView.query({});
@@ -187,7 +190,7 @@ export const createProject: ActionCreator<ThunkAction> = (
         projectLabel,
         payload
       );
-      await pollProjectCreated(project);
+      await pollProjectCreated(orgLabel, projectLabel);
       return dispatch(createProjectSuccessAction(project));
     } catch (e) {
       return Promise.reject(dispatch(createProjectFailureAction(e)));


### PR DESCRIPTION
Prompts the user to wait until the project is "scaffolded"

The app will wait until the default view is created AND wait until there are documents inside the view.

resolve https://github.com/BlueBrain/nexus/issues/635