### PR TITLE
✨ FEAT: Left/Right side menus

### DIFF
--- a/src/shared/components/Menu/SideMenu.less
+++ b/src/shared/components/Menu/SideMenu.less
@@ -1,4 +1,7 @@
+@import '../../lib.less';
+
 .side-menu {
+  .highShadow();
   position: fixed;
   z-index: 5;
   right: 0;

--- a/src/shared/components/Menu/SideMenu.stories.tsx
+++ b/src/shared/components/Menu/SideMenu.stories.tsx
@@ -6,7 +6,7 @@ import { action } from '@storybook/addon-actions';
 import SideMenu from './SideMenu';
 import { Divider, Button } from 'antd';
 
-storiesOf('Components/SideMenu', module)
+storiesOf('Components/Menus/SideMenu', module)
   .addDecorator(withKnobs)
   .add(
     'SideMenu',
@@ -24,11 +24,31 @@ storiesOf('Components/SideMenu', module)
     ~~~
   `)(() => {
       const title = text('Title', 'What a header!');
-      const open = boolean('Opened?', true);
+      const openright = boolean('Opened Right?', true);
+      const openleft = boolean('Opened Left?', true);
       return (
         <div style={{ margin: '50px 40px 0px' }}>
           <h2>Side Menu</h2>
-          <SideMenu title={title} visible={open} onClose={action('on-close')}>
+          <SideMenu
+            title={title}
+            visible={openright}
+            onClose={action('on-close')}
+          >
+            <Button type="primary" style={{ width: '100%', margin: '1em 0' }}>
+              Serious Button
+            </Button>
+            <Button style={{ width: '100%', margin: '1em 0' }}>
+              Another Button
+            </Button>
+            <Divider />
+            <p>You had better pay attention to this important text!</p>
+          </SideMenu>
+          <SideMenu
+            title={title}
+            visible={openleft}
+            side="left"
+            onClose={action('on-close')}
+          >
             <Button type="primary" style={{ width: '100%', margin: '1em 0' }}>
               Serious Button
             </Button>

--- a/src/shared/components/Menu/SideMenu.tsx
+++ b/src/shared/components/Menu/SideMenu.tsx
@@ -3,21 +3,29 @@ import { Icon, Card } from 'antd';
 import './SideMenu.less';
 import { useTransition, animated } from 'react-spring';
 
-const DEFAULT_ANIMATIONS = {
-  from: () => ({ right: -300, opacity: 0 }),
-  leave: () => ({ right: -300, opacity: 0 }),
-  enter: () => ({ right: 0, opacity: 1 }),
+const ANIMATIONS = {
+  left: {
+    from: () => ({ left: -300, opacity: 0 }),
+    leave: () => ({ left: -300, opacity: 0 }),
+    enter: () => ({ left: 0, opacity: 1 }),
+  },
+  right: {
+    from: () => ({ right: -300, opacity: 0 }),
+    leave: () => ({ right: -300, opacity: 0 }),
+    enter: () => ({ right: 0, opacity: 1 }),
+  },
 };
 
 export interface SideMenuProps {
   title?: string;
   visible: boolean;
   onClose: () => void;
+  side?: 'left' | 'right';
 }
 
 const SideMenu: React.FunctionComponent<SideMenuProps> = props => {
-  const { title, children, visible, onClose } = props;
-  const transitions = useTransition(visible, null, DEFAULT_ANIMATIONS);
+  const { title, children, visible, onClose, side = 'right' } = props;
+  const transitions = useTransition(visible, null, ANIMATIONS[side]);
   return (
     <>
       {transitions.map(
@@ -38,6 +46,7 @@ const SideMenu: React.FunctionComponent<SideMenuProps> = props => {
                   </div>
                 }
                 size="small"
+                bordered={false}
               >
                 <div className="content">{children}</div>
               </Card>

--- a/src/shared/components/Workspace/Menu.tsx
+++ b/src/shared/components/Workspace/Menu.tsx
@@ -4,7 +4,7 @@ import { Project, Resource, NexusFile } from '@bbp/nexus-sdk-legacy';
 import ResourceForm from '../Resources/ResourceFormModal';
 import { Link } from 'react-router-dom';
 import { CreateResourcePayload } from '@bbp/nexus-sdk-legacy/lib/Resource/types';
-import SideMenu from './SideMenu';
+import SideMenu from '../Menu/SideMenu';
 import FileUploader from '../FileUpload';
 import { AccessControl } from '@bbp/react-nexus';
 

--- a/src/shared/lib.less
+++ b/src/shared/lib.less
@@ -47,6 +47,14 @@ h1 {
 }
 
 // Mixins
+
+// Good for elements that want to look like
+// they're at the very top
+.highShadow() {
+  box-shadow: 0 12px 24px -6px rgba(9, 30, 66, 0.25),
+    0 0 0 1px rgba(9, 30, 66, 0.08);
+}
+
 .unstyleList() {
   list-style: none;
 }


### PR DESCRIPTION
- new `side` prop can be used to open `left` or `right`
- added fancy shadows
- moved to the "Menu" components folder

Useful for the upcoming project/org menu

![Screenshot 2019-07-03 at 16 53 16](https://user-images.githubusercontent.com/5485824/60602030-59094f80-9db3-11e9-902f-73109456f0ef.png)
