### PR TITLE
FIX List item for safari - linear gradient

### DIFF
--- a/src/shared/components/List/Item.less
+++ b/src/shared/components/List/Item.less
@@ -17,7 +17,6 @@
   }
   > .actions {
     background-image: -webkit-linear-gradient(right, #fcfdfd 20%, rgba(255,255,255,0));
-    // background-image: -webkit-linear-gradient(right, transparent, @component-background);
     display: flex;
     height: 100%;
     justify-content: flex-end;

--- a/src/shared/components/List/Item.less
+++ b/src/shared/components/List/Item.less
@@ -16,12 +16,8 @@
     max-width: 100%;
   }
   > .actions {
-    background-image: linear-gradient(
-      to right,
-      transparent,
-      @component-background,
-      @component-background;
-    );
+    background-image: -webkit-linear-gradient(right, #fcfdfd 20%, rgba(255,255,255,0));
+    // background-image: -webkit-linear-gradient(right, transparent, @component-background);
     display: flex;
     height: 100%;
     justify-content: flex-end;


### PR DESCRIPTION
Fixes BlueBrain/nexus#752

List items are not broken any more.
Linear gradient is still present.
Tested in Chrome, Safari and Mozilla.

![Screenshot 2019-11-22 at 14 22 10](https://user-images.githubusercontent.com/23080476/69429434-d1a58400-0d33-11ea-88c8-521bad5d1b30.png)
