### PR TITLE
Bugfix/remove "_" type inserted during resource creation

### DIFF
--- a/src/shared/components/ResourceForm/ResourceForm.tsx
+++ b/src/shared/components/ResourceForm/ResourceForm.tsx
@@ -105,10 +105,8 @@ const ResourceForm: React.FunctionComponent<ResourceFormProps> = ({
           resourceTypes.find((type: string) =>
             Object.keys(RESOURCES_SCHEMA_URI).includes(type)
           ) || '_';
-
         const payload = {
           ...editorContent,
-          type: resourceTypes,
         };
         onSubmit({
           payload,

--- a/src/shared/utils/nexusMaybe.ts
+++ b/src/shared/utils/nexusMaybe.ts
@@ -38,6 +38,6 @@ export const isSparqlView = isOfType(SPARQL_VIEW);
 export const isFile = isOfType(NEXUS_FILE_TYPE);
 export const toPromise = (func: Function) => {
   return function() {
-    return Promise.resolve(func(arguments));
+    return Promise.resolve(func(...arguments));
   };
 };


### PR DESCRIPTION
fixes: https://github.com/BlueBrain/nexus/issues/921

## How to test?

Create a resource without an `@type` and check to see if it will have an `type` field of value `_`.  It should not!