### PR TITLE
Bugfix/849 ES Query error message

### DIFF
--- a/src/shared/components/ViewForm/ElasticSearchQueryForm.tsx
+++ b/src/shared/components/ViewForm/ElasticSearchQueryForm.tsx
@@ -11,11 +11,23 @@ import './view-form.less';
 const FormItem = Form.Item;
 const ListItem = List.Item;
 
+/**
+ * This is tricky because error can be KG error OR an ElasticSearch Error.
+ *
+ * In the case of ES, the reason message is nested within an error object
+ */
+type NexusESError = {
+  reason?: string;
+  error?: {
+    reason?: string;
+  };
+};
+
 const ElasticSearchQueryForm: React.FunctionComponent<{
   query: object;
   response: ElasticSearchViewQueryResponse<any> | null;
   busy: boolean;
-  error: Error | null;
+  error: NexusESError | null;
   from: number;
   size: number;
   onPaginationChange: (page: number) => void;
@@ -94,11 +106,8 @@ const ElasticSearchQueryForm: React.FunctionComponent<{
       <Card bordered className="results">
         {error && (
           <Empty
-            description={
-              error.message === 'Bad Request'
-                ? 'The query is malformed'
-                : error.message
-            }
+            description={`An error occurred: ${error.reason ||
+              (error.error && error.error.reason)}`}
           />
         )}
         {!error && (

--- a/src/shared/components/ViewForm/SparqlQueryForm.tsx
+++ b/src/shared/components/ViewForm/SparqlQueryForm.tsx
@@ -62,7 +62,6 @@ const SparqlQueryForm: React.FunctionComponent<{
     setValue(value);
   };
 
-  console.log('Boo', error);
   return (
     <div className="view-form">
       <Form

--- a/src/shared/components/ViewForm/SparqlQueryForm.tsx
+++ b/src/shared/components/ViewForm/SparqlQueryForm.tsx
@@ -3,7 +3,11 @@ import { Form, Button, Card, Empty, Table, Tooltip } from 'antd';
 import Column from 'antd/lib/table/Column';
 import { UnControlled as CodeMirror } from 'react-codemirror2';
 import * as hash from 'object-hash';
-import { AskQueryResponse, SelectQueryResponse, SparqlViewQueryResponse } from '@bbp/nexus-sdk';
+import {
+  AskQueryResponse,
+  SelectQueryResponse,
+  SparqlViewQueryResponse,
+} from '@bbp/nexus-sdk';
 
 import 'codemirror/addon/display/placeholder';
 import 'codemirror/mode/sparql/sparql';
@@ -11,6 +15,12 @@ import 'codemirror/mode/sparql/sparql';
 import './view-form.less';
 
 const FormItem = Form.Item;
+
+type NexusSparqlError =
+  | string
+  | {
+      reason: string;
+    };
 
 type Entry = {
   [key: string]: string;
@@ -23,7 +33,7 @@ const SparqlQueryForm: React.FunctionComponent<{
   query: string;
   response: SparqlViewQueryResponse | null;
   busy: boolean;
-  error: Error | null;
+  error: NexusSparqlError | null;
   onQueryChange: (query: string) => void;
 }> = ({ query, response, busy, error, onQueryChange }): JSX.Element => {
   // TODO: Validate Sparql with some cool library
@@ -40,7 +50,9 @@ const SparqlQueryForm: React.FunctionComponent<{
 
   const data: any[] =
     (response &&
-      (!!(response as AskQueryResponse).boolean ? [(response as AskQueryResponse).boolean.toString()] : (response as SelectQueryResponse).results.bindings)) ||
+      (!!(response as AskQueryResponse).boolean
+        ? [(response as AskQueryResponse).boolean.toString()]
+        : (response as SelectQueryResponse).results.bindings)) ||
     [];
 
   const handleChange = (editor: any, data: any, value: string) => {
@@ -50,6 +62,7 @@ const SparqlQueryForm: React.FunctionComponent<{
     setValue(value);
   };
 
+  console.log('Boo', error);
   return (
     <div className="view-form">
       <Form
@@ -80,11 +93,7 @@ const SparqlQueryForm: React.FunctionComponent<{
       <Card bordered className="results">
         {error && (
           <Empty
-            description={
-              error.message === 'Bad Request'
-                ? 'The query is malformed'
-                : error.message
-            }
+            description={typeof error === 'string' ? error : error.reason}
           />
         )}
         {!error && (

--- a/src/shared/containers/SparqlQuery.tsx
+++ b/src/shared/containers/SparqlQuery.tsx
@@ -31,7 +31,7 @@ const SparqlQueryContainer: React.FunctionComponent<{
   const [{ response, busy, error }, setResponse] = React.useState<{
     response: SparqlViewQueryResponse | null;
     busy: boolean;
-    error: Error | null;
+    error: string | { reason: string } | null;
   }>({
     response: null,
     busy: false,


### PR DESCRIPTION
Fixes BlueBrain/nexus#849

This is the error response and the message displayed  when `Unauthorised`:
![Screenshot from 2019-11-25 15-15-50](https://user-images.githubusercontent.com/4364154/69552388-ad011480-0f9e-11ea-89b7-13b35b06f807.png)
![Screenshot from 2019-11-25 15-55-31](https://user-images.githubusercontent.com/4364154/69551949-dff6d880-0f9d-11ea-82a2-1a7de9c53f8e.png)

This is the error response and the error message displayed when `Bad Request`:
![Screenshot from 2019-11-25 15-15-28](https://user-images.githubusercontent.com/4364154/69552396-b12d3200-0f9e-11ea-9286-a6f245f5bb20.png)
![Screenshot from 2019-11-25 16-15-19](https://user-images.githubusercontent.com/4364154/69552469-cd30d380-0f9e-11ea-8639-72ad85ae5675.png)

