### PR TITLE
👷‍♀️ FIX: fix max zoom

### DIFF
--- a/src/shared/components/Graph/index.tsx
+++ b/src/shared/components/Graph/index.tsx
@@ -50,6 +50,7 @@ const Graph: React.FunctionComponent<{
   React.useEffect(() => {
     graph.current = cytoscape({
       elements,
+      maxZoom: 1,
       wheelSensitivity: 0.2,
       container: container.current,
       style: [


### PR DESCRIPTION
Fixes a bug where the node would appear really big if there's only a few nodes
<img width="1430" alt="Screenshot 2019-11-12 at 10 25 41" src="https://user-images.githubusercontent.com/5485824/68659148-085eeb80-0537-11ea-9531-3f4fedebead9.png">
