### PR TITLE
Display Resource metadata in Editor

### DIFF
--- a/src/shared/components/ResourceEditor/index.tsx
+++ b/src/shared/components/ResourceEditor/index.tsx
@@ -9,10 +9,12 @@ export interface ResourceEditorProps {
   rawData: { [key: string]: any };
   onSubmit: (rawData: { [key: string]: any }) => void;
   onFormatChange?(expanded: boolean): void;
+  onMetaDataChange?(expanded: boolean): void;
   editable?: boolean;
   editing?: boolean;
   busy?: boolean;
   expanded?: boolean;
+  metaData?: boolean;
   showExpanded?: boolean;
 }
 
@@ -20,11 +22,13 @@ const ResourceEditor: React.FunctionComponent<ResourceEditorProps> = props => {
   const {
     rawData,
     onFormatChange,
+    onMetaDataChange,
     onSubmit,
     editable = false,
     busy = false,
     editing = false,
     expanded = false,
+    metaData = false,
     showExpanded = true,
   } = props;
 
@@ -88,6 +92,14 @@ const ResourceEditor: React.FunctionComponent<ResourceEditorProps> = props => {
               unCheckedChildren="expand"
               checked={expanded}
               onChange={onFormatChange}
+            />
+          )}
+          {!expanded && !isEditing && valid && (
+            <Switch
+              checkedChildren="Meta Data"
+              unCheckedChildren="Show Meta Data"
+              checked={metaData}
+              onChange={onMetaDataChange}
             />
           )}
           {editable && isEditing && valid && (

--- a/src/shared/components/ResourceEditor/index.tsx
+++ b/src/shared/components/ResourceEditor/index.tsx
@@ -85,7 +85,7 @@ const ResourceEditor: React.FunctionComponent<ResourceEditorProps> = props => {
             </div>
           )}
         </div>
-        
+
         <div className="controls">
           {!expanded && !isEditing && valid && (
             <>
@@ -94,8 +94,7 @@ const ResourceEditor: React.FunctionComponent<ResourceEditorProps> = props => {
                 unCheckedChildren="Show Meta Data"
                 checked={metaData}
                 onChange={onMetaDataChange}
-              />
-              {' '}
+              />{' '}
             </>
           )}
           {showExpanded && !isEditing && valid && (

--- a/src/shared/components/ResourceEditor/index.tsx
+++ b/src/shared/components/ResourceEditor/index.tsx
@@ -85,7 +85,19 @@ const ResourceEditor: React.FunctionComponent<ResourceEditorProps> = props => {
             </div>
           )}
         </div>
+        
         <div className="controls">
+          {!expanded && !isEditing && valid && (
+            <>
+              <Switch
+                checkedChildren="Meta Data"
+                unCheckedChildren="Show Meta Data"
+                checked={metaData}
+                onChange={onMetaDataChange}
+              />
+              {' '}
+            </>
+          )}
           {showExpanded && !isEditing && valid && (
             <Switch
               checkedChildren="expanded"
@@ -94,14 +106,7 @@ const ResourceEditor: React.FunctionComponent<ResourceEditorProps> = props => {
               onChange={onFormatChange}
             />
           )}
-          {!expanded && !isEditing && valid && (
-            <Switch
-              checkedChildren="Meta Data"
-              unCheckedChildren="Show Meta Data"
-              checked={metaData}
-              onChange={onMetaDataChange}
-            />
-          )}
+
           {editable && isEditing && valid && (
             <Button
               icon="save"

--- a/src/shared/components/ResourceEditor/index.tsx
+++ b/src/shared/components/ResourceEditor/index.tsx
@@ -9,12 +9,12 @@ export interface ResourceEditorProps {
   rawData: { [key: string]: any };
   onSubmit: (rawData: { [key: string]: any }) => void;
   onFormatChange?(expanded: boolean): void;
-  onMetaDataChange?(expanded: boolean): void;
+  onMetadataChange?(expanded: boolean): void;
   editable?: boolean;
   editing?: boolean;
   busy?: boolean;
   expanded?: boolean;
-  metaData?: boolean;
+  showMetadata?: boolean;
   showExpanded?: boolean;
 }
 
@@ -22,13 +22,13 @@ const ResourceEditor: React.FunctionComponent<ResourceEditorProps> = props => {
   const {
     rawData,
     onFormatChange,
-    onMetaDataChange,
+    onMetadataChange,
     onSubmit,
     editable = false,
     busy = false,
     editing = false,
     expanded = false,
-    metaData = false,
+    showMetadata = false,
     showExpanded = true,
   } = props;
 
@@ -90,10 +90,10 @@ const ResourceEditor: React.FunctionComponent<ResourceEditorProps> = props => {
           {!expanded && !isEditing && valid && (
             <>
               <Switch
-                checkedChildren="Meta Data"
-                unCheckedChildren="Show Meta Data"
-                checked={metaData}
-                onChange={onMetaDataChange}
+                checkedChildren="Metadata"
+                unCheckedChildren="Show Metadata"
+                checked={showMetadata}
+                onChange={onMetadataChange}
               />{' '}
             </>
           )}

--- a/src/shared/containers/ResourceActions.tsx
+++ b/src/shared/containers/ResourceActions.tsx
@@ -21,7 +21,7 @@ const ResourceActionsContainer: React.FunctionComponent<{
     orgLabel: string,
     projectLabel: string,
     resourceId: string,
-    revision: number,
+    revision: number
   ) => void;
 }> = ({ resource, goToView, goToResource }) => {
   const {
@@ -105,7 +105,7 @@ const mapDispatchToProps = (dispatch: any) => ({
     orgLabel: string,
     projectLabel: string,
     resourceId: string,
-    revision: number,
+    revision: number
   ) => {
     dispatch(
       push(

--- a/src/shared/containers/ResourceEditor.tsx
+++ b/src/shared/containers/ResourceEditor.tsx
@@ -1,11 +1,15 @@
 import * as React from 'react';
 import { useAsyncEffect } from 'use-async-effect';
-import { ExpandedResource, ResourceSource, Resource, NexusClient } from '@bbp/nexus-sdk';
+import {
+  ExpandedResource,
+  ResourceSource,
+  Resource,
+  NexusClient,
+} from '@bbp/nexus-sdk';
 import { useNexusContext } from '@bbp/react-nexus';
 
 import { getResourceLabelsAndIdsFromSelf } from '../utils';
 import ResourceEditor from '../components/ResourceEditor';
-
 
 const ResourceEditorContainer: React.FunctionComponent<{
   self: string;
@@ -25,7 +29,7 @@ const ResourceEditorContainer: React.FunctionComponent<{
   const nexus = useNexusContext();
   const [expanded, setExpanded] = React.useState(defaultExpanded);
   const [showMetaData, setShowMetaData] = React.useState<boolean>(false);
-  
+
   const {
     orgLabel,
     projectLabel,
@@ -33,7 +37,7 @@ const ResourceEditorContainer: React.FunctionComponent<{
   } = getResourceLabelsAndIdsFromSelf(self);
   const [{ busy, resource, error }, setResource] = React.useState<{
     busy: boolean;
-    resource: ResourceSource | ExpandedResource | Resource |null;
+    resource: ResourceSource | ExpandedResource | Resource | null;
     error: Error | null;
   }>({
     busy: false,
@@ -51,17 +55,17 @@ const ResourceEditorContainer: React.FunctionComponent<{
   };
 
   const getNewResource = async () => {
-    if(expanded) {
-      return  await nexus.Resource.get(orgLabel, projectLabel, resourceId, {
+    if (expanded) {
+      return await nexus.Resource.get(orgLabel, projectLabel, resourceId, {
         rev,
         format: 'expanded',
-      })
-    } 
-    if(showMetaData) {
+      });
+    }
+    if (showMetaData) {
       return await nexus.Resource.get(orgLabel, projectLabel, resourceId);
-    } 
+    }
     return await nexus.Resource.getSource(orgLabel, projectLabel, resourceId);
-  }
+  };
 
   useAsyncEffect(
     async isMounted => {
@@ -75,7 +79,7 @@ const ResourceEditorContainer: React.FunctionComponent<{
           busy: true,
         });
 
-        const  newResource =  await getNewResource();
+        const newResource = await getNewResource();
 
         setResource({
           resource: newResource,

--- a/src/shared/containers/ResourceEditor.tsx
+++ b/src/shared/containers/ResourceEditor.tsx
@@ -28,7 +28,7 @@ const ResourceEditorContainer: React.FunctionComponent<{
 }) => {
   const nexus = useNexusContext();
   const [expanded, setExpanded] = React.useState(defaultExpanded);
-  const [showMetaData, setShowMetaData] = React.useState<boolean>(false);
+  const [showMetadata, setShowMetadata] = React.useState<boolean>(false);
 
   const {
     orgLabel,
@@ -51,7 +51,7 @@ const ResourceEditorContainer: React.FunctionComponent<{
   };
 
   const handleMetaDataChange = () => {
-    setShowMetaData(!showMetaData);
+    setShowMetadata(!showMetadata);
   };
 
   const getNewResource = async () => {
@@ -61,7 +61,7 @@ const ResourceEditorContainer: React.FunctionComponent<{
         format: 'expanded',
       });
     }
-    if (showMetaData) {
+    if (showMetadata) {
       return await nexus.Resource.get(orgLabel, projectLabel, resourceId);
     }
     return await nexus.Resource.getSource(orgLabel, projectLabel, resourceId);
@@ -94,7 +94,7 @@ const ResourceEditorContainer: React.FunctionComponent<{
         });
       }
     },
-    [self, rev, expanded, showMetaData]
+    [self, rev, expanded, showMetadata]
   );
 
   return (
@@ -104,10 +104,10 @@ const ResourceEditorContainer: React.FunctionComponent<{
         rawData={resource}
         onSubmit={onSubmit}
         onFormatChange={handleFormatChange}
-        onMetaDataChange={handleMetaDataChange}
-        editable={defaultEditable && !expanded && !showMetaData}
+        onMetadataChange={handleMetaDataChange}
+        editable={defaultEditable && !expanded && !showMetadata}
         expanded={expanded}
-        metaData={showMetaData}
+        showMetadata={showMetadata}
       />
     )
   );


### PR DESCRIPTION
- Add a toggle to show/hide meta data in editor.
- Fetch and display meta-data, the content is non editable when meta
data is displayed.

Implements, BlueBrain/nexus/issues/779