### PR TITLE
FIX: use self to fetch resources

### DIFF
--- a/src/shared/components/Graph/index.tsx
+++ b/src/shared/components/Graph/index.tsx
@@ -9,6 +9,16 @@ import GraphLegend from './GraphLegend';
 
 import './GraphComponent.less';
 
+export type ElementNodeData = {
+  label: string;
+  isExternal: boolean;
+  isExpandable: boolean;
+  isOrigin?: boolean;
+  isBlankNode?: boolean;
+  self?: string;
+  id: string;
+};
+
 export const LAYOUTS: {
   [layoutName: string]: {
     name: string;
@@ -36,9 +46,9 @@ export const DEFAULT_LAYOUT = 'breadthFirst';
 
 const Graph: React.FunctionComponent<{
   elements: cytoscape.ElementDefinition[];
-  onNodeClick?(id: string, isExternal: boolean): void;
-  onNodeExpand?(id: string, isExternal: boolean): void;
-  onNodeHoverOver?(id: string, isExternal: boolean): void;
+  onNodeClick?(id: string, data: ElementNodeData): void;
+  onNodeClickAndHold?(id: string, data: ElementNodeData): void;
+  onNodeHover?(id: string, idata: ElementNodeData): void;
   onReset?(): void;
   onCollapse?(): void;
   onLayoutChange?(type: string): void;
@@ -48,8 +58,8 @@ const Graph: React.FunctionComponent<{
 }> = ({
   elements,
   onNodeClick,
-  onNodeExpand,
-  onNodeHoverOver,
+  onNodeClickAndHold,
+  onNodeHover,
   onReset,
   collapsed,
   onCollapse,
@@ -135,28 +145,19 @@ const Graph: React.FunctionComponent<{
       return;
     }
     graph.current.on('tap', 'node', (e: cytoscape.EventObject) => {
-      const { isBlankNode, isExpandable } = e.target.data();
-      if (isBlankNode || !isExpandable) {
-        return;
-      }
-      onNodeExpand && onNodeExpand(e.target.id(), e.target.data('isExternal'));
+      onNodeClick && onNodeClick(e.target.id(), e.target.data());
     });
     graph.current.on('taphold', 'node', (e: cytoscape.EventObject) => {
-      onNodeClick && onNodeClick(e.target.id(), e.target.data('isExternal'));
+      onNodeClickAndHold && onNodeClickAndHold(e.target.id(), e.target.data());
     });
     graph.current.on('mouseover', 'node', (e: cytoscape.EventObject) => {
-      const { isBlankNode, isExpandable } = e.target.data();
-
+      const { isExpandable } = e.target.data();
       if (isExpandable) {
         setCursorPointer('pointer');
       } else {
         setCursorPointer('grab');
       }
-
-      if (isBlankNode) return;
-
-      onNodeHoverOver &&
-        onNodeHoverOver(e.target.id(), e.target.data('isExternal'));
+      onNodeHover && onNodeHover(e.target.id(), e.target.data());
     });
     graph.current.on('mouseout', 'node', (e: cytoscape.EventObject) => {
       setCursorPointer(null);

--- a/src/shared/components/ResourceCard/ResourceCardCollapsed.tsx
+++ b/src/shared/components/ResourceCard/ResourceCardCollapsed.tsx
@@ -1,29 +1,33 @@
 import * as React from 'react';
 import { Card, Button, Skeleton } from 'antd';
+import { Resource } from '@bbp/nexus-sdk';
 
-import { labelOf } from '../../utils';
+import { labelOf, getResourceLabel } from '../../utils';
 import TypesIcon from '../Types/TypesIcon';
 
 const ResourceCardCollapsed: React.FunctionComponent<{
   onClickExpand?(): void;
-  resourceId: string;
-  busy: boolean,
-  types?: string[],
-  isExternal?: boolean,
-}> = ({ onClickExpand, resourceId, busy, isExternal, types }) => {
-  const label: string = labelOf(resourceId);
+  resource: Resource;
+  busy: boolean;
+  types?: string[];
+  isExternal?: boolean;
+}> = ({ onClickExpand, resource, busy, isExternal, types }) => {
+  const label: string = getResourceLabel(resource);
+  const resourceId = resource['@id'];
 
   if (busy) {
     return (
-      <Card bodyStyle={{ 
-        padding: '0px 10px',
-        width: '200px',
-      }}>
+      <Card
+        bodyStyle={{
+          padding: '0px 10px',
+          width: '200px',
+        }}
+      >
         <Skeleton active paragraph={{ rows: 1 }} />
       </Card>
     );
   }
-  
+
   return (
     <Card
       headStyle={{ fontSize: '12px' }}
@@ -33,17 +37,28 @@ const ResourceCardCollapsed: React.FunctionComponent<{
       }}
       title={<span>{label}&nbsp;</span>}
       size="small"
-      extra={isExternal ? null : <Button onClick={onClickExpand} shape="circle" icon="up" size="small" />}
+      extra={
+        isExternal ? null : (
+          <Button
+            onClick={onClickExpand}
+            shape="circle"
+            icon="up"
+            size="small"
+          />
+        )
+      }
       style={{ maxWidth: '400px' }}
     >
       {!!types && (
         <div>{!!types && <TypesIcon type={types} full={true} />}</div>
       )}
       {!!isExternal && (
-        <a href={resourceId} target="_blank">{resourceId}</a>
+        <a href={resourceId} target="_blank">
+          {resourceId}
+        </a>
       )}
     </Card>
-  )
-}
+  );
+};
 
 export default ResourceCardCollapsed;

--- a/src/shared/components/ResourceCard/ResourceCardCollapsed.tsx
+++ b/src/shared/components/ResourceCard/ResourceCardCollapsed.tsx
@@ -6,10 +6,11 @@ import TypesIcon from '../Types/TypesIcon';
 const ResourceCardCollapsed: React.FunctionComponent<{
   onClickExpand?(): void;
   label: string;
+  resourceUrl: string;
   busy: boolean;
   types?: string[];
   isExternal?: boolean;
-}> = ({ onClickExpand, label, busy, isExternal, types }) => {
+}> = ({ onClickExpand, label, resourceUrl, busy, isExternal, types }) => {
   if (busy) {
     return (
       <Card
@@ -48,8 +49,8 @@ const ResourceCardCollapsed: React.FunctionComponent<{
         <div>{!!types && <TypesIcon type={types} full={true} />}</div>
       )}
       {!!isExternal && (
-        <a href={label} target="_blank">
-          {label}
+        <a href={resourceUrl} target="_blank">
+          {resourceUrl}
         </a>
       )}
     </Card>

--- a/src/shared/components/ResourceCard/ResourceCardCollapsed.tsx
+++ b/src/shared/components/ResourceCard/ResourceCardCollapsed.tsx
@@ -1,20 +1,15 @@
 import * as React from 'react';
 import { Card, Button, Skeleton } from 'antd';
-import { Resource } from '@bbp/nexus-sdk';
 
-import { labelOf, getResourceLabel } from '../../utils';
 import TypesIcon from '../Types/TypesIcon';
 
 const ResourceCardCollapsed: React.FunctionComponent<{
   onClickExpand?(): void;
-  resource: Resource;
+  label: string;
   busy: boolean;
   types?: string[];
   isExternal?: boolean;
-}> = ({ onClickExpand, resource, busy, isExternal, types }) => {
-  const label: string = getResourceLabel(resource);
-  const resourceId = resource['@id'];
-
+}> = ({ onClickExpand, label, busy, isExternal, types }) => {
   if (busy) {
     return (
       <Card
@@ -53,8 +48,8 @@ const ResourceCardCollapsed: React.FunctionComponent<{
         <div>{!!types && <TypesIcon type={types} full={true} />}</div>
       )}
       {!!isExternal && (
-        <a href={resourceId} target="_blank">
-          {resourceId}
+        <a href={label} target="_blank">
+          {label}
         </a>
       )}
     </Card>

--- a/src/shared/containers/GraphContainer/Graph.ts
+++ b/src/shared/containers/GraphContainer/Graph.ts
@@ -8,10 +8,11 @@ export const makeNode = async (
   link: ResourceLink,
   getResourceLinks: (self: string) => Promise<PaginatedList<ResourceLink>>
 ) => {
-  const isExternal = !(link as Resource)._self;
+  const self = (link as Resource)._self;
+  const isExternal = !self;
   let isExpandable = !isExternal; // External resources are never expandable
   if (!isExternal) {
-    const response = await getResourceLinks((link as Resource)._self);
+    const response = await getResourceLinks(self);
     isExpandable = !!response._total;
   }
   let label = labelOf(link['@id']);
@@ -27,6 +28,7 @@ export const makeNode = async (
       label,
       isExternal,
       isExpandable,
+      self,
       id: link['@id'],
     },
   };

--- a/src/shared/containers/GraphContainer/index.tsx
+++ b/src/shared/containers/GraphContainer/index.tsx
@@ -25,13 +25,13 @@ const GraphContainer: React.FunctionComponent<{
   const [collapsed, setCollapsed] = React.useState(true);
   const [layout, setLayout] = React.useState(DEFAULT_LAYOUT);
   const [
-    { selectedResourceId, isSelectedExternal },
+    { selectedResourceSelf, isSelectedExternal },
     setSelectedResource,
   ] = React.useState<{
-    selectedResourceId: string;
+    selectedResourceSelf: string;
     isSelectedExternal: boolean | null;
   }>({
-    selectedResourceId: '',
+    selectedResourceSelf: '',
     isSelectedExternal: null,
   });
   const [elements, setElements] = React.useState<cytoscape.ElementDefinition[]>(
@@ -195,12 +195,12 @@ const GraphContainer: React.FunctionComponent<{
   };
 
   const showResourcePreview = (id: string, data: ElementNodeData) => {
-    const { isBlankNode, isExpandable, self, isExternal } = data;
-    if (isBlankNode) {
+    const { isBlankNode, self, isExternal } = data;
+    if (isBlankNode || !self) {
       return;
     }
     setSelectedResource({
-      selectedResourceId: id,
+      selectedResourceSelf: self,
       isSelectedExternal: isExternal,
     });
   };
@@ -229,11 +229,9 @@ const GraphContainer: React.FunctionComponent<{
         layout={layout}
         loading={loading}
       />
-      {!!selectedResourceId && (
+      {!!selectedResourceSelf && (
         <ResourcePreviewCardContainer
-          resourceId={selectedResourceId}
-          projectLabel={projectLabel}
-          orgLabel={orgLabel}
+          resourceSelf={selectedResourceSelf}
           isExternal={isSelectedExternal}
         />
       )}

--- a/src/shared/containers/GraphContainer/index.tsx
+++ b/src/shared/containers/GraphContainer/index.tsx
@@ -6,7 +6,7 @@ import { useNexusContext } from '@bbp/react-nexus';
 import { ResourceLink, Resource } from '@bbp/nexus-sdk';
 
 import { getResourceLabelsAndIdsFromSelf, getResourceLabel } from '../../utils';
-import Graph, { DEFAULT_LAYOUT } from '../../components/Graph';
+import Graph, { DEFAULT_LAYOUT, ElementNodeData } from '../../components/Graph';
 import ResourcePreviewCardContainer from './../ResourcePreviewCardContainer';
 import { DEFAULT_ACTIVE_TAB_KEY } from '../../views/ResourceView';
 import { createNodesAndEdgesFromResourceLinks, makeNode } from './Graph';
@@ -65,23 +65,20 @@ const GraphContainer: React.FunctionComponent<{
     );
   };
 
-    React.useEffect(() => {
-      setLoading(true);
+  React.useEffect(() => {
+    setLoading(true);
 
-      setLinks({
-        next,
-        links,
-        total,
-        error: null,
-      });
+    setLinks({
+      next,
+      links,
+      total,
+      error: null,
+    });
 
-      let fetchedLinks: ResourceLink[];
+    let fetchedLinks: ResourceLink[];
 
-      const fetchLinks = async () => {
-        return await getResourceLinks(resource._self);
-      }
-
-      fetchLinks().then(response => {
+    getResourceLinks(resource._self)
+      .then(response => {
         fetchedLinks = response._results;
 
         setLinks({
@@ -90,9 +87,12 @@ const GraphContainer: React.FunctionComponent<{
           total: response._total,
           error: null,
         });
-        
-        return Promise.all(fetchedLinks.map(async link => await makeNode(link, getResourceLinks)))
-      }).then(linkNodes => {        
+
+        return Promise.all(
+          fetchedLinks.map(async link => await makeNode(link, getResourceLinks))
+        );
+      })
+      .then(linkNodes => {
         const newElements: cytoscape.ElementDefinition[] = [
           {
             classes: '-expandable -main',
@@ -123,21 +123,17 @@ const GraphContainer: React.FunctionComponent<{
 
         setLoading(false);
       });
-    }, [resource._self, reset, collapsed]);
+  }, [resource._self, reset, collapsed]);
 
-  const handleNodeExpand = async (id: string, isExternal: boolean) => {
-    if (isExternal) {
+  const handleNodeClick = async (id: string, data: ElementNodeData) => {
+    const { isBlankNode, isExternal, isExpandable, self } = data;
+    if (isBlankNode || isExternal || !isExpandable || !self) {
       return;
     }
     try {
       setLoading(true);
       // TODO: should get from self not ID if its in another project
-      const response = await nexus.Resource.links(
-        orgLabel,
-        projectLabel,
-        encodeURIComponent(id),
-        'outgoing'
-      );
+      const response = await getResourceLinks(self);
 
       const targetNode = elements.find(element => element.data.id === id);
       if (!targetNode) {
@@ -176,22 +172,35 @@ const GraphContainer: React.FunctionComponent<{
     setReset(!reset);
   };
 
-  const handleNodeClick = (id: string, isExternal: boolean) => {    
+  const handleVisitResource = (id: string, data: ElementNodeData) => {
+    const { isExternal, self } = data;
     if (isExternal) {
       open(id);
       return;
     }
+    if (!self) {
+      return;
+    }
+    const {
+      orgLabel,
+      projectLabel,
+      resourceId,
+    } = getResourceLabelsAndIdsFromSelf(self);
 
     history.push(
       `/${orgLabel}/${projectLabel}/resources/${encodeURIComponent(
-        id
+        resourceId
       )}${activeTabKey}`
     );
   };
 
-  const showResourcePreview = (resourceId: string, isExternal: boolean) => {
+  const showResourcePreview = (id: string, data: ElementNodeData) => {
+    const { isBlankNode, isExpandable, self, isExternal } = data;
+    if (isBlankNode) {
+      return;
+    }
     setSelectedResource({
-      selectedResourceId: resourceId,
+      selectedResourceId: id,
       isSelectedExternal: isExternal,
     });
   };
@@ -211,8 +220,8 @@ const GraphContainer: React.FunctionComponent<{
       <Graph
         elements={elements}
         onNodeClick={handleNodeClick}
-        onNodeExpand={handleNodeExpand}
-        onNodeHoverOver={showResourcePreview}
+        onNodeClickAndHold={handleVisitResource}
+        onNodeHover={showResourcePreview}
         onReset={handleReset}
         collapsed={collapsed}
         onCollapse={handleCollapse}

--- a/src/shared/containers/GraphContainer/index.tsx
+++ b/src/shared/containers/GraphContainer/index.tsx
@@ -28,7 +28,7 @@ const GraphContainer: React.FunctionComponent<{
     { selectedResourceSelf, isSelectedExternal },
     setSelectedResource,
   ] = React.useState<{
-    selectedResourceSelf: string;
+    selectedResourceSelf: string | null;
     isSelectedExternal: boolean | null;
   }>({
     selectedResourceSelf: '',
@@ -196,11 +196,11 @@ const GraphContainer: React.FunctionComponent<{
 
   const showResourcePreview = (id: string, data: ElementNodeData) => {
     const { isBlankNode, self, isExternal } = data;
-    if (isBlankNode || !self) {
+    if (isBlankNode) {
       return;
     }
     setSelectedResource({
-      selectedResourceSelf: self,
+      selectedResourceSelf: self || id,
       isSelectedExternal: isExternal,
     });
   };

--- a/src/shared/containers/ResourcePreviewCardContainer.tsx
+++ b/src/shared/containers/ResourcePreviewCardContainer.tsx
@@ -6,7 +6,11 @@ import { Resource } from '@bbp/nexus-sdk';
 import ResourceCard from '../components/ResourceCard';
 import ResourceCardCollapsed from '../components/ResourceCard/ResourceCardCollapsed';
 import ResourcePreviewCard from '../components/ResourceCard/ResourcePreviewCard';
-import { getResourceLabelsAndIdsFromSelf } from '../utils';
+import {
+  getResourceLabelsAndIdsFromSelf,
+  labelOf,
+  getResourceLabel,
+} from '../utils';
 
 const ResourcePreviewCardContainer: React.FunctionComponent<{
   resourceSelf: string;
@@ -66,15 +70,17 @@ const ResourcePreviewCardContainer: React.FunctionComponent<{
     [resourceSelf]
   );
 
-  if (resource) {
-    if (isExternal) {
-      return (
-        <ResourcePreviewCard>
-          <ResourceCardCollapsed resource={resource} busy={busy} isExternal />
-        </ResourcePreviewCard>
-      );
-    }
+  if (isExternal) {
+    const label = labelOf(resourceId);
+    return (
+      <ResourcePreviewCard>
+        <ResourceCardCollapsed label={label} busy={busy} isExternal />
+      </ResourcePreviewCard>
+    );
+  }
 
+  if (resource) {
+    const label = getResourceLabel(resource);
     const { '@type': type } = resource;
     const types: string[] = Array.isArray(type) ? type : [type || ''];
 
@@ -87,7 +93,7 @@ const ResourcePreviewCardContainer: React.FunctionComponent<{
           />
         ) : (
           <ResourceCardCollapsed
-            resource={resource}
+            label={label}
             onClickExpand={() => setShowFullCard(true)}
             busy={busy}
             types={types}

--- a/src/shared/containers/ResourcePreviewCardContainer.tsx
+++ b/src/shared/containers/ResourcePreviewCardContainer.tsx
@@ -77,7 +77,12 @@ const ResourcePreviewCardContainer: React.FunctionComponent<{
     const label = labelOf(resourceId);
     return (
       <ResourcePreviewCard>
-        <ResourceCardCollapsed label={label} busy={busy} isExternal />
+        <ResourceCardCollapsed
+          label={label}
+          resourceUrl={resourceSelf}
+          busy={busy}
+          isExternal
+        />
       </ResourcePreviewCard>
     );
   }
@@ -97,6 +102,7 @@ const ResourcePreviewCardContainer: React.FunctionComponent<{
         ) : (
           <ResourceCardCollapsed
             label={label}
+            resourceUrl={resourceSelf}
             onClickExpand={() => setShowFullCard(true)}
             busy={busy}
             types={types}

--- a/src/shared/containers/ResourcePreviewCardContainer.tsx
+++ b/src/shared/containers/ResourcePreviewCardContainer.tsx
@@ -6,26 +6,28 @@ import { Resource } from '@bbp/nexus-sdk';
 import ResourceCard from '../components/ResourceCard';
 import ResourceCardCollapsed from '../components/ResourceCard/ResourceCardCollapsed';
 import ResourcePreviewCard from '../components/ResourceCard/ResourcePreviewCard';
+import { getResourceLabelsAndIdsFromSelf } from '../utils';
 
 const ResourcePreviewCardContainer: React.FunctionComponent<{
-    orgLabel: string,
-    projectLabel: string,
-    resourceId: string,
-    isExternal: boolean | null,
-}> = ({ orgLabel, projectLabel, resourceId, isExternal }) => {
-    const nexus = useNexusContext();
-    const [showFullCard, setShowFullCard] = React.useState(false);
-    const [{ busy, resource, error }, setResource] = React.useState<{
-        busy: boolean;
-        resource: Resource | null;
-        error: Error | null;
-      }>({
-        busy: false,
-        resource: null,
-        error: null,
-      });
+  resourceSelf: string;
+  isExternal: boolean | null;
+}> = ({ resourceSelf, isExternal }) => {
+  const nexus = useNexusContext();
+  const [showFullCard, setShowFullCard] = React.useState(false);
+  const [{ busy, resource, error }, setResource] = React.useState<{
+    busy: boolean;
+    resource: Resource | null;
+    error: Error | null;
+  }>({
+    busy: false,
+    resource: null,
+    error: null,
+  });
 
-    useAsyncEffect(async isMounted => {
+  const { resourceId } = getResourceLabelsAndIdsFromSelf(resourceSelf);
+
+  useAsyncEffect(
+    async isMounted => {
       if (!isMounted()) {
         return;
       }
@@ -45,11 +47,9 @@ const ResourcePreviewCardContainer: React.FunctionComponent<{
           error: null,
           busy: true,
         });
-        const nextResource = (await nexus.Resource.get(
-          orgLabel,
-          projectLabel,
-          encodeURIComponent(resourceId)
-        )) as Resource;
+        const nextResource = (await nexus.httpGet({
+          path: resourceSelf,
+        })) as Resource;
         setResource({
           resource: nextResource,
           error: null,
@@ -62,34 +62,42 @@ const ResourcePreviewCardContainer: React.FunctionComponent<{
           busy: false,
         });
       }
-    }, [orgLabel, projectLabel, resourceId]);
+    },
+    [resourceSelf]
+  );
 
-  if (isExternal) {
-    return (
-      <ResourcePreviewCard>
-        <ResourceCardCollapsed resourceId={resourceId} busy={busy} isExternal />
-      </ResourcePreviewCard>
-    )
-  }
-  
   if (resource) {
-    const {
-      '@type': type,
-    } = resource;
+    if (isExternal) {
+      return (
+        <ResourcePreviewCard>
+          <ResourceCardCollapsed resource={resource} busy={busy} isExternal />
+        </ResourcePreviewCard>
+      );
+    }
+
+    const { '@type': type } = resource;
     const types: string[] = Array.isArray(type) ? type : [type || ''];
 
     return (
       <ResourcePreviewCard>
         {showFullCard ? (
-          <ResourceCard resource={resource} onClickCollapse={() => setShowFullCard(false)} />
+          <ResourceCard
+            resource={resource}
+            onClickCollapse={() => setShowFullCard(false)}
+          />
         ) : (
-          <ResourceCardCollapsed resourceId={resourceId} onClickExpand={() => setShowFullCard(true)} busy={busy} types={types} />
+          <ResourceCardCollapsed
+            resource={resource}
+            onClickExpand={() => setShowFullCard(true)}
+            busy={busy}
+            types={types}
+          />
         )}
       </ResourcePreviewCard>
     );
   }
 
   return null;
-}
+};
 
 export default ResourcePreviewCardContainer;

--- a/src/shared/containers/ResourcePreviewCardContainer.tsx
+++ b/src/shared/containers/ResourcePreviewCardContainer.tsx
@@ -53,6 +53,9 @@ const ResourcePreviewCardContainer: React.FunctionComponent<{
         });
         const nextResource = (await nexus.httpGet({
           path: resourceSelf,
+          headers: {
+            Accept: 'application/json',
+          },
         })) as Resource;
         setResource({
           resource: nextResource,


### PR DESCRIPTION
use resource _self to fetch resources instead of id, because sometimes resources would come from different projects which would cause them not to load!

Also, I renamed the GraphComponent callbacks to better reflect what events they're calling back from.