### PR TITLE
Feat/make node expand from its parent

### DIFF
--- a/src/shared/components/Graph/index.tsx
+++ b/src/shared/components/Graph/index.tsx
@@ -115,9 +115,24 @@ const Graph: React.FunctionComponent<{
       const graphElementIds = graph.current
         .elements()
         .map(element => element.id());
-      const newElements = elements.filter(
-        element => !graphElementIds.includes(element.data.id || '')
-      );
+      const newElements = elements
+        .filter(element => !graphElementIds.includes(element.data.id || ''))
+        .map(newElement => {
+          // If I have a parent, assign my initial position to be the same
+          // that way it will appear I emerge out of my parent element
+          // instead of 0,0
+          if (newElement.data.parentId && graph.current) {
+            const parentEl = graph.current.getElementById(newElement.data.parentId);
+            const position = parentEl.position();
+            return {
+              position: {
+                ...position
+              },
+              ...newElement,
+            };
+          }
+          return newElement;
+        });
       graph.current.add(newElements);
 
       // Animate graph with the updated elements

--- a/src/shared/containers/GraphContainer/Graph.ts
+++ b/src/shared/containers/GraphContainer/Graph.ts
@@ -6,6 +6,7 @@ const MAX_LABEL_LENGTH = 20;
 
 export const makeNode = async (
   link: ResourceLink,
+  parentId: string | null,
   getResourceLinks: (self: string) => Promise<PaginatedList<ResourceLink>>
 ) => {
   const self = (link as Resource)._self;
@@ -26,6 +27,7 @@ export const makeNode = async (
       isExternal,
       isExpandable,
       self,
+      parentId,
       id: link['@id'],
     },
   };

--- a/src/shared/containers/GraphContainer/index.tsx
+++ b/src/shared/containers/GraphContainer/index.tsx
@@ -89,7 +89,10 @@ const GraphContainer: React.FunctionComponent<{
         });
 
         return Promise.all(
-          fetchedLinks.map(async link => await makeNode(link, getResourceLinks))
+          fetchedLinks.map(
+            async link =>
+              await makeNode(link, resource['@id'], getResourceLinks)
+          )
         );
       })
       .then(linkNodes => {
@@ -145,7 +148,7 @@ const GraphContainer: React.FunctionComponent<{
 
         // Link Nodes
         ...(await Promise.all(
-          response._results.map(link => makeNode(link, getResourceLinks))
+          response._results.map(link => makeNode(link, id, getResourceLinks))
         )),
 
         // Link Path Nodes and Edges


### PR DESCRIPTION
When clicking on a node to expand, make sure it emerges outside of its parent instead of appearing at the canvas origin