### PR TITLE
Add a cancel button to ResourceEditor

### DIFF
--- a/src/shared/components/ResourceEditor/index.tsx
+++ b/src/shared/components/ResourceEditor/index.tsx
@@ -60,6 +60,10 @@ const ResourceEditor: React.FunctionComponent<ResourceEditorProps> = props => {
     }
   };
 
+  const handleCancel = () => {
+    setEditing(false);
+  };
+
   return (
     <div className={valid ? 'resource-editor' : 'resource-editor _invalid'}>
       <div className="control-panel">
@@ -107,14 +111,23 @@ const ResourceEditor: React.FunctionComponent<ResourceEditorProps> = props => {
           )}
 
           {editable && isEditing && valid && (
-            <Button
-              icon="save"
-              type="primary"
-              size="small"
-              onClick={handleSubmit}
-            >
-              Save
-            </Button>
+            <>
+              <Button
+                icon="save"
+                type="primary"
+                size="small"
+                onClick={handleSubmit}
+              >
+                Save
+              </Button>{' '}
+              <Button
+                type="danger"
+                size="small"
+                onClick={handleCancel}
+              >
+                Cancel
+              </Button>
+            </>
           )}
         </div>
       </div>


### PR DESCRIPTION
Allow user to cancel the edit and go back to non-redit view.

FIX: #BlueBrain/nexus/issues/799
![Screenshot_2019-11-21 A knowledge graph for data-driven science](https://user-images.githubusercontent.com/1479155/69344751-39929680-0c70-11ea-8a0c-9a3cdb51ef95.png)
