### PR TITLE
829 navigate to other resouces in the graph

### DIFF
--- a/src/shared/components/Graph/index.tsx
+++ b/src/shared/components/Graph/index.tsx
@@ -78,9 +78,7 @@ const Graph: React.FunctionComponent<{
     }).on('tap', 'node', (e: cytoscape.EventObject) => {
       // we should expand a graph here when user clicks on a node 
     }).on('mouseover', 'node', (e: cytoscape.EventObject) => {
-      // show a resorce preview tooltip
-      console.log(e);
-      
+      // show a resorce preview tooltip      
       setResourcePreviewCoords({
         x: e.originalEvent.offsetX,
         y: e.originalEvent.offsetY,

--- a/src/shared/components/Graph/index.tsx
+++ b/src/shared/components/Graph/index.tsx
@@ -76,10 +76,6 @@ const Graph: React.FunctionComponent<{
     };
   }, [container, elements, showLabels]);
 
-  const handleClose = () => {
-    setShowAlert(false);
-  };
-
   return (
     <div>
       <div>
@@ -93,10 +89,10 @@ const Graph: React.FunctionComponent<{
       <div style={{ padding: '20px 0 0' }}>
         {showAlert ? (
           <Alert
-            message="Click and hold a node to go to a resource"
+            message="Click and hold to visit a resource"
             type="info"
             closable
-            afterClose={() => handleClose()}
+            afterClose={() => setShowAlert(false)}
           />
         ) : null}
       </div>

--- a/src/shared/components/Graph/index.tsx
+++ b/src/shared/components/Graph/index.tsx
@@ -75,6 +75,8 @@ const Graph: React.FunctionComponent<{
         coolingFactor: 0.95,
         minTemp: 1.0,
       },
+    }).on('tap', 'node', (e: cytoscape.EventObject) => {
+      // we should expand a graph here when user clicks on a node 
     }).on('mouseover', 'node', (e: cytoscape.EventObject) => {
       // show a resorce preview tooltip
       setResourcePreviewCoords({

--- a/src/shared/components/Graph/index.tsx
+++ b/src/shared/components/Graph/index.tsx
@@ -76,9 +76,7 @@ const Graph: React.FunctionComponent<{
       setResourcePreviewCoords({
         x: e.originalEvent.clientX - 100,
         y: e.originalEvent.clientY - 400,
-      });
-      console.log('e.target.position()', e);
-      
+      });      
       setShowResourcePreview(true);
       setSelectedResource(e.target.id());      
     }).on('mouseout', 'node', () => setShowResourcePreview(false));

--- a/src/shared/components/Graph/index.tsx
+++ b/src/shared/components/Graph/index.tsx
@@ -14,7 +14,13 @@ const Graph: React.FunctionComponent<{
     x?: number,
     y?: number,
   }>({});
-  const [selectedResource, setSelectedResource] = React.useState<any>('');
+  const [selectedResource, setSelectedResource] = React.useState<{
+    id: string,
+    isExternal: boolean,
+  }>({
+    id: '',
+    isExternal: false,
+  });
 
   React.useEffect(() => {
     const graph = cytoscape({
@@ -69,16 +75,17 @@ const Graph: React.FunctionComponent<{
         coolingFactor: 0.95,
         minTemp: 1.0,
       },
-    }).on('tap', 'node', (e: cytoscape.EventObject) => {
-      onNodeClick && onNodeClick(e.target.id(), e.target.data('isExternal'));
     }).on('mouseover', 'node', (e: cytoscape.EventObject) => {
       // show a resorce preview tooltip
       setResourcePreviewCoords({
         x: e.originalEvent.clientX - 100,
-        y: e.originalEvent.clientY - 400,
+        y: e.originalEvent.clientY - 420,
       });      
       setShowResourcePreview(true);
-      setSelectedResource(e.target.id());      
+      setSelectedResource({
+        id: e.target.id(),
+        isExternal: e.target.data('isExternal'),
+      });      
     }).on('mouseout', 'node', () => setShowResourcePreview(false));
 
     return () => {
@@ -86,8 +93,9 @@ const Graph: React.FunctionComponent<{
     };
   }, [container, elements, showLabels]);
   
-  const onClickGoToResource = () => {    
-    // onNodeClick(selectedResource, false);
+  const onClickGoToResource = () => {
+    const { id, isExternal } = selectedResource;    
+    onNodeClick && onNodeClick(id, isExternal);
   }
 
   return (
@@ -109,19 +117,18 @@ const Graph: React.FunctionComponent<{
           marginTop: '1em',
         }}
       ></div>
-      <Card
+      {showResourcePreview && (<Card
         size="small"
-        title="Resource"
+        title={`${selectedResource && selectedResource.isExternal ? 'External Resource' : 'Internal Resource'}`}
         style={{
-          display: showResourcePreview ? 'block' : 'none',
           position: 'absolute',
           top: resourcePreviewCoords.y,
           left: resourcePreviewCoords.x,
           height: '100px',
           maxWidth: '300px',
         }}>
-        <Button type="link" onClick={onClickGoToResource}>{selectedResource}</Button>
-      </Card>   
+        <Button type="link" onClick={onClickGoToResource}>{selectedResource && selectedResource.id}</Button>
+      </Card>)} 
     </div>
   );
 };

--- a/src/shared/components/Graph/index.tsx
+++ b/src/shared/components/Graph/index.tsx
@@ -79,9 +79,11 @@ const Graph: React.FunctionComponent<{
       // we should expand a graph here when user clicks on a node 
     }).on('mouseover', 'node', (e: cytoscape.EventObject) => {
       // show a resorce preview tooltip
+      console.log(e);
+      
       setResourcePreviewCoords({
-        x: e.originalEvent.clientX - 100,
-        y: e.originalEvent.clientY - 420,
+        x: e.originalEvent.offsetX,
+        y: e.originalEvent.offsetY,
       });      
       setShowResourcePreview(true);
       setSelectedResource({
@@ -127,7 +129,6 @@ const Graph: React.FunctionComponent<{
           top: resourcePreviewCoords.y,
           left: resourcePreviewCoords.x,
           height: '100px',
-          maxWidth: '300px',
         }}>
         <Button type="link" onClick={onClickGoToResource}>{selectedResource && selectedResource.id}</Button>
       </Card>)} 

--- a/src/shared/components/Graph/index.tsx
+++ b/src/shared/components/Graph/index.tsx
@@ -65,11 +65,13 @@ const Graph: React.FunctionComponent<{
         coolingFactor: 0.95,
         minTemp: 1.0,
       },
-    }).on('tap', 'node', (e: cytoscape.EventObject) => {
-      // expand a graph here?
-    }).on('taphold', 'node', (e: cytoscape.EventObject) => {
-      onNodeClick && onNodeClick(e.target.id(), e.target.data('isExternal'));
-    });
+    })
+      .on('tap', 'node', (e: cytoscape.EventObject) => {
+        // TODO: expand a graph here?
+      })
+      .on('taphold', 'node', (e: cytoscape.EventObject) => {
+        onNodeClick && onNodeClick(e.target.id(), e.target.data('isExternal'));
+      });
 
     return () => {
       graph.destroy();

--- a/src/shared/containers/GraphContainer.tsx
+++ b/src/shared/containers/GraphContainer.tsx
@@ -72,7 +72,7 @@ const GraphContainer: React.FunctionComponent<{
         });
       }
     },
-    [self]
+    [resource._self]
   );
 
   const elements: cytoscape.ElementDefinition[] = [
@@ -113,6 +113,8 @@ const GraphContainer: React.FunctionComponent<{
       `/${orgLabel}/${projectLabel}/resources/${encodeURIComponent(id)}#graph`
     );
   };
+
+  if (busy || error) return null;
 
   return <Graph elements={elements} onNodeClick={handleNodeClick} />;
 };

--- a/src/shared/containers/GraphContainer.tsx
+++ b/src/shared/containers/GraphContainer.tsx
@@ -87,6 +87,7 @@ const GraphContainer: React.FunctionComponent<{
       classes: `${!(link as Resource)._self ? 'external' : 'internal'}`,
       data: {
         id: link['@id'],
+        // label: labelOf(<a href={`/${orgLabel}/${projectLabel}/resources/${encodeURIComponent(link['@id'])}#graph`}>{link['@id']}</a>),
         label: labelOf(link['@id']),
         isExternal: !(link as Resource)._self,
       },

--- a/src/shared/containers/GraphContainer.tsx
+++ b/src/shared/containers/GraphContainer.tsx
@@ -87,7 +87,6 @@ const GraphContainer: React.FunctionComponent<{
       classes: `${!(link as Resource)._self ? 'external' : 'internal'}`,
       data: {
         id: link['@id'],
-        // label: labelOf(<a href={`/${orgLabel}/${projectLabel}/resources/${encodeURIComponent(link['@id'])}#graph`}>{link['@id']}</a>),
         label: labelOf(link['@id']),
         isExternal: !(link as Resource)._self,
       },


### PR DESCRIPTION
Implements BlueBrain/nexus#829

Part of BlueBrain/nexus#820

redoes @Stafeeva 's work for https://github.com/BlueBrain/nexus-web/pull/351 in the new epic branch convention