### PR TITLE
✨ FEAT: add a scary warning message before deprecating defaultElasticSearchView

### DIFF
--- a/src/shared/components/Resources/ResourceActions.tsx
+++ b/src/shared/components/Resources/ResourceActions.tsx
@@ -19,6 +19,15 @@ const actionTypes = [
     predicate: chainPredicates([isDefaultElasticView, not(isDeprecated)]),
     title: 'Deprecate this resource',
     shortTitle: 'Dangerously Deprecate',
+    message: (
+      <div>
+        <h3>Warning!</h3>
+        <p>
+          Deprecating this resource <em>WILL ABSOLUTELY</em> break this
+          application for this project. Are you sure you want to deprecate it?
+        </p>
+      </div>
+    ),
     icon: 'delete',
     danger: true,
   },
@@ -26,6 +35,7 @@ const actionTypes = [
     name: 'deprecateResource',
     predicate: chainPredicates([not(isDeprecated), not(isDefaultElasticView)]),
     title: 'Deprecate this resource',
+    message: "Are you sure you'd like to deprecate this resource?",
     shortTitle: 'Deprecate',
     icon: 'delete',
     danger: true,
@@ -55,14 +65,14 @@ const actionTypes = [
 
 const makeButton = ({
   title,
-  name,
   icon,
   shortTitle,
   danger,
+  message,
 }: {
-  name: string;
   title: string;
   icon: string;
+  message?: React.ReactElement | string;
   shortTitle: string;
   danger?: boolean;
 }) => (resource: Resource, actionToDispatch: (resource: Resource) => void) => (
@@ -70,18 +80,7 @@ const makeButton = ({
     {danger ? (
       <Popconfirm
         title={
-          name === 'veryDangerousToDeprecate' ? (
-            <div>
-              <h3>Warning!</h3>
-              <p>
-                Deprecating this resource <em>WILL ABSOLUTELY</em> break this
-                application for this project. Are you sure you want to deprecate
-                it?
-              </p>
-            </div>
-          ) : (
-            "Are you sure you'd like to deprecate this resource?"
-          )
+          message ? message : 'Are you sure you want to perform this action?'
         }
         onConfirm={() => actionToDispatch && actionToDispatch(resource)}
         okText="Yes"

--- a/src/shared/utils/nexus-maybe.ts
+++ b/src/shared/utils/nexus-maybe.ts
@@ -5,13 +5,29 @@ const VIEW = 'View';
 const ES_VIEW = 'ElasticSearchView';
 const SPARQL_VIEW = 'SparqlView';
 
+const DEFAULT_ELASTIC_SEARCH_VIEW_ID = 'nxv:defaultElasticSearchIndex';
+
 const isOfType = (type: string) => (resource: Resource) =>
   !!resource.type && resource.type.includes(type);
+const hasIdOf = (id: string) => (resource: Resource) =>
+  resource.raw['@id'] === id;
 
+type predicateFunction = (resource: Resource) => boolean;
+
+// asks a question in a row and returns the combined booleans
+export const chainPredicates = (predicates: predicateFunction[]) => (
+  resource: Resource
+) => predicates.reduce((memo, predicate) => memo && predicate(resource), true);
+
+export const not = (predicate: predicateFunction) => (resource: Resource) =>
+  !predicate(resource);
 export const isDeprecated = (resource: Resource) => resource.deprecated;
-export const isNotDeprecated = (resource: Resource) => !resource.deprecated;
 export const isView = isOfType(VIEW);
 export const isElasticView = isOfType(ES_VIEW);
+export const isDefaultElasticView = chainPredicates([
+  isOfType(ES_VIEW),
+  hasIdOf(DEFAULT_ELASTIC_SEARCH_VIEW_ID),
+]);
 export const isSparqlView = isOfType(SPARQL_VIEW);
 export const isFile = (resource: Resource) =>
   resource && resource.type && resource.type.includes(NEXUS_FILE_TYPE);


### PR DESCRIPTION
![Kapture 2019-06-13 at 15 37 32](https://user-images.githubusercontent.com/5485824/59437295-99e3f900-8df1-11e9-8b71-e8d2967edfd8.gif)

resolves https://github.com/BlueBrain/nexus/issues/662