### PR TITLE
Add redux-logger to the middle ware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5948,6 +5948,11 @@
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
+    "deep-diff": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.8.tgz",
+      "integrity": "sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ="
+    },
     "deep-equal-ident": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/deep-equal-ident/-/deep-equal-ident-1.1.1.tgz",
@@ -13756,6 +13761,14 @@
       "requires": {
         "loose-envify": "^1.4.0",
         "symbol-observable": "^1.2.0"
+      }
+    },
+    "redux-logger": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/redux-logger/-/redux-logger-3.0.6.tgz",
+      "integrity": "sha1-91VZZvMJjzyIYExEnPC69XeCdL8=",
+      "requires": {
+        "deep-diff": "^0.3.5"
       }
     },
     "redux-oidc": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2783,6 +2783,27 @@
         "@types/react": "*"
       }
     },
+    "@types/redux-logger": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/redux-logger/-/redux-logger-3.0.7.tgz",
+      "integrity": "sha512-oV9qiCuowhVR/ehqUobWWkXJjohontbDGLV88Be/7T4bqMQ3kjXwkFNL7doIIqlbg3X2PC5WPziZ8/j/QHNQ4A==",
+      "requires": {
+        "redux": "^3.6.0"
+      },
+      "dependencies": {
+        "redux": {
+          "version": "3.7.2",
+          "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
+          "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+          "requires": {
+            "lodash": "^4.2.1",
+            "lodash-es": "^4.2.1",
+            "loose-envify": "^1.1.0",
+            "symbol-observable": "^1.0.3"
+          }
+        }
+      }
+    },
     "@types/serve-static": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.2.tgz",
@@ -10376,8 +10397,7 @@
     "lodash-es": {
       "version": "4.17.14",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.14.tgz",
-      "integrity": "sha512-7zchRrGa8UZXjD/4ivUWP1867jDkhzTG2c/uj739utSd7O/pFFdxspCemIFKEEjErbcqRzn8nKnGsi7mvTgRPA==",
-      "dev": true
+      "integrity": "sha512-7zchRrGa8UZXjD/4ivUWP1867jDkhzTG2c/uj739utSd7O/pFFdxspCemIFKEEjErbcqRzn8nKnGsi7mvTgRPA=="
     },
     "lodash._baseisequal": {
       "version": "3.0.7",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "react-router-dom": "^4.3.1",
     "react-spring": "^8.0.19",
     "redux": "^4.0.1",
+    "redux-logger": "^3.0.6",
     "redux-oidc": "^3.1.2",
     "redux-thunk": "^2.3.0",
     "resize-observer-polyfill": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "redux": "^4.0.1",
     "redux-logger": "^3.0.6",
     "redux-oidc": "^3.1.2",
-    "redux-promise": "^0.6.0",
     "redux-thunk": "^2.3.0",
     "resize-observer-polyfill": "^1.5.1",
     "ts-debounce": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@bbp/nexus-sdk": "^1.1.5",
     "@bbp/nexus-sdk-legacy": "npm:@bbp/nexus-sdk@1.0.0-beta.25",
     "@bbp/react-nexus": "^1.1.5",
+    "@types/redux-logger": "^3.0.7",
     "antd": "^3.19.5",
     "codemirror": "^5.44.0",
     "connected-react-router": "^6.3.2",
@@ -51,6 +52,7 @@
     "redux": "^4.0.1",
     "redux-logger": "^3.0.6",
     "redux-oidc": "^3.1.2",
+    "redux-promise": "^0.6.0",
     "redux-thunk": "^2.3.0",
     "resize-observer-polyfill": "^1.5.1",
     "ts-debounce": "^1.0.0"

--- a/src/shared/store/index.ts
+++ b/src/shared/store/index.ts
@@ -14,6 +14,8 @@ import reducers, { RootState } from './reducers';
 import { saveState, loadState } from './reducers/localStorage';
 import { persistanceMapper, ListsByProjectState } from './reducers/lists';
 import { NexusClient } from '@bbp/nexus-sdk';
+import * as reduxLogger from 'redux-logger';
+
 
 export type Services = {
   nexusLegacy: Nexus;
@@ -41,6 +43,7 @@ export default function configureStore(
 ): Store {
   // ignore server lists, fetch from local storage when available
   preloadedState.lists = { ...loadState('lists') };
+  const logger = reduxLogger.createLogger();
   const store = createStore(
     // @ts-ignore
     combineReducers({
@@ -52,7 +55,8 @@ export default function configureStore(
     composeEnhancers(
       applyMiddleware(
         thunk.withExtraArgument({ nexusLegacy, nexus }),
-        routerMiddleware(history)
+        routerMiddleware(history),
+        logger
       )
     )
   );


### PR DESCRIPTION
redux-logger helps to see the changes to redux store in the browser's developer console.
Developer can quickly debug or verify the changes to redux store during development with this logs.

A screenshot how the logs will look like is given below.

![Screenshot 2019-08-09 at 14 49 39 (3)](https://user-images.githubusercontent.com/1479155/62779993-f8a5b600-bab4-11e9-97ca-2de493abe825.png)

More Info : https://github.com/LogRocket/redux-logger
