### PR TITLE
Feature/859-analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ docker build . --tag=nexus-web
 - `CLIENT_ID`: The application name used for _OpenID Connect_ authentication (default is `nexus-web`)
 - `API_ENDPOINT`: The URL pointing to Nexus API. Default is '/'
 - `SECURE`: Is nexus web running in https or not. Default is `false`
+- `GTAG`: The Google Analytics Identifier. GA won't be present unless an ID is specified.
 
 ## Getting involved
 

--- a/src/server/html.ts
+++ b/src/server/html.ts
@@ -29,6 +29,20 @@ const html = ({
           ? ''
           : `<link rel="stylesheet" href="${base}public/bundle.css" />`
       }
+      ${
+        process.env.GTAG
+          ? `<!-- Global site tag (gtag.js) - Google Analytics -->
+      <script async src="https://www.googletagmanager.com/gtag/js?id=${process.env.GTAG}"></script>
+      <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', '${process.env.GTAG}');
+      </script>
+      `
+          : ``
+      }
       <meta name="viewport" content="width=device-width, initial-scale=1">
       <base href="${base}" />
     </head>


### PR DESCRIPTION
closes https://github.com/BlueBrain/nexus/issues/859

This gets added to DOM get `GTAG` env variable is present:

![Screenshot from 2019-11-13 15-34-48](https://user-images.githubusercontent.com/4364154/68773167-62d97400-062b-11ea-90e1-2c7b33628512.png)

The env variable has also been added to our OpenShift Config in a separate commit (in a separate repo)