### PR TITLE
FIX: resource preview card width

### DIFF
--- a/src/shared/components/ResourceCard/ResourcePreviewCard.less
+++ b/src/shared/components/ResourceCard/ResourcePreviewCard.less
@@ -3,5 +3,5 @@
   position: absolute;
   bottom: 0;
   right: 0;
-  max-width: '600px';
+  max-width: 600px;
 }

--- a/src/shared/containers/GraphContainer/index.tsx
+++ b/src/shared/containers/GraphContainer/index.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { notification } from 'antd';
-import { useAsyncEffect } from 'use-async-effect';
 import { useHistory, useLocation } from 'react-router';
 import { useNexusContext } from '@bbp/react-nexus';
 import { ResourceLink, Resource } from '@bbp/nexus-sdk';


### PR DESCRIPTION
Max width didn't work, so a resource card was stretched across the whole screen.
Now it is not so ugly.

![Screenshot 2019-11-21 at 11 45 12](https://user-images.githubusercontent.com/23080476/69331113-80729300-0c54-11ea-9c05-83d731049735.png)


