### PR TITLE
✨ FEAT: 665 select view from query

### DIFF
--- a/src/shared/components/RawQueryView/RawElasticSearchQueryView.tsx
+++ b/src/shared/components/RawQueryView/RawElasticSearchQueryView.tsx
@@ -74,7 +74,16 @@ const RawElasticSearchQueryView: React.FunctionComponent<
   const [query, setQuery] = React.useState(formattedInitialQuery);
   const [valid, setValid] = React.useState(true);
 
-  const data = response.results.map(result => result._source || []);
+  // Sometimes the results from sparql query are living in this response
+  // That's really bad!
+  // That's because these two queries share redux stuff
+  // This is a quick fix to solve this bug without doing much infrastructure work.
+  let data: any[];
+  if (response && (response as any).head) {
+    data = [];
+  } else {
+    data = response.results.map(result => result._source || []);
+  }
   const total = response.total || 0;
   const { from, size } = paginationSettings;
   const totalPages = Math.floor(total / size);

--- a/src/shared/components/Workspace/Queries/QueriesContainer.tsx
+++ b/src/shared/components/Workspace/Queries/QueriesContainer.tsx
@@ -78,7 +78,7 @@ const mapDispatchToProps = (
     dispatch(
       push(
         `/${org.label}/${project.label}/resources/${encodeURIComponent(
-          resource.id
+          resource.raw['@id']
         )}`
       )
     ),

--- a/src/shared/store/actions/nexus/views.ts
+++ b/src/shared/store/actions/nexus/views.ts
@@ -1,0 +1,30 @@
+import { ActionCreator, Dispatch } from 'redux';
+import { ThunkAction } from '../..';
+import { Resource } from '@bbp/nexus-sdk';
+
+export const listViews: ActionCreator<ThunkAction> = (
+  orgLabel: string,
+  projectLabel: string
+) => {
+  return async (
+    dispatch: Dispatch<any>,
+    getState,
+    { nexus }
+  ): Promise<Resource[]> => {
+    const Project = nexus.Project;
+    const Resource = nexus.Resource;
+    const realProject = await Project.get(orgLabel, projectLabel);
+    const views = await realProject.listViews();
+    // Getting lists as projects because View classes for this SDK
+    // doesn't offer the convenience methods that a Resource has
+    const promises = views.map(view =>
+      Resource.get(
+        view.orgLabel,
+        view.projectLabel,
+        '_',
+        encodeURIComponent(view.id)
+      )
+    );
+    return await Promise.all(promises);
+  };
+};

--- a/src/shared/views/RawQuery.tsx
+++ b/src/shared/views/RawQuery.tsx
@@ -7,8 +7,8 @@ import { RouteComponentProps, match } from 'react-router';
 import { fetchAndAssignProject } from '../store/actions/nexus/projects';
 import { fetchOrg } from '../store/actions/nexus/activeOrg';
 import * as queryString from 'query-string';
-import { Resource } from '@bbp/nexus-sdk';
 import { push } from 'connected-react-router';
+import { Menu, Dropdown, Icon } from 'antd';
 
 interface RawQueryProps extends RouteComponentProps {
   activeOrg: { label: string };
@@ -16,7 +16,7 @@ interface RawQueryProps extends RouteComponentProps {
   activeView?: { id: string };
   busy: boolean;
   fetchProject(orgName: string, projectName: string): void;
-  match: match<{ org: string; project: string; view?: string }>;
+  match: match<{ org: string; project: string; view: string }>;
   goToOrg(orgLabel: string): void;
   goToProject(orgLabel: string, projectLabel: string): void;
   location: any;
@@ -41,7 +41,21 @@ export const RawElasticSearchQueryComponent: React.FunctionComponent<
       fetchProject(match.params.org, match.params.project);
     }
   }, [match.params.org, match.params.project]);
+  const view = decodeURIComponent(match.params.view);
   const query = queryString.parse(location.search).query;
+  const menu = (
+    <Menu>
+      <Menu.Item key="0">
+        <a href="http://www.alipay.com/">1st menu item</a>
+      </Menu.Item>
+      <Menu.Item key="1">
+        <a href="http://www.taobao.com/">2nd menu item</a>
+      </Menu.Item>
+      <Menu.Divider />
+      <Menu.Item key="3">3rd menu item</Menu.Item>
+    </Menu>
+  );
+
   return (
     <div className="view-view">
       <h1 className="name">
@@ -54,7 +68,12 @@ export const RawElasticSearchQueryComponent: React.FunctionComponent<
           </a>{' '}
           |{' '}
         </span>
-        {match.params.view}
+        <Dropdown overlay={menu}>
+          <a className="ant-dropdown-link">
+            {view}
+            <Icon type="down" />
+          </a>
+        </Dropdown>
       </h1>
       <RawElasticSearchQueryView
         initialQuery={query}
@@ -82,6 +101,7 @@ const RawSparqlQueryComponent: React.FunctionComponent<RawQueryProps> = ({
       fetchProject(match.params.org, match.params.project);
     }
   }, [match.params.org, match.params.project]);
+  const view = decodeURIComponent(match.params.view);
   return (
     <div className="view-view">
       <h1 className="name">
@@ -94,12 +114,12 @@ const RawSparqlQueryComponent: React.FunctionComponent<RawQueryProps> = ({
           </a>{' '}
           |{' '}
         </span>
-        {match.params.view}
+        {view}
       </h1>
       <RawSparqlQueryView
         wantedOrg={match.params.org}
         wantedProject={match.params.project}
-        wantedView={match.params.view}
+        wantedView={view}
       />
     </div>
   );

--- a/src/shared/views/RawQuery.tsx
+++ b/src/shared/views/RawQuery.tsx
@@ -49,7 +49,9 @@ export const RawElasticSearchQueryComponent: React.FunctionComponent<
       fetchProject(match.params.org, match.params.project);
       listViews(match.params.org, match.params.project)
         .then(setViews)
-        .catch(console.error);
+        .catch((error: Error) => {
+          // do something
+        });
     }
   }, [match.params.org, match.params.project]);
   const view = decodeURIComponent(match.params.view);
@@ -114,7 +116,9 @@ const RawSparqlQueryComponent: React.FunctionComponent<RawQueryProps> = ({
       fetchProject(match.params.org, match.params.project);
       listViews(match.params.org, match.params.project)
         .then(setViews)
-        .catch(console.error);
+        .catch((error: Error) => {
+          // do something
+        });
     }
   }, [match.params.org, match.params.project]);
   const view = decodeURIComponent(match.params.view);

--- a/src/shared/views/Resource.tsx
+++ b/src/shared/views/Resource.tsx
@@ -147,21 +147,23 @@ const mapDispatchToProps = (dispatch: any) => {
         push(
           `/${resource.orgLabel}/${
             resource.projectLabel
-          }/resources/${encodeURIComponent(resource.id)}`
+          }/resources/${encodeURIComponent(resource.raw['@id'])}`
         )
       ),
     goToSparqlView: (resource: Resource) =>
       dispatch(
         push(
-          `/${resource.orgLabel}/${resource.projectLabel}/${resource.id}/sparql`
+          `/${resource.orgLabel}/${resource.projectLabel}/${encodeURIComponent(
+            resource.raw['@id']
+          )}/sparql`
         )
       ),
     goToElasticSearchView: (resource: Resource) =>
       dispatch(
         push(
-          `/${resource.orgLabel}/${resource.projectLabel}/${
-            resource.id
-          }/_search`
+          `/${resource.orgLabel}/${resource.projectLabel}/${encodeURIComponent(
+            resource.raw['@id']
+          )}/_search`
         )
       ),
     fetchResource: (


### PR DESCRIPTION
resolves https://github.com/BlueBrain/nexus/issues/665

Also fixes 

- a problem dealing with sparql query results crashing the elastic search view page
- a bug where strange view "ids" like "graph" and "documents" will be used in URLS, causing lots of confusion and headaches!