### PR TITLE
👷‍♀️ FIX: Link list displays 2 spinners

### DIFF
--- a/src/shared/components/ResourceLinks/index.tsx
+++ b/src/shared/components/ResourceLinks/index.tsx
@@ -7,16 +7,17 @@ import ResourceLinkItem from './ResourceLinkItem';
 import InfiniteSearch from '../List/InfiniteSearch';
 
 const ResourceLinks: React.FunctionComponent<{
-  firstLoad: boolean;
+  busy: boolean;
   error: Error | null;
   links: ResourceLink[];
   total: number;
   onLoadMore: () => void;
   onClick?: (link: ResourceLink) => void;
 }> = props => {
-  const { firstLoad, error, links, total, onLoadMore, onClick } = props;
+  const { busy, error, links, total, onLoadMore, onClick } = props;
   const scrollParent = React.useRef<HTMLDivElement>(null);
   const hasMore = links.length < total;
+  const firstLoad = busy && links.length === 0;
 
   return (
     <div className="resource-links" ref={scrollParent}>

--- a/src/shared/components/ResourceLinks/index.tsx
+++ b/src/shared/components/ResourceLinks/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Spin, Empty } from 'antd';
+import { Spin, Empty, Skeleton } from 'antd';
 import { ResourceLink } from '@bbp/nexus-sdk';
 
 import ListItem from '../List/Item';
@@ -7,36 +7,40 @@ import ResourceLinkItem from './ResourceLinkItem';
 import InfiniteSearch from '../List/InfiniteSearch';
 
 const ResourceLinks: React.FunctionComponent<{
-  busy: boolean;
+  firstLoad: boolean;
   error: Error | null;
   links: ResourceLink[];
   total: number;
   onLoadMore: () => void;
   onClick?: (link: ResourceLink) => void;
 }> = props => {
-  const { busy, error, links, total, onLoadMore, onClick } = props;
+  const { firstLoad, error, links, total, onLoadMore, onClick } = props;
   const scrollParent = React.useRef<HTMLDivElement>(null);
   const hasMore = links.length < total;
 
   return (
     <div className="resource-links" ref={scrollParent}>
-      <Spin spinning={busy}>
-        {!!error && <Empty description={error.message} />}
-        {!error && (
-          <InfiniteSearch
-            dataLength={links.length}
-            onLoadMore={onLoadMore}
-            hasMore={hasMore}
-            hasSearch={false}
-          >
-            {links.map(link => (
-              <ListItem key={link['@id']}>
-                <ResourceLinkItem link={link} onInternalClick={onClick} />
-              </ListItem>
-            ))}
-          </InfiniteSearch>
-        )}
-      </Spin>
+      {firstLoad ? (
+        <Skeleton active></Skeleton>
+      ) : (
+        <>
+          {!!error && <Empty description={error.message} />}
+          {!error && (
+            <InfiniteSearch
+              dataLength={links.length}
+              onLoadMore={onLoadMore}
+              hasMore={hasMore}
+              hasSearch={false}
+            >
+              {links.map(link => (
+                <ListItem key={link['@id']}>
+                  <ResourceLinkItem link={link} onInternalClick={onClick} />
+                </ListItem>
+              ))}
+            </InfiniteSearch>
+          )}
+        </>
+      )}
     </div>
   );
 };

--- a/src/shared/components/ResourceLinks/index.tsx
+++ b/src/shared/components/ResourceLinks/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Spin, Empty, Skeleton } from 'antd';
+import { Empty, Skeleton } from 'antd';
 import { ResourceLink } from '@bbp/nexus-sdk';
 
 import ListItem from '../List/Item';

--- a/src/shared/components/ResourceLinks/index.tsx
+++ b/src/shared/components/ResourceLinks/index.tsx
@@ -22,7 +22,7 @@ const ResourceLinks: React.FunctionComponent<{
   return (
     <div className="resource-links" ref={scrollParent}>
       {firstLoad ? (
-        <Skeleton active></Skeleton>
+        <Skeleton active />
       ) : (
         <>
           {!!error && <Empty description={error.message} />}

--- a/src/shared/containers/ResourceLinks.tsx
+++ b/src/shared/containers/ResourceLinks.tsx
@@ -14,13 +14,18 @@ const ResourceLinksContainer: React.FunctionComponent<{
   onClick?: (link: ResourceLink) => void;
 }> = ({ self, rev, direction, onClick }) => {
   const nexus = useNexusContext();
-  const [{ busy, error, links, total, next }, setLinks] = React.useState<{
+  const [
+    { firstLoad, busy, error, links, total, next },
+    setLinks,
+  ] = React.useState<{
+    firstLoad: boolean;
     busy: boolean;
     error: Error | null;
     links: ResourceLink[];
     next: string | null;
     total: number;
   }>({
+    firstLoad: true,
     next: null,
     busy: false,
     error: null,
@@ -42,6 +47,7 @@ const ResourceLinksContainer: React.FunctionComponent<{
         next,
         links,
         total,
+        firstLoad: false,
         busy: true,
         error: null,
       });
@@ -52,6 +58,7 @@ const ResourceLinksContainer: React.FunctionComponent<{
         next: response._next || null,
         links: [...links, ...response._results],
         total: response._total,
+        firstLoad: false,
         busy: false,
         error: null,
       });
@@ -61,6 +68,7 @@ const ResourceLinksContainer: React.FunctionComponent<{
         error,
         links,
         total,
+        firstLoad: false,
         busy: false,
       });
     }
@@ -77,6 +85,7 @@ const ResourceLinksContainer: React.FunctionComponent<{
           next,
           links,
           total,
+          firstLoad: true,
           busy: true,
           error: null,
         });
@@ -95,6 +104,7 @@ const ResourceLinksContainer: React.FunctionComponent<{
           next: response._next || null,
           links: response._results,
           total: response._total,
+          firstLoad: false,
           busy: false,
           error: null,
         });
@@ -104,6 +114,7 @@ const ResourceLinksContainer: React.FunctionComponent<{
           error,
           links,
           total,
+          firstLoad: false,
           busy: false,
         });
       }
@@ -116,7 +127,7 @@ const ResourceLinksContainer: React.FunctionComponent<{
       error={error}
       links={links}
       total={total}
-      busy={busy}
+      firstLoad={firstLoad}
       onLoadMore={handleLoadMore}
       onClick={onClick}
     />

--- a/src/shared/containers/ResourceLinks.tsx
+++ b/src/shared/containers/ResourceLinks.tsx
@@ -14,18 +14,13 @@ const ResourceLinksContainer: React.FunctionComponent<{
   onClick?: (link: ResourceLink) => void;
 }> = ({ self, rev, direction, onClick }) => {
   const nexus = useNexusContext();
-  const [
-    { firstLoad, busy, error, links, total, next },
-    setLinks,
-  ] = React.useState<{
-    firstLoad: boolean;
+  const [{ busy, error, links, total, next }, setLinks] = React.useState<{
     busy: boolean;
     error: Error | null;
     links: ResourceLink[];
     next: string | null;
     total: number;
   }>({
-    firstLoad: true,
     next: null,
     busy: false,
     error: null,
@@ -47,7 +42,6 @@ const ResourceLinksContainer: React.FunctionComponent<{
         next,
         links,
         total,
-        firstLoad: false,
         busy: true,
         error: null,
       });
@@ -58,7 +52,6 @@ const ResourceLinksContainer: React.FunctionComponent<{
         next: response._next || null,
         links: [...links, ...response._results],
         total: response._total,
-        firstLoad: false,
         busy: false,
         error: null,
       });
@@ -68,7 +61,6 @@ const ResourceLinksContainer: React.FunctionComponent<{
         error,
         links,
         total,
-        firstLoad: false,
         busy: false,
       });
     }
@@ -85,7 +77,6 @@ const ResourceLinksContainer: React.FunctionComponent<{
           next,
           links,
           total,
-          firstLoad: true,
           busy: true,
           error: null,
         });
@@ -104,7 +95,6 @@ const ResourceLinksContainer: React.FunctionComponent<{
           next: response._next || null,
           links: response._results,
           total: response._total,
-          firstLoad: false,
           busy: false,
           error: null,
         });
@@ -114,7 +104,6 @@ const ResourceLinksContainer: React.FunctionComponent<{
           error,
           links,
           total,
-          firstLoad: false,
           busy: false,
         });
       }
@@ -127,7 +116,7 @@ const ResourceLinksContainer: React.FunctionComponent<{
       error={error}
       links={links}
       total={total}
-      firstLoad={firstLoad}
+      busy={busy}
       onLoadMore={handleLoadMore}
       onClick={onClick}
     />


### PR DESCRIPTION
fixes https://github.com/BlueBrain/nexus/issues/781

Removes the throbber and uses a skeleton on initial load.