### PR TITLE
Fix #778:  use latestRev in updateParams

### DIFF
--- a/src/shared/containers/HistoryContainer.tsx
+++ b/src/shared/containers/HistoryContainer.tsx
@@ -65,7 +65,7 @@ const HistoryContainer: React.FunctionComponent<{
         };
       })
     );
-  }, [orgLabel, projectLabel, resourceId]);
+  }, [orgLabel, projectLabel, resourceId, latestRev]);
 
   return <HistoryComponent revisions={revisions} link={link} />;
 };

--- a/src/shared/views/ResourceView.tsx
+++ b/src/shared/views/ResourceView.tsx
@@ -95,11 +95,10 @@ const ResourceView: React.FunctionComponent<ResourceViewProps> = props => {
           resource._rev,
           value
         );
-        setLatestResource(value);
         goToResource(orgLabel, projectLabel, resourceId, { revision: _rev });
         notification.success({
           message: 'Resource saved',
-          description: getResourceLabel(value),
+          description: getResourceLabel(resource),
           duration: 2,
         });
       } catch (error) {

--- a/src/shared/views/ResourceView.tsx
+++ b/src/shared/views/ResourceView.tsx
@@ -95,10 +95,11 @@ const ResourceView: React.FunctionComponent<ResourceViewProps> = props => {
           resource._rev,
           value
         );
+        setLatestResource(value);
         goToResource(orgLabel, projectLabel, resourceId, { revision: _rev });
         notification.success({
           message: 'Resource saved',
-          description: getResourceLabel(resource),
+          description: getResourceLabel(value),
           duration: 2,
         });
       } catch (error) {


### PR DESCRIPTION
The history tab will update on revision chnage, when latestRev is part
of updateParams. 
Fixes BlueBrain/nexus#778
