### PR TITLE
895 fix GitHub login for mobile

### DIFF
--- a/src/shared/App.less
+++ b/src/shared/App.less
@@ -4,7 +4,7 @@
 @import 'styles/project-banner.less';
 
 .view-container {
-  padding: 2em 0;
+  padding: 2em 1rem;
   max-width: @maxConstrainedItemWidth;
   margin: 0 auto;
   display: flex;

--- a/src/shared/components/Login/Login.less
+++ b/src/shared/components/Login/Login.less
@@ -19,11 +19,11 @@
   .link {
     // we need to override ant d styles that displays actions inline-block
     display: inline !important;
+  }
 
-    .realm {
-      color: @primary-color;
-      text-decoration: underline;
-      text-decoration-style: dotted;
-    }
+  .realm {
+    color: @primary-color;
+    text-decoration: underline;
+    text-decoration-style: dotted;
   }
 }

--- a/src/shared/components/Login/Login.less
+++ b/src/shared/components/Login/Login.less
@@ -17,11 +17,10 @@
   }
 
   .link {
-    // we need to overide ant d styles that displays actions inline-block
+    // we need to override ant d styles that displays actions inline-block
     display: inline !important;
 
     .realm {
-      display: inline;
       color: @primary-color;
       text-decoration: underline;
       text-decoration-style: dotted;

--- a/src/shared/components/Login/Login.less
+++ b/src/shared/components/Login/Login.less
@@ -17,7 +17,11 @@
   }
 
   .link {
+    // we need to overide ant d styles that displays actions inline-block
+    display: inline !important;
+
     .realm {
+      display: inline;
       color: @primary-color;
       text-decoration: underline;
       text-decoration-style: dotted;

--- a/src/shared/components/Login/__tests__/Login.test.tsx
+++ b/src/shared/components/Login/__tests__/Login.test.tsx
@@ -18,7 +18,7 @@ describe('login component', () => {
     });
 
     it('anchor tag text should only display Log in', () => {
-      expect(wrapper.find('a.link').text()).toEqual('Log in ');
+      expect(wrapper.find('span').first().text()).toEqual('Log in ');
     });
   });
 
@@ -36,8 +36,8 @@ describe('login component', () => {
       expect(wrapper.find('a.link')).toHaveLength(1);
     });
 
-    it("anchor tag text should display Realm's name", () => {
-      expect(wrapper.find('a').text()).toEqual('Log in with HBP ');
+    it("a dropdown should show a Realm's name", () => {
+      expect(wrapper.find('span.realm').text()).toEqual('HBP');
     });
   });
 });

--- a/src/shared/components/Login/__tests__/__snapshots__/Login.test.tsx.snap
+++ b/src/shared/components/Login/__tests__/__snapshots__/Login.test.tsx.snap
@@ -14,15 +14,19 @@ exports[`login component should render correctly 1`] = `
     <Card
       actions={
         Array [
-          <a
-            className="link"
-            onClick={[Function]}
-          >
-            Log in 
-            <Icon
-              type="login"
-            />
-          </a>,
+          <div>
+            <span>
+              Log in 
+            </span>
+            <a
+              className="link"
+              onClick={[Function]}
+            >
+              <Icon
+                type="login"
+              />
+            </a>
+          </div>,
         ]
       }
       cover={
@@ -67,47 +71,51 @@ exports[`login component should render correctly 1`] = `
             }
           >
             <span>
-              <a
-                className="link"
-                key="login"
-                onClick={[Function]}
-              >
-                Log in 
-                <Icon
-                  type="login"
+              <div>
+                <span>
+                  Log in 
+                </span>
+                <a
+                  className="link"
+                  key="login"
+                  onClick={[Function]}
                 >
-                  <LocaleReceiver
-                    componentName="Icon"
+                  <Icon
+                    type="login"
                   >
-                    <i
-                      aria-label="icon: login"
-                      className="anticon anticon-login"
+                    <LocaleReceiver
+                      componentName="Icon"
                     >
-                      <IconReact
-                        className=""
-                        type="login-o"
+                      <i
+                        aria-label="icon: login"
+                        className="anticon anticon-login"
                       >
-                        <svg
-                          aria-hidden="true"
+                        <IconReact
                           className=""
-                          data-icon="login"
-                          fill="currentColor"
-                          focusable="false"
-                          height="1em"
-                          key="svg-login"
-                          viewBox="64 64 896 896"
-                          width="1em"
+                          type="login-o"
                         >
-                          <path
-                            d="M521.7 82c-152.5-.4-286.7 78.5-363.4 197.7-3.4 5.3.4 12.3 6.7 12.3h70.3c4.8 0 9.3-2.1 12.3-5.8 7-8.5 14.5-16.7 22.4-24.5 32.6-32.5 70.5-58.1 112.7-75.9 43.6-18.4 90-27.8 137.9-27.8 47.9 0 94.3 9.3 137.9 27.8 42.2 17.8 80.1 43.4 112.7 75.9 32.6 32.5 58.1 70.4 76 112.5C865.7 417.8 875 464.1 875 512c0 47.9-9.4 94.2-27.8 137.8-17.8 42.1-43.4 80-76 112.5s-70.5 58.1-112.7 75.9A352.8 352.8 0 0 1 520.6 866c-47.9 0-94.3-9.4-137.9-27.8A353.84 353.84 0 0 1 270 762.3c-7.9-7.9-15.3-16.1-22.4-24.5-3-3.7-7.6-5.8-12.3-5.8H165c-6.3 0-10.2 7-6.7 12.3C234.9 863.2 368.5 942 520.6 942c236.2 0 428-190.1 430.4-425.6C953.4 277.1 761.3 82.6 521.7 82zM395.02 624v-76h-314c-4.4 0-8-3.6-8-8v-56c0-4.4 3.6-8 8-8h314v-76c0-6.7 7.8-10.5 13-6.3l141.9 112a8 8 0 0 1 0 12.6l-141.9 112c-5.2 4.1-13 .4-13-6.3z"
-                            key="svg-login-svg-0"
-                          />
-                        </svg>
-                      </IconReact>
-                    </i>
-                  </LocaleReceiver>
-                </Icon>
-              </a>
+                          <svg
+                            aria-hidden="true"
+                            className=""
+                            data-icon="login"
+                            fill="currentColor"
+                            focusable="false"
+                            height="1em"
+                            key="svg-login"
+                            viewBox="64 64 896 896"
+                            width="1em"
+                          >
+                            <path
+                              d="M521.7 82c-152.5-.4-286.7 78.5-363.4 197.7-3.4 5.3.4 12.3 6.7 12.3h70.3c4.8 0 9.3-2.1 12.3-5.8 7-8.5 14.5-16.7 22.4-24.5 32.6-32.5 70.5-58.1 112.7-75.9 43.6-18.4 90-27.8 137.9-27.8 47.9 0 94.3 9.3 137.9 27.8 42.2 17.8 80.1 43.4 112.7 75.9 32.6 32.5 58.1 70.4 76 112.5C865.7 417.8 875 464.1 875 512c0 47.9-9.4 94.2-27.8 137.8-17.8 42.1-43.4 80-76 112.5s-70.5 58.1-112.7 75.9A352.8 352.8 0 0 1 520.6 866c-47.9 0-94.3-9.4-137.9-27.8A353.84 353.84 0 0 1 270 762.3c-7.9-7.9-15.3-16.1-22.4-24.5-3-3.7-7.6-5.8-12.3-5.8H165c-6.3 0-10.2 7-6.7 12.3C234.9 863.2 368.5 942 520.6 942c236.2 0 428-190.1 430.4-425.6C953.4 277.1 761.3 82.6 521.7 82zM395.02 624v-76h-314c-4.4 0-8-3.6-8-8v-56c0-4.4 3.6-8 8-8h314v-76c0-6.7 7.8-10.5 13-6.3l141.9 112a8 8 0 0 1 0 12.6l-141.9 112c-5.2 4.1-13 .4-13-6.3z"
+                              key="svg-login-svg-0"
+                            />
+                          </svg>
+                        </IconReact>
+                      </i>
+                    </LocaleReceiver>
+                  </Icon>
+                </a>
+              </div>
             </span>
           </li>
         </ul>
@@ -133,13 +141,12 @@ exports[`login component with more than 1 realm should render correctly 1`] = `
     <Card
       actions={
         Array [
-          <a
-            className="link"
-            onClick={[Function]}
-          >
+          <div>
             <React.Fragment>
-              Log in with
-               
+              <span>
+                Log in with
+                 
+              </span>
               <Dropdown
                 mouseEnterDelay={0.15}
                 mouseLeaveDelay={0.1}
@@ -159,6 +166,12 @@ exports[`login component with more than 1 realm should render correctly 1`] = `
                   </Menu>
                 }
                 placement="bottomLeft"
+                trigger={
+                  Array [
+                    "click",
+                    "hover",
+                  ]
+                }
               >
                 <span
                   className="realm"
@@ -168,10 +181,15 @@ exports[`login component with more than 1 realm should render correctly 1`] = `
               </Dropdown>
                
             </React.Fragment>
-            <Icon
-              type="login"
-            />
-          </a>,
+            <a
+              className="link"
+              onClick={[Function]}
+            >
+              <Icon
+                type="login"
+              />
+            </a>
+          </div>,
         ]
       }
       cover={
@@ -216,13 +234,11 @@ exports[`login component with more than 1 realm should render correctly 1`] = `
             }
           >
             <span>
-              <a
-                className="link"
-                key="login"
-                onClick={[Function]}
-              >
-                Log in with
-                 
+              <div>
+                <span>
+                  Log in with
+                   
+                </span>
                 <Dropdown
                   mouseEnterDelay={0.15}
                   mouseLeaveDelay={0.1}
@@ -242,6 +258,12 @@ exports[`login component with more than 1 realm should render correctly 1`] = `
                     </Menu>
                   }
                   placement="bottomLeft"
+                  trigger={
+                    Array [
+                      "click",
+                      "hover",
+                    ]
+                  }
                 >
                   <Dropdown
                     defaultVisible={false}
@@ -257,6 +279,7 @@ exports[`login component with more than 1 realm should render correctly 1`] = `
                     transitionName="slide-up"
                     trigger={
                       Array [
+                        "click",
                         "hover",
                       ]
                     }
@@ -264,6 +287,7 @@ exports[`login component with more than 1 realm should render correctly 1`] = `
                     <Trigger
                       action={
                         Array [
+                          "click",
                           "hover",
                         ]
                       }
@@ -409,8 +433,11 @@ exports[`login component with more than 1 realm should render correctly 1`] = `
                       <span
                         className="realm ant-dropdown-trigger"
                         key="trigger"
+                        onClick={[Function]}
+                        onMouseDown={[Function]}
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
+                        onTouchStart={[Function]}
                       >
                         HBP
                       </span>
@@ -418,41 +445,47 @@ exports[`login component with more than 1 realm should render correctly 1`] = `
                   </Dropdown>
                 </Dropdown>
                  
-                <Icon
-                  type="login"
+                <a
+                  className="link"
+                  key="login"
+                  onClick={[Function]}
                 >
-                  <LocaleReceiver
-                    componentName="Icon"
+                  <Icon
+                    type="login"
                   >
-                    <i
-                      aria-label="icon: login"
-                      className="anticon anticon-login"
+                    <LocaleReceiver
+                      componentName="Icon"
                     >
-                      <IconReact
-                        className=""
-                        type="login-o"
+                      <i
+                        aria-label="icon: login"
+                        className="anticon anticon-login"
                       >
-                        <svg
-                          aria-hidden="true"
+                        <IconReact
                           className=""
-                          data-icon="login"
-                          fill="currentColor"
-                          focusable="false"
-                          height="1em"
-                          key="svg-login"
-                          viewBox="64 64 896 896"
-                          width="1em"
+                          type="login-o"
                         >
-                          <path
-                            d="M521.7 82c-152.5-.4-286.7 78.5-363.4 197.7-3.4 5.3.4 12.3 6.7 12.3h70.3c4.8 0 9.3-2.1 12.3-5.8 7-8.5 14.5-16.7 22.4-24.5 32.6-32.5 70.5-58.1 112.7-75.9 43.6-18.4 90-27.8 137.9-27.8 47.9 0 94.3 9.3 137.9 27.8 42.2 17.8 80.1 43.4 112.7 75.9 32.6 32.5 58.1 70.4 76 112.5C865.7 417.8 875 464.1 875 512c0 47.9-9.4 94.2-27.8 137.8-17.8 42.1-43.4 80-76 112.5s-70.5 58.1-112.7 75.9A352.8 352.8 0 0 1 520.6 866c-47.9 0-94.3-9.4-137.9-27.8A353.84 353.84 0 0 1 270 762.3c-7.9-7.9-15.3-16.1-22.4-24.5-3-3.7-7.6-5.8-12.3-5.8H165c-6.3 0-10.2 7-6.7 12.3C234.9 863.2 368.5 942 520.6 942c236.2 0 428-190.1 430.4-425.6C953.4 277.1 761.3 82.6 521.7 82zM395.02 624v-76h-314c-4.4 0-8-3.6-8-8v-56c0-4.4 3.6-8 8-8h314v-76c0-6.7 7.8-10.5 13-6.3l141.9 112a8 8 0 0 1 0 12.6l-141.9 112c-5.2 4.1-13 .4-13-6.3z"
-                            key="svg-login-svg-0"
-                          />
-                        </svg>
-                      </IconReact>
-                    </i>
-                  </LocaleReceiver>
-                </Icon>
-              </a>
+                          <svg
+                            aria-hidden="true"
+                            className=""
+                            data-icon="login"
+                            fill="currentColor"
+                            focusable="false"
+                            height="1em"
+                            key="svg-login"
+                            viewBox="64 64 896 896"
+                            width="1em"
+                          >
+                            <path
+                              d="M521.7 82c-152.5-.4-286.7 78.5-363.4 197.7-3.4 5.3.4 12.3 6.7 12.3h70.3c4.8 0 9.3-2.1 12.3-5.8 7-8.5 14.5-16.7 22.4-24.5 32.6-32.5 70.5-58.1 112.7-75.9 43.6-18.4 90-27.8 137.9-27.8 47.9 0 94.3 9.3 137.9 27.8 42.2 17.8 80.1 43.4 112.7 75.9 32.6 32.5 58.1 70.4 76 112.5C865.7 417.8 875 464.1 875 512c0 47.9-9.4 94.2-27.8 137.8-17.8 42.1-43.4 80-76 112.5s-70.5 58.1-112.7 75.9A352.8 352.8 0 0 1 520.6 866c-47.9 0-94.3-9.4-137.9-27.8A353.84 353.84 0 0 1 270 762.3c-7.9-7.9-15.3-16.1-22.4-24.5-3-3.7-7.6-5.8-12.3-5.8H165c-6.3 0-10.2 7-6.7 12.3C234.9 863.2 368.5 942 520.6 942c236.2 0 428-190.1 430.4-425.6C953.4 277.1 761.3 82.6 521.7 82zM395.02 624v-76h-314c-4.4 0-8-3.6-8-8v-56c0-4.4 3.6-8 8-8h314v-76c0-6.7 7.8-10.5 13-6.3l141.9 112a8 8 0 0 1 0 12.6l-141.9 112c-5.2 4.1-13 .4-13-6.3z"
+                              key="svg-login-svg-0"
+                            />
+                          </svg>
+                        </IconReact>
+                      </i>
+                    </LocaleReceiver>
+                  </Icon>
+                </a>
+              </div>
             </span>
           </li>
         </ul>

--- a/src/shared/components/Login/index.tsx
+++ b/src/shared/components/Login/index.tsx
@@ -23,6 +23,7 @@ const Login: React.FunctionComponent<LoginProps> = ({
   const menu = (
     <Menu
       onClick={({ key, domEvent }) => {
+        domEvent.preventDefault();
         domEvent.stopPropagation();
         const realm = realms.find(r => r === key);
         if (realm) {
@@ -42,19 +43,23 @@ const Login: React.FunctionComponent<LoginProps> = ({
       <Card
         cover={<img className="logo" alt="Nexus logo" src={logo} />}
         actions={[
-          <a onClick={onLogin} className="link" key="login">
+          <div>
             {realms.length === 1 ? (
               'Log in '
             ) : (
               <React.Fragment>
-                Log in with{' '}
-                <Dropdown overlay={menu}>
+                <a onClick={onLogin} className="link" key="login">
+                  Log in with{' '}
+                </a>
+                <Dropdown overlay={menu} trigger={['click', 'hover']}>
                   <span className="realm">{realm}</span>
                 </Dropdown>{' '}
               </React.Fragment>
             )}
-            <Icon type="login" />
-          </a>,
+            <a onClick={onLogin} className="link" key="login">
+              <Icon type="login" />
+            </a>
+          </div>,
         ]}
       >
         <p className="message">Please log in to continue.</p>

--- a/src/shared/components/Login/index.tsx
+++ b/src/shared/components/Login/index.tsx
@@ -45,12 +45,10 @@ const Login: React.FunctionComponent<LoginProps> = ({
         actions={[
           <div>
             {realms.length === 1 ? (
-              'Log in '
+              <span>Log in </span>
             ) : (
               <React.Fragment>
-                <a onClick={onLogin} className="link" key="login">
-                  Log in with{' '}
-                </a>
+                <span>Log in with{' '}</span>
                 <Dropdown overlay={menu} trigger={['click', 'hover']}>
                   <span className="realm">{realm}</span>
                 </Dropdown>{' '}


### PR DESCRIPTION
Fixes BlueBrain/nexus#895

![Screenshot 2019-11-25 at 15 27 37](https://user-images.githubusercontent.com/23080476/69548771-41b44400-0f98-11ea-8c15-245636882c7c.png)

Tested in Chrome Desktop and on an iPad (Safari)

The issue is that there is no hover events on touchscreens.
Added a Click action to open a dropdown menu with Realms. 
Hover action is still present in Chrome Desktop.
