### PR TITLE
Bugfix/marking expanded nodes as not expandable

### DIFF
--- a/src/shared/components/Graph/index.tsx
+++ b/src/shared/components/Graph/index.tsx
@@ -155,16 +155,20 @@ const Graph: React.FunctionComponent<{
       ></div>
       <div className="legend">
         <div>
-          <span className="node -main" />Origin
+          <span className="node -main" />
+          Origin
         </div>
         <div>
-          <span className="node -external" />External Link
+          <span className="node -external" />
+          External Link
         </div>
         <div>
-          <span className="node -internal" />Internal Link
+          <span className="node -internal" />
+          Internal Link
         </div>
         <div>
-          <span className="node -blank-node" />Blank Node
+          <span className="node -blank-node" />
+          Blank Node
         </div>
       </div>
       <div className="top">

--- a/src/shared/containers/GraphContainer.tsx
+++ b/src/shared/containers/GraphContainer.tsx
@@ -250,7 +250,7 @@ const GraphContainer: React.FunctionComponent<{
         '-expandable',
         '-expanded'
       );
-      targetNode.data.visited = true;
+      targetNode.data.isExpandable = false;
       setElements([
         ...elements,
 


### PR DESCRIPTION
fixes a bug where clicking on a node that was already expanded would cause a graph layout re-run because the node was never marked as expanded already