### PR TITLE
876 add reset graph button

### DIFF
--- a/src/shared/components/Graph/index.tsx
+++ b/src/shared/components/Graph/index.tsx
@@ -29,7 +29,8 @@ const Graph: React.FunctionComponent<{
   onNodeClick?(id: string, isExternal: boolean): void;
   onNodeExpand?(id: string, isExternal: boolean): void;
   onNodeHoverOver?(id: string, isExternal: boolean): void;
-}> = ({ elements, onNodeClick, onNodeExpand, onNodeHoverOver }) => {
+  onReset?(): void;
+}> = ({ elements, onNodeClick, onNodeExpand, onNodeHoverOver, onReset }) => {
   const container = React.useRef<HTMLDivElement>(null);
   const [showAlert, setShowAlert] = React.useState(true);
   const [layoutBusy, setLayoutBusy] = React.useState(false);
@@ -80,7 +81,8 @@ const Graph: React.FunctionComponent<{
 
         if (isBlankNode) return;
 
-        onNodeHoverOver && onNodeHoverOver(e.target.id(), e.target.data('isExternal'));
+        onNodeHoverOver &&
+          onNodeHoverOver(e.target.id(), e.target.data('isExternal'));
       });
       graph.current.on('mouseout', 'node', (e: cytoscape.EventObject) => {
         setCursorPointer(null);
@@ -212,9 +214,17 @@ const Graph: React.FunctionComponent<{
 
   return (
     <div className="graph-component">
-      <div className="graph" ref={container} style={cursorPointer ? {
-        cursor: cursorPointer,
-      } : {}}></div>
+      <div
+        className="graph"
+        ref={container}
+        style={
+          cursorPointer
+            ? {
+                cursor: cursorPointer,
+              }
+            : {}
+        }
+      ></div>
       <div className="legend">
         <div>
           <span className="node -external" /> External Link
@@ -240,6 +250,9 @@ const Graph: React.FunctionComponent<{
                 </Button>
               );
             })}
+          </div>
+          <div>
+            <Button onClick={onReset}>Reset</Button>
           </div>
         </div>
         <div className="alert">

--- a/src/shared/containers/GraphContainer.tsx
+++ b/src/shared/containers/GraphContainer.tsx
@@ -119,7 +119,7 @@ const GraphContainer: React.FunctionComponent<{
   const { orgLabel, projectLabel } = getResourceLabelsAndIdsFromSelf(
     resource._self
   );
-
+  const [reset, setReset] = React.useState(false);
   const [selectedResource, setSelectedResource] = React.useState<string>('');
   const [elements, setElements] = React.useState<cytoscape.ElementDefinition[]>(
     []
@@ -208,7 +208,7 @@ const GraphContainer: React.FunctionComponent<{
         });
       }
     },
-    [resource._self]
+    [resource._self, reset]
   );
 
   const handleNodeExpand = async (id: string, isExternal: boolean) => {
@@ -252,6 +252,10 @@ const GraphContainer: React.FunctionComponent<{
     }
   };
 
+  const handleReset = () => {
+    setReset(!reset);
+  };
+
   const handleNodeClick = (id: string, isExternal: boolean) => {
     if (isExternal) {
       open(id);
@@ -271,9 +275,9 @@ const GraphContainer: React.FunctionComponent<{
     }
 
     setSelectedResource(resourceId);
-  }
+  };
 
-  if (busy || error) return null;  
+  if (busy || error) return null;
 
   return (
     <>
@@ -282,6 +286,7 @@ const GraphContainer: React.FunctionComponent<{
         onNodeClick={handleNodeClick}
         onNodeExpand={handleNodeExpand}
         onNodeHoverOver={showResourcePreview}
+        onReset={handleReset}
       />
       {!!selectedResource && (
         <ResourcePreviewCardContainer


### PR DESCRIPTION
Adds a button that will reset the graph to the original shape where the nodes were not expanded.

closes: https://github.com/BlueBrain/nexus/issues/876
