### PR TITLE
👷‍♀️FIX: 636 fix previous query results

### DIFF
--- a/src/shared/components/RawQueryView/RawElasticSearchQueryView.tsx
+++ b/src/shared/components/RawQueryView/RawElasticSearchQueryView.tsx
@@ -130,7 +130,7 @@ const RawElasticSearchQueryView: React.FunctionComponent<
             </div>
           </div>
           <CodeMirror
-            value={initialQuery}
+            value={formattedInitialQuery}
             options={{
               mode: { name: 'javascript', json: true },
               theme: 'base16-light',

--- a/src/shared/components/RawQueryView/RawElasticSearchQueryView.tsx
+++ b/src/shared/components/RawQueryView/RawElasticSearchQueryView.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
 import { Form, Icon, Button, Card, List, Empty } from 'antd';
-import { executeRawElasticSearchQuery } from '../../store/actions/rawQuery';
+import {
+  executeRawElasticSearchQuery,
+  resetQueryAction,
+} from '../../store/actions/rawQuery';
 import { RawElasticSearchQueryState } from '../../store/reducers/rawQuery';
 import { connect } from 'react-redux';
 import { PaginatedList, PaginationSettings } from '@bbp/nexus-sdk';
@@ -39,6 +42,7 @@ export interface RawElasticSearchQueryViewProps {
     query: string,
     paginationSettings: PaginationSettings
   ): void;
+  reset: VoidFunction;
 }
 
 const FormItem = Form.Item;
@@ -56,7 +60,12 @@ const RawElasticSearchQueryView: React.FunctionComponent<
   wantedProject,
   wantedView,
   error,
+  reset,
 }): JSX.Element => {
+  React.useEffect(() => {
+    return reset;
+  }, []);
+
   const formattedInitialQuery = JSON.stringify(
     JSON.parse(initialQuery),
     null,
@@ -234,6 +243,7 @@ const mapDispatchToProps = (dispatch: any) => ({
         paginationSettings
       )
     ),
+  reset: () => dispatch(resetQueryAction()),
 });
 
 export default connect(

--- a/src/shared/components/RawQueryView/RawSparqlQueryView.tsx
+++ b/src/shared/components/RawQueryView/RawSparqlQueryView.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
 import { Form, Button, Table, Card, Empty } from 'antd';
-import { executeRawQuery } from '../../store/actions/rawQuery';
+import {
+  executeRawQuery,
+  resetQueryAction,
+} from '../../store/actions/rawQuery';
 import { RawQueryState } from '../../store/reducers/rawQuery';
 import { connect } from 'react-redux';
 import { SparqlViewQueryResponse } from '@bbp/nexus-sdk/lib/View/SparqlView/types';
@@ -24,6 +27,7 @@ export interface RawSparqlQueryViewProps {
   wantedProject: any;
   error: RequestError | null;
   executeRawQuery(orgName: string, projectName: string, query: string): void;
+  reset: VoidFunction;
 }
 
 const FormItem = Form.Item;
@@ -37,8 +41,12 @@ const RawSparqlQueryView: React.FunctionComponent<RawSparqlQueryViewProps> = ({
   wantedOrg,
   wantedProject,
   error,
+  reset,
 }): JSX.Element => {
   const [query, setQuery] = React.useState(initialQuery);
+  React.useEffect(() => {
+    return reset;
+  }, []);
 
   let cols: string[];
   let data: any;
@@ -162,6 +170,7 @@ const mapDispatchToProps = (dispatch: any) => ({
     projectName: string,
     query: string
   ): void => dispatch(executeRawQuery(orgName, projectName, query)),
+  reset: () => dispatch(resetQueryAction()),
 });
 
 export default connect(

--- a/src/shared/store/actions/rawQuery.ts
+++ b/src/shared/store/actions/rawQuery.ts
@@ -1,4 +1,4 @@
-import { Action, ActionCreator, Dispatch } from 'redux';
+import { Action, ActionCreator, Dispatch, AnyAction } from 'redux';
 import {
   PaginatedList,
   PaginationSettings,
@@ -26,7 +26,9 @@ interface RawQueryActionFailure extends Action {
   type: '@@rawQuery/QUERYING_FAILURE';
   error: RequestError;
 }
-
+export const resetQueryAction: ActionCreator<AnyAction> = () => ({
+  type: '@@rawQuery/RESET',
+});
 const rawQueryAction: ActionCreator<RawQueryAction> = (
   query: string,
   paginationSettings
@@ -49,6 +51,7 @@ const rawQueryFailureAction: ActionCreator<RawQueryActionFailure> = (
 });
 
 export type RawQueryActions =
+  | { type: '@@rawQuery/RESET' }
   | RawQueryAction
   | RawQueryActionSuccess
   | RawQueryActionFailure;

--- a/src/shared/store/reducers/rawQuery.ts
+++ b/src/shared/store/reducers/rawQuery.ts
@@ -59,6 +59,8 @@ export function rawElasticSearchQueryReducer(
   action: RawQueryActions
 ) {
   switch (action.type) {
+    case '@@rawQuery/RESET':
+      return initialElasticSearchState;
     case '@@rawQuery/QUERYING':
       return {
         ...state,
@@ -94,6 +96,8 @@ export default function rawQueryReducer(
   action: RawQueryActions
 ) {
   switch (action.type) {
+    case '@@rawQuery/RESET':
+      return initialState;
     case '@@rawQuery/QUERYING':
       return { ...state, fetching: true, error: null };
     case '@@rawQuery/QUERYING_FAILURE':


### PR DESCRIPTION
- removes previous query results between `ElasticSearchView` or `SparqlView` query pages
- fixes a formatting bug for queries that provided by the query list interface

resolves https://github.com/BlueBrain/nexus/issues/636