### PR TITLE
FIX: Remove org dependency on ProjectView

### DIFF
--- a/src/shared/views/ProjectView.tsx
+++ b/src/shared/views/ProjectView.tsx
@@ -24,13 +24,11 @@ const ProjectView: React.FunctionComponent<{
     params: { orgLabel, projectLabel },
   } = match;
 
-  const [{ org, project, busy, error }, setState] = React.useState<{
-    org: OrgResponseCommon | null;
+  const [{ project, busy, error }, setState] = React.useState<{
     project: ProjectResponseCommon | null;
     busy: boolean;
     error: Error | null;
   }>({
-    org: null,
     project: null,
     busy: false,
     error: null,
@@ -45,15 +43,12 @@ const ProjectView: React.FunctionComponent<{
       }
       try {
         setState({
-          org,
           project,
           error: null,
           busy: true,
         });
-        const activeOrg = await nexus.Organization.get(orgLabel);
         const activeProject = await nexus.Project.get(orgLabel, projectLabel);
         setState({
-          org: activeOrg,
           project: activeProject,
           busy: false,
           error: null,
@@ -64,7 +59,6 @@ const ProjectView: React.FunctionComponent<{
           description: error.message,
         });
         setState({
-          org,
           project,
           error,
           busy: false,
@@ -76,7 +70,7 @@ const ProjectView: React.FunctionComponent<{
 
   return (
     <div className="project-view">
-      {!!project && !!org && (
+      {!!project && (
         <>
           <div className="project-banner">
             <div className="label">
@@ -87,18 +81,16 @@ const ProjectView: React.FunctionComponent<{
                   </Tooltip>
                 </Link>
                 {' | '}
-                {org && (
-                  <span>
-                    <Link to={`/${org._label}`}>{org._label}</Link>
-                    {' | '}
-                  </span>
-                )}{' '}
+                <span>
+                  <Link to={`/${orgLabel}`}>{orgLabel}</Link>
+                  {' | '}
+                </span>{' '}
                 {project._label}
                 {'  '}
               </h1>
               <div style={{ marginLeft: 10 }}>
                 <ViewStatisticsContainer
-                  orgLabel={org._label}
+                  orgLabel={orgLabel}
                   projectLabel={project._label}
                   resourceId={DEFAULT_ELASTIC_SEARCH_VIEW_ID}
                 />


### PR DESCRIPTION
fixes https://github.com/BlueBrain/nexus/issues/873

## How to Test?

Navigate while logged-out to `http://localhost:8000/Permissions-Test-Org/Permissions-Test-Project`

This project is set up to have the org permissions removed 

![Screenshot 2019-11-25 at 14 59 20](https://user-images.githubusercontent.com/5485824/69546697-876f0d80-0f94-11ea-9b7f-1ce01038a8da.png)

You won't be able to access the orgs list, but you can still see the project. 

![Screenshot 2019-11-25 at 14 59 35](https://user-images.githubusercontent.com/5485824/69546770-a66d9f80-0f94-11ea-9321-da8665d824f6.png)


You should be able to load the project resource and do everything normally, instead of having this page crash. 

Try this out between master and this branch, and you'll see the difference. 


