### PR TITLE
Fix origin button

### DIFF
--- a/src/shared/components/Graph/index.tsx
+++ b/src/shared/components/Graph/index.tsx
@@ -83,8 +83,11 @@ const Graph: React.FunctionComponent<{
 
   const onRecenter = () => {
     if (graph.current) {
-      const origin = graph.current.elements()[0];
-      graph.current.center(origin);
+      const origin = elements.find(element => element.data.isOrigin);
+      
+      if (origin && origin.data && origin.data.id) {
+        graph.current.center(graph.current.getElementById(origin.data.id));
+      }
     }
   };
 

--- a/src/shared/containers/GraphContainer/index.tsx
+++ b/src/shared/containers/GraphContainer/index.tsx
@@ -99,6 +99,7 @@ const GraphContainer: React.FunctionComponent<{
             data: {
               id: resource['@id'],
               label: getResourceLabel(resource),
+              isOrigin: true,
             },
           },
           // Link Nodes


### PR DESCRIPTION
The main node (origin) is not centred when you click 'origin' button.