### PR TITLE
870 indicate expandable nodes

### DIFF
--- a/src/shared/components/Graph/GraphComponent.less
+++ b/src/shared/components/Graph/GraphComponent.less
@@ -32,7 +32,10 @@
     height: 1em;
     width: 1em;
     border-radius: 50%;
-    background-color: @link-color;
+    &.-external {
+      background-color: white;
+      border: 2px solid @link-color;
+    }
     &.-internal {
       background-color: @internal-link-color;
     }
@@ -40,7 +43,7 @@
       background-color: white;
       width: 12px;
       height: 12px;
-      border: 2px solid @link-color;
+      border: 2px solid @warning-color;
     }
   }
   & > .graph {

--- a/src/shared/components/Graph/index.tsx
+++ b/src/shared/components/Graph/index.tsx
@@ -58,8 +58,8 @@ const Graph: React.FunctionComponent<{
   React.useEffect(() => {
     if (graph.current) {
       graph.current.on('tap', 'node', (e: cytoscape.EventObject) => {
-        const { visited, isBlankNode } = e.target.data();
-        if (visited || isBlankNode) {
+        const { visited, isBlankNode, isExpandable } = e.target.data();
+        if (visited || isBlankNode || !isExpandable) {
           return;
         }
         onNodeExpand &&
@@ -94,9 +94,17 @@ const Graph: React.FunctionComponent<{
       },
     },
     {
+      selector: '.expandable',
+      style: {
+        height: 24,
+        width: 24,
+      },
+    },
+    {
       selector: 'edge',
       style: {
         width: 2,
+        'target-arrow-shape': 'triangle',
         'line-color': '#8a8b8b',
       },
     },

--- a/src/shared/components/Graph/index.tsx
+++ b/src/shared/components/Graph/index.tsx
@@ -94,7 +94,7 @@ const Graph: React.FunctionComponent<{
       },
     },
     {
-      selector: '.expandable',
+      selector: '.-expandable',
       style: {
         height: 24,
         width: 24,
@@ -131,26 +131,30 @@ const Graph: React.FunctionComponent<{
         width: 12,
         height: 12,
         'background-color': 'white',
+        'border-color': '#faad14',
+        'border-width': 2,
+      },
+    },
+    {
+      selector: '.-external',
+      style: {
+        'background-color': 'white',
         'border-color': '#00adee',
         'border-width': 2,
       },
     },
     {
-      selector: '.external',
-      style: {
-        'background-color': '#00adee',
-      },
-    },
-    {
-      selector: '.internal',
+      selector: '.-internal',
       style: {
         'background-color': '#ff6666',
       },
     },
     {
-      selector: '.-visited',
+      selector: '.-internal.-expanded',
       style: {
-        'background-color': '#ffd3d3',
+        'background-color': 'white',
+        'border-color': '#ff6666',
+        'border-width': 2,
       },
     },
   ];

--- a/src/shared/containers/GraphContainer.tsx
+++ b/src/shared/containers/GraphContainer.tsx
@@ -32,8 +32,8 @@ const makeNode = async (
       ? `${label.slice(0, MAX_LABEL_LENGTH)}...`
       : label;
   return {
-    classes: `${isExternal ? 'external' : 'internal'} ${
-      isExpandable ? 'expandable' : ''
+    classes: `${isExternal ? '-external' : '-internal'} ${
+      isExpandable ? '-expandable' : '-expanded'
     }`,
     data: {
       label,
@@ -176,7 +176,7 @@ const GraphContainer: React.FunctionComponent<{
 
         const newElements: cytoscape.ElementDefinition[] = [
           {
-            classes: 'expandable main',
+            classes: '-expandable -main',
             data: {
               id: resource['@id'],
               label: getResourceLabel(resource),
@@ -228,7 +228,10 @@ const GraphContainer: React.FunctionComponent<{
       if (!targetNode) {
         return;
       }
-      targetNode.classes = `${targetNode.classes} -visited`;
+      targetNode.classes = (targetNode.classes || '').replace(
+        '-expandable',
+        '-expanded'
+      );
       targetNode.data.visited = true;
       setElements([
         ...elements,


### PR DESCRIPTION
closes https://github.com/BlueBrain/nexus/issues/870

lets the user know ahead of time if a node is expandable or not. Nodes that can be expanded are filled in, and are bigger, while un-expandable nodes are represented as a smaller little ring. 

![Screenshot 2019-11-14 at 13 23 48](https://user-images.githubusercontent.com/5485824/68857060-48160680-06e2-11ea-9331-1997f24e3eaf.png)
