### PR TITLE
👷‍♀️ FIX: image detection using file name

### DIFF
--- a/src/shared/components/hooks/useNexusImage.ts
+++ b/src/shared/components/hooks/useNexusImage.ts
@@ -5,13 +5,32 @@ import useNexusFile from './useNexusFile';
 // Don't download preview if filesize is > than 1MB
 const DEFAULT_DISPLAY_SIZE = 1e6;
 
+function includesAny(s: string, listOfStrings: string[]) {
+  return listOfStrings.reduce(
+    (memo, compareString) => memo || s.includes(compareString),
+    false
+  );
+}
+
 export function hasDisplayableImage(resource: Resource): boolean {
+  // Is a File
+  // has mediaType Image
+  // OR
+  // Includes any of these image names in the filename
   return (
-    resource.type &&
-    resource.type.includes('File') &&
-    (resource.data as any)['_mediaType'] &&
-    (resource.data as any)['_mediaType'].includes('image') &&
-    (resource.data as any)['_bytes'] <= DEFAULT_DISPLAY_SIZE
+    (resource.type &&
+      resource.type.includes('File') &&
+      ((resource.data as any)['_mediaType'] &&
+        (resource.data as any)['_mediaType'].includes('image'))) ||
+    (includesAny((resource.data as any)['_filename'], [
+      'tiff',
+      'tif',
+      'jpeg',
+      'jpg',
+      'png',
+      'svg',
+    ]) &&
+      (resource.data as any)['_bytes'] <= DEFAULT_DISPLAY_SIZE)
   );
 }
 


### PR DESCRIPTION
Meant as a fallback for when, for example, the python SDK doesn't not use the correct `content type` whilst posting an image file to the backend. 

In such a case, the media type would be `text`, but the filename may still have an image file extension. therewith, we'll try to show the image anyway.  

🖼