### PR TITLE
Fix issue# 791: Show correct description in history tab

### DIFF
--- a/src/shared/containers/HistoryContainer.tsx
+++ b/src/shared/containers/HistoryContainer.tsx
@@ -53,7 +53,7 @@ const HistoryContainer: React.FunctionComponent<{
           metadataKeys
         );
         const current = blacklistKeys(revision, metadataKeys);
-        const changes = diff(current, previous);
+        const changes = diff(previous, current);
         const hasChanges = JSON.stringify(changes, null, 2) !== '{}';
 
         return {


### PR DESCRIPTION
Update the parameter order passed in to diff method, so that it
calculates the correct diff.

Fix BlueBrain/nexus#791