### PR TITLE
879 collapsing paths

### DIFF
--- a/src/shared/components/Graph/index.tsx
+++ b/src/shared/components/Graph/index.tsx
@@ -55,22 +55,21 @@ const Graph: React.FunctionComponent<{
 }) => {
   const container = React.useRef<HTMLDivElement>(null);
   const [showAlert, setShowAlert] = React.useState(true);
-  const [layoutBusy, setLayoutBusy] = React.useState(false);
   const [cursorPointer, setCursorPointer] = React.useState<string | null>(null);
+  const layoutInstance = React.useRef<cytoscape.Layouts>();
   const graph = React.useRef<cytoscape.Core>();
 
   const forceLayout = () => {
     if (graph.current) {
-      setLayoutBusy(true);
-      graph.current &&
-        graph.current
-          .layout({
-            ...LAYOUTS[layout],
-            stop() {
-              setLayoutBusy(false);
-            },
-          })
-          .run();
+      if (layoutInstance.current) {
+        layoutInstance.current.stop();
+      }
+      layoutInstance.current = graph.current
+        .elements()
+        .makeLayout({
+          ...LAYOUTS[layout],
+        })
+        .run();
     }
   };
 
@@ -203,7 +202,6 @@ const Graph: React.FunctionComponent<{
             {Object.keys(LAYOUTS).map(layoutKey => {
               return (
                 <Button
-                  disabled={layoutBusy}
                   size="small"
                   type={layoutKey === layout ? 'primary' : 'default'}
                   onClick={handleLayoutClick(layoutKey)}
@@ -217,15 +215,14 @@ const Graph: React.FunctionComponent<{
             <Button
               type={collapsed ? 'primary' : 'default'}
               size="small"
-              disabled={layoutBusy}
               onClick={onCollapse}
             >
               {collapsed ? 'Expand Paths' : 'Collapse Paths'}
             </Button>
-            <Button disabled={layoutBusy} size="small" onClick={onRecenter}>
+            <Button size="small" onClick={onRecenter}>
               Origin
             </Button>
-            <Button disabled={layoutBusy} size="small" onClick={onReset}>
+            <Button size="small" onClick={onReset}>
               Reset
             </Button>
           </div>

--- a/src/shared/components/Graph/index.tsx
+++ b/src/shared/components/Graph/index.tsx
@@ -20,12 +20,13 @@ export const LAYOUTS: {
       const { label } = edge.data();
       // lets define the edge lengths based on how long
       // the labels will end up being
-      return 100 + label.length * 8;
+      return 50 + label.length * 8;
     },
   },
   breadthFirst: {
     name: 'breadthfirst',
     label: 'Tree',
+    animate: true,
   },
 };
 
@@ -203,6 +204,7 @@ const Graph: React.FunctionComponent<{
               return (
                 <Button
                   disabled={layoutBusy}
+                  size="small"
                   type={layoutKey === layout ? 'primary' : 'default'}
                   onClick={handleLayoutClick(layoutKey)}
                 >
@@ -214,15 +216,16 @@ const Graph: React.FunctionComponent<{
           <div>
             <Button
               type={collapsed ? 'primary' : 'default'}
+              size="small"
               disabled={layoutBusy}
               onClick={onCollapse}
             >
               {collapsed ? 'Expand Paths' : 'Collapse Paths'}
             </Button>
-            <Button disabled={layoutBusy} onClick={onRecenter}>
+            <Button disabled={layoutBusy} size="small" onClick={onRecenter}>
               Origin
             </Button>
-            <Button disabled={layoutBusy} onClick={onReset}>
+            <Button disabled={layoutBusy} size="small" onClick={onReset}>
               Reset
             </Button>
           </div>

--- a/src/shared/containers/GraphContainer/Graph.ts
+++ b/src/shared/containers/GraphContainer/Graph.ts
@@ -34,11 +34,26 @@ export const makeNode = async (
 
 export const createNodesAndEdgesFromResourceLinks = (
   resourceLinks: ResourceLink[],
-  originId: string
+  originId: string,
+  collapsed: boolean
 ) => {
   return resourceLinks.reduce(
     (pathNodes: cytoscape.ElementDefinition[], link) => {
       const paths = Array.isArray(link.paths) ? link.paths : [link.paths];
+
+      if (collapsed) {
+        return [
+          ...pathNodes,
+          {
+            data: {
+              label: paths.map(path => labelOf(path)).join(' / '),
+              id: `edge-${originId}-${link['@id']}`,
+              source: originId,
+              target: link['@id'],
+            },
+          },
+        ];
+      }
 
       const blankNodes = paths
         .map((path, index) => {

--- a/src/shared/containers/GraphContainer/index.tsx
+++ b/src/shared/containers/GraphContainer/index.tsx
@@ -6,7 +6,7 @@ import { useNexusContext } from '@bbp/react-nexus';
 import { ResourceLink, Resource } from '@bbp/nexus-sdk';
 
 import { getResourceLabelsAndIdsFromSelf, getResourceLabel } from '../../utils';
-import Graph from '../../components/Graph';
+import Graph, { DEFAULT_LAYOUT } from '../../components/Graph';
 import ResourcePreviewCardContainer from './../ResourcePreviewCardContainer';
 import { DEFAULT_ACTIVE_TAB_KEY } from '../../views/ResourceView';
 import { createNodesAndEdgesFromResourceLinks, makeNode } from './Graph';
@@ -22,6 +22,8 @@ const GraphContainer: React.FunctionComponent<{
     resource._self
   );
   const [reset, setReset] = React.useState(false);
+  const [collapsed, setCollapsed] = React.useState(true);
+  const [layout, setLayout] = React.useState(DEFAULT_LAYOUT);
   const [
     { selectedResourceId, isSelectedExternal },
     setSelectedResource,
@@ -100,7 +102,8 @@ const GraphContainer: React.FunctionComponent<{
           // Link Path Nodes and Edges
           ...createNodesAndEdgesFromResourceLinks(
             response._results,
-            resource['@id']
+            resource['@id'],
+            collapsed
           ),
         ];
         setElements(newElements);
@@ -118,7 +121,7 @@ const GraphContainer: React.FunctionComponent<{
         });
       }
     },
-    [resource._self, reset]
+    [resource._self, reset, collapsed]
   );
 
   const handleNodeExpand = async (id: string, isExternal: boolean) => {
@@ -152,7 +155,11 @@ const GraphContainer: React.FunctionComponent<{
         )),
 
         // Link Path Nodes and Edges
-        ...createNodesAndEdgesFromResourceLinks(response._results, id),
+        ...createNodesAndEdgesFromResourceLinks(
+          response._results,
+          id,
+          collapsed
+        ),
       ]);
     } catch (error) {
       notification.error({
@@ -185,6 +192,14 @@ const GraphContainer: React.FunctionComponent<{
     });
   };
 
+  const handleCollapse = () => {
+    setCollapsed(!collapsed);
+  };
+
+  const handleLayoutChange = (layout: string) => {
+    setLayout(layout);
+  };
+
   if (busy || error) return null;
 
   return (
@@ -195,6 +210,10 @@ const GraphContainer: React.FunctionComponent<{
         onNodeExpand={handleNodeExpand}
         onNodeHoverOver={showResourcePreview}
         onReset={handleReset}
+        collapsed={collapsed}
+        onCollapse={handleCollapse}
+        onLayoutChange={handleLayoutChange}
+        layout={layout}
       />
       {!!selectedResourceId && (
         <ResourcePreviewCardContainer


### PR DESCRIPTION
Adds a button to "collapse" or "expand" the graph, adding or removing blank nodes. 

This forces a reset in the graph. A further improvement would be to dynamically change the element collection without forcing graph layout. See https://github.com/BlueBrain/nexus/issues/863 

Also lifts the layout state to the container, which makes transition animations possible. 

fixes https://github.com/BlueBrain/nexus/issues/879
part of https://github.com/BlueBrain/nexus/issues/820