### PR TITLE
[Draft] Studio Create/Edit Wizard

### DIFF
--- a/src/shared/App.less
+++ b/src/shared/App.less
@@ -70,3 +70,16 @@
 .ant-drawer-right.ant-drawer-open .ant-drawer-content-wrapper {
   box-shadow: -2px 8px 8px rgba(0, 0, 0, 0.15);
 }
+
+.studio-view {
+  padding: 0 2em;
+  .title {
+    margin-bottom: 0;
+  }
+  .workspace {
+    display: flex;
+  }
+  .studio-back-button {
+    margin-bottom: 5px;
+  }
+}

--- a/src/shared/components/HomeIcon/index.tsx
+++ b/src/shared/components/HomeIcon/index.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { Tooltip, Icon } from 'antd';
+
+const HomeIcon: React.FunctionComponent<{}> = () => (
+  <Link to="/">
+    <Tooltip title="Back to all organizations" placement="right">
+      <Icon type="home" />
+    </Tooltip>
+  </Link>
+);
+
+export default HomeIcon;

--- a/src/shared/components/ResourceEditor/index.tsx
+++ b/src/shared/components/ResourceEditor/index.tsx
@@ -34,30 +34,59 @@ const ResourceEditor: React.FunctionComponent<ResourceEditorProps> = props => {
 
   const [isEditing, setEditing] = React.useState(editing);
   const [valid, setValid] = React.useState(true);
-  const [value, setValue] = React.useState(rawData);
+  const [parsedValue, setParsedValue] = React.useState(rawData);
+  const [stringValue, setStringValue] = React.useState(JSON.stringify(rawData, null, 2));
+
+  const renderCodeMirror = (value: string) => {
+    return (
+      <Spin spinning={busy}>
+        <CodeMirror
+          value={value}
+          autoCursor={false}
+          detach={false}
+          options={{
+            readOnly: !editable,
+            mode: { name: 'javascript', json: true },
+            theme: 'base16-light',
+            lineNumbers: true,
+            lineWrapping: true,
+            viewportMargin: Infinity,
+          }}
+          onChange={handleChange}
+        />
+      </Spin>
+    );
+  };
 
   React.useEffect(() => {
     setEditing(false);
   }, [rawData]); // only runs when Editor receives new resource to edit
 
   const handleChange = (editor: any, data: any, value: any) => {
-    if (!editable) {
+    if (!editable || value === JSON.stringify(rawData, null, 2)) {
       return;
     }
     try {
       const parsedVal = JSON.parse(value);
-      setValue(parsedVal);
-      setEditing(true);
+      setParsedValue(parsedVal);
       setValid(true);
     } catch (error) {
       setValid(false);
     }
+    setEditing(true);
+    setStringValue(value);
   };
 
   const handleSubmit = () => {
     if (onSubmit) {
-      onSubmit(value);
+      onSubmit(parsedValue);
     }
+  };
+
+  const handleCancel = () => {
+    setStringValue(JSON.stringify(rawData, null, 2));
+    setValid(true);
+    setEditing(false);
   };
 
   return (
@@ -69,7 +98,7 @@ const ResourceEditor: React.FunctionComponent<ResourceEditorProps> = props => {
               <Icon type="info-circle" /> This resource cannot be edited
             </div>
           )}
-          {editable && !isEditing && (
+          {editable && !isEditing && valid && (
             <div className="feedback">
               <Icon type="info-circle" /> Directly edit this resource
             </div>
@@ -106,33 +135,27 @@ const ResourceEditor: React.FunctionComponent<ResourceEditorProps> = props => {
             />
           )}
 
-          {editable && isEditing && valid && (
-            <Button
-              icon="save"
-              type="primary"
-              size="small"
-              onClick={handleSubmit}
-            >
-              Save
-            </Button>
+          {editable && isEditing && (
+            <>
+            {valid ? 
+              <Button
+                icon="save"
+                type="primary"
+                size="small"
+                onClick={handleSubmit}
+              >
+                Save
+              </Button> : null }
+              {' '}
+              <Button type="danger" size="small" onClick={handleCancel}>
+                Cancel
+              </Button>
+            </>
           )}
         </div>
       </div>
 
-      <Spin spinning={busy}>
-        <CodeMirror
-          value={JSON.stringify(rawData, null, 2)}
-          options={{
-            readOnly: !editable,
-            mode: { name: 'javascript', json: true },
-            theme: 'base16-light',
-            lineNumbers: true,
-            lineWrapping: true,
-            viewportMargin: Infinity,
-          }}
-          onChange={handleChange}
-        />
-      </Spin>
+      {renderCodeMirror(stringValue)}
     </div>
   );
 };

--- a/src/shared/components/ResourceList/ResourceList.less
+++ b/src/shared/components/ResourceList/ResourceList.less
@@ -6,7 +6,6 @@
   width: @default-card-width;
   min-width: @default-card-width;
   resize: horizontal;
-  overflow: auto;
   display: flex;
   flex-direction: column;
   max-height: 100%;

--- a/src/shared/components/ResourceListBoard/index.tsx
+++ b/src/shared/components/ResourceListBoard/index.tsx
@@ -8,14 +8,12 @@ const ResourceListBoardComponent: React.FunctionComponent<{
 }> = props => {
   const { createList, children } = props;
   return (
-    <div className="list-board">
-      <div className="wrapper">
-        {children}
-        <div className="resource-list -add" onClick={() => createList()}>
-          <Icon type="plus" /> Add another resource list
-        </div>
+    <>
+      {children}
+      <div className="resource-list -add" onClick={() => createList()}>
+        <Icon type="plus" /> Add another resource list
       </div>
-    </div>
+    </>
   );
 };
 

--- a/src/shared/components/ResultsTable/ResultTable.less
+++ b/src/shared/components/ResultsTable/ResultTable.less
@@ -1,0 +1,17 @@
+.result-table {
+  width: 100%;
+  .header {
+    display: flex;
+    justify-content: space-between;
+    .search {
+      width: 50%;
+    }
+    .total {
+      margin-top: 6px;
+    }
+  }
+}
+.result-column {
+  cursor: pointer;
+  background-color: rgba(255, 255, 255, 0.9);
+}

--- a/src/shared/components/ResultsTable/ResultsTable.tsx
+++ b/src/shared/components/ResultsTable/ResultsTable.tsx
@@ -1,0 +1,118 @@
+import * as React from 'react';
+import './ResultTable.less';
+import * as moment from 'moment';
+import { Input, Table } from 'antd';
+import { parseProjectUrl } from '../../utils/index';
+
+const { Search } = Input;
+
+const PAGE_SIZE = 10;
+
+type ResultTableProps = {
+  headerProperties?: {
+    title: string;
+    dataIndex: string;
+  }[];
+  items: {
+    id: string;
+    [dataIndex: string]: any;
+  }[];
+  pageSize?: number;
+  handleClick: (self: string) => void;
+};
+
+const ResultsTable: React.FunctionComponent<ResultTableProps> = ({
+  headerProperties,
+  items,
+  pageSize = PAGE_SIZE,
+  handleClick,
+}) => {
+  const [searchValue, setSearchValue] = React.useState();
+
+  const columnList = [
+    ...(headerProperties
+      ? headerProperties.map(({ title, dataIndex }) => {
+          // We can create special renderers for the cells here
+          let render;
+          switch (title) {
+            case 'Created At':
+              render = (date: string) => <span>{moment(date).fromNow()}</span>;
+              break;
+            case 'Project':
+              render = (projectURI: string) => {
+                if (projectURI) {
+                  const [org, project] = parseProjectUrl(projectURI);
+                  return (
+                    <span>
+                      <b>{org}</b> / {project}
+                    </span>
+                  );
+                }
+                return null;
+              };
+              break;
+            default:
+              render = (value: string) => <span>{value}</span>;
+              break;
+          }
+
+          return {
+            title,
+            dataIndex,
+            render,
+            className: `result-column ${dataIndex}`,
+          };
+        })
+      : []),
+  ];
+
+  const filteredItems = items.filter(item => {
+    return (
+      Object.values(item)
+        .join(' ')
+        .toLowerCase()
+        .search((searchValue || '').toLowerCase()) >= 0
+    );
+  });
+
+  const tableItems = searchValue ? filteredItems : items;
+  const total = tableItems.length;
+  const showPagination = total > pageSize;
+
+  return (
+    <div className="result-table">
+      <Table
+        onRow={data => ({
+          onClick: event => handleClick(data.self.value),
+        })}
+        columns={columnList}
+        dataSource={tableItems}
+        bordered
+        pagination={
+          showPagination && {
+            total,
+            pageSize,
+          }
+        }
+        title={() => (
+          <div className="header">
+            {(showPagination || !!searchValue) && (
+              <Search
+                className="search"
+                value={searchValue}
+                onChange={(e: React.FormEvent<HTMLInputElement>) => {
+                  setSearchValue(e.currentTarget.value);
+                }}
+              />
+            )}
+            <div className="total">
+              {total} {`Result${total > 1 ? 's' : ''}`}
+            </div>
+          </div>
+        )}
+      />
+    </div>
+  );
+};
+
+export default ResultsTable;

--- a/src/shared/components/Studio/Studio.less
+++ b/src/shared/components/Studio/Studio.less
@@ -1,0 +1,27 @@
+@import '../../lib.less';
+
+.studio-list {
+  .cardlike();
+  background-color: @primary-card;
+  width: @default-card-width;
+  min-width: @default-card-width;
+  resize: horizontal;
+  display: flex;
+  flex-direction: column;
+  max-height: 100%;
+  overflow: hidden;
+}
+
+.studio-item {
+  .label {
+    .ellipsis();
+    font-weight: bold;
+    color: @text-color;
+  }
+
+  .description {
+    .ellipsis();
+    margin-bottom: 0;
+    color: @text-color-secondary;
+  }
+}

--- a/src/shared/components/Studio/Studio.stories.tsx
+++ b/src/shared/components/Studio/Studio.stories.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { withKnobs, boolean } from '@storybook/addon-knobs';
+import { withInfo } from '@storybook/addon-info';
+
+import StudioList from './StudioList';
+
+const studios = [
+  {
+    id: 'thalamus',
+    name: 'Thalamus',
+  },
+  {
+    id: 'sscx',
+    name: 'SSCx',
+    description: 'Somatosensory Cortex project',
+  },
+];
+
+storiesOf('Components/Studio', module)
+  .addDecorator(withKnobs)
+  .add(
+    'StudioList',
+    withInfo(`
+  `)(() => {
+      const busy = boolean('busy', false);
+      return (
+        <div style={{ width: 400 }}>
+          <h3>List of studios</h3>
+          <StudioList
+            studios={studios}
+            busy={busy}
+            goToStudio={action('studio click')}
+          />
+          <br />
+          <h3>Empty list</h3>
+          <StudioList studios={[]} busy={busy} />
+          <br />
+          <h3>Error</h3>
+          <StudioList
+            studios={[]}
+            busy={busy}
+            error={new Error('Not authorized')}
+          />
+        </div>
+      );
+    })
+  );

--- a/src/shared/components/Studio/StudioList.tsx
+++ b/src/shared/components/Studio/StudioList.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { Empty, Spin } from 'antd';
+
+import ListItem from '../List/Item';
+
+import './Studio.less';
+
+type StudioItemProps = {
+  id: string;
+  name: string;
+  description?: string;
+};
+
+const StudioItem: React.FC<StudioItemProps> = ({ name, description }) => {
+  return (
+    <div className="studio-item">
+      <p className="label">{name}</p>
+      {description && <p className="description">{description}</p>}
+    </div>
+  );
+};
+
+const StudioList: React.FC<{
+  studios: StudioItemProps[];
+  busy?: boolean;
+  error?: Error | null;
+  goToStudio?(studioId: string): void;
+}> = ({ studios, busy, error, goToStudio = () => {} }) => {
+  const noStudios = studios.length === 0;
+  return (
+    <div className="studio-list">
+      <h3>Studios</h3>
+      <Spin spinning={busy}>
+        {error && <Empty description={error.message || 'An error occurred'} />}
+        {!error && noStudios && <Empty description="No studios available" />}
+        {!noStudios && (
+          <div>
+            {studios.map(studio => (
+              <ListItem onClick={() => goToStudio(studio.id)} key={studio.id}>
+                <StudioItem {...studio} />
+              </ListItem>
+            ))}
+          </div>
+        )}
+      </Spin>
+    </div>
+  );
+};
+
+export default StudioList;

--- a/src/shared/components/Tabs/TabList.less
+++ b/src/shared/components/Tabs/TabList.less
@@ -1,0 +1,20 @@
+.tab-item {
+	display: flex;
+	flex-direction: column;
+	justify-content: flex-start;
+	text-align: left;
+	max-width: 250px;
+	>.title {
+		font-size: 1.2em;
+	}
+	>.description {
+		white-space: normal;
+		line-height: 1.2em;
+		color: rgba(0, 0, 0, 0.5);
+	}
+}
+.ellipsis {
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}

--- a/src/shared/components/Tabs/TabList.tsx
+++ b/src/shared/components/Tabs/TabList.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import './TabList.less';
+import { Tabs } from 'antd';
+
+const { TabPane } = Tabs;
+
+type TabItem = {
+  id: string;
+  label: string;
+  description: string;
+};
+
+type TabListProps = {
+  items: TabItem[];
+  onSelected: (activeKey: string) => void;
+  defaultActiveId?: string;
+  position?: 'left' | 'right' | 'top' | 'bottom' | undefined;
+};
+
+const TabList: React.FunctionComponent<TabListProps> = ({
+  items,
+  onSelected,
+  defaultActiveId,
+  position = 'left',
+  children,
+}) => {
+  return (
+    <div className="tab-list">
+      <Tabs
+        tabPosition={position}
+        onChange={onSelected}
+        defaultActiveKey={defaultActiveId}
+      >
+        {items.map(({ label, description, id }) => (
+          <TabPane
+            tab={
+              <div className="tab-item">
+                <span className="title ellipsis">{label}</span>
+                <p className="description fade">{description}</p>
+              </div>
+            }
+            key={id}
+          >
+            {children}
+          </TabPane>
+        ))}
+      </Tabs>
+    </div>
+  );
+};
+
+export default TabList;

--- a/src/shared/components/Tabs/__tests__/TabList.spec.tsx
+++ b/src/shared/components/Tabs/__tests__/TabList.spec.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+
+import TabList from '../TabList';
+
+const tabListComponent = <TabList items={[]} onSelected={jest.fn}/>;
+const wrapper = shallow(tabListComponent);
+
+describe('TabList component', () => {
+  it('should render correctly', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+});
+
+
+jest.restoreAllMocks();

--- a/src/shared/components/Tabs/__tests__/__snapshots__/TabList.spec.tsx.snap
+++ b/src/shared/components/Tabs/__tests__/__snapshots__/TabList.spec.tsx.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TabList component should render correctly 1`] = `
+<div
+  className="tab-list"
+>
+  <Tabs
+    hideAdd={false}
+    onChange={[Function]}
+    tabPosition="left"
+  />
+</div>
+`;

--- a/src/shared/containers/DashboardListContainer.tsx
+++ b/src/shared/containers/DashboardListContainer.tsx
@@ -1,0 +1,122 @@
+import * as React from 'react';
+import { Resource } from '@bbp/nexus-sdk';
+import { useNexusContext } from '@bbp/react-nexus';
+import TabList from '../components/Tabs/TabList';
+import DashboardResultsContainer from './DashboardResultsContainer';
+import { useHistory } from 'react-router-dom';
+
+type Dashboard = {
+  dashboard: string;
+  view: string;
+};
+interface DashboardListProps {
+  dashboards: Dashboard[];
+  orgLabel: string;
+  projectLabel: string;
+  workspaceId: string;
+  dashboardId: string;
+  studioResourceId: string;
+}
+
+const DashboardList: React.FunctionComponent<DashboardListProps> = ({
+  dashboards,
+  orgLabel,
+  projectLabel,
+  workspaceId,
+  dashboardId,
+  studioResourceId,
+}) => {
+  const history = useHistory();
+  const [dashboardResources, setDashboardResources] = React.useState<
+    Resource[]
+  >([]);
+  const [selectedDashboard, setSelectedDashboard] = React.useState<Resource>();
+  const nexus = useNexusContext();
+
+  const selectDashboard = (id: string) => {
+    const dashboard = dashboardResources.find(d => d['@id'] === id);
+    setSelectedDashboard(dashboard);
+    const path = history.location.pathname.split('/dashboards');
+    let newPath;
+    if (path[0].includes('/workspaces')) {
+      newPath = `${path[0]}/dashboards/${encodeURIComponent(id)}`;
+    } else {
+      newPath = `${
+        path[0]
+      }/workspaces/${workspaceId}/dashboards/${encodeURIComponent(id)}`;
+    }
+    history.push(newPath);
+  };
+
+  React.useEffect(() => {
+    Promise.all(
+      dashboards.map(dashboardObject => {
+        return nexus.Resource.get(
+          orgLabel,
+          projectLabel,
+          encodeURIComponent(dashboardObject.dashboard)
+        );
+      })
+    )
+      .then(values => {
+        setDashboardResources(values);
+        let d;
+        if (
+          dashboardId &&
+          (selectedDashboard === undefined ||
+            selectedDashboard['@id'] !== dashboardId)
+        ) {
+          const id = decodeURIComponent(dashboardId);
+          d = values.find(d => d['@id'] === id);
+        } else {
+          d = values[0];
+        }
+        setSelectedDashboard(d);
+      })
+      .catch(e => {
+        // TODO: show a meaningful error to the user.
+      });
+  }, [orgLabel, projectLabel, dashboardId]);
+  return (
+    <div>
+      {dashboardResources.length > 0 ? (
+        <>
+          <TabList
+            items={dashboardResources.map(w => ({
+              label: w.label,
+              description: w.description,
+              id: w['@id'],
+            }))}
+            onSelected={(id: string) => {
+              selectDashboard(id);
+            }}
+            position="left"
+            defaultActiveId={
+              dashboardId
+                ? decodeURIComponent(dashboardId)
+                : dashboardResources[0]['@id']
+            }
+          >
+            {selectedDashboard ? (
+              <DashboardResultsContainer
+                orgLabel={orgLabel}
+                projectLabel={projectLabel}
+                viewId={dashboards[0].view}
+                workspaceId={workspaceId}
+                dashboardId={
+                  dashboardId ? dashboardId : selectedDashboard['@id']
+                }
+                studioResourceId={studioResourceId}
+                dataQuery={selectedDashboard['dataQuery']}
+              />
+            ) : null}
+          </TabList>
+        </>
+      ) : (
+        'No Dashboards are available'
+      )}
+    </div>
+  );
+};
+
+export default DashboardList;

--- a/src/shared/containers/DashboardResultsContainer.tsx
+++ b/src/shared/containers/DashboardResultsContainer.tsx
@@ -1,0 +1,190 @@
+import * as React from 'react';
+import { Spin, Alert, Button } from 'antd';
+import ResultsTable from '../components/ResultsTable/ResultsTable';
+import { camelCaseToLabelString } from '../utils';
+import {
+  Resource,
+  SelectQueryResponse,
+  SparqlViewQueryResponse,
+} from '@bbp/nexus-sdk';
+import ResourceCardComponent from '../components/ResourceCard';
+import { useHistory } from 'react-router-dom';
+import { useNexusContext } from '@bbp/react-nexus';
+
+export type Binding = {
+  [key: string]: {
+    dataType?: string;
+    type: string;
+    value: string;
+  };
+};
+
+type Item = {
+  id: string;
+  self: string;
+  key: string;
+  [key: string]: any;
+};
+
+const DashboardResultsContainer: React.FunctionComponent<{
+  dataQuery: string;
+  orgLabel: string;
+  projectLabel: string;
+  viewId: string;
+  workspaceId: string;
+  dashboardId: string;
+  studioResourceId: string;
+}> = ({
+  orgLabel,
+  projectLabel,
+  dataQuery,
+  viewId,
+  workspaceId,
+  dashboardId,
+  studioResourceId,
+}) => {
+  const history = useHistory();
+  const [selectedResource, setSelectedResource] = React.useState<Resource>();
+  const [error, setError] = React.useState<Error>();
+  const [items, setItems] = React.useState<any[]>();
+  const [headerProperties, setHeaderProperties] = React.useState<any[]>();
+  const nexus = useNexusContext();
+  const selectResource = (selfUrl: string, setHistory = true) => {
+    nexus
+      .httpGet({ path: selfUrl })
+      .then(res => {
+        setSelectedResource(res);
+        if (setHistory) {
+          updateResourcePath(res);
+        }
+      })
+      .catch(e => {
+        setError(e);
+        // TODO: show a meaningful error to the user.
+      });
+  };
+
+  const updateResourcePath = (res: Resource) => {
+    const path = history.location.pathname.split('/studioResource');
+    let newPath;
+    if (path[0].includes('/workspaces') && path[0].includes('/dashboards')) {
+      newPath = `${path[0]}/studioResource/${encodeURIComponent(res['@id'])}`;
+      history.push(newPath);
+    } else {
+      if (path[0].includes('/dashboards')) {
+        newPath = `${
+          path[0]
+        }/workspaces/${workspaceId}/dashboards/${encodeURIComponent(
+          dashboardId
+        )}/studioResource/${encodeURIComponent(res['@id'])}`;
+      } else {
+        newPath = `${path[0]}/dashboards/${encodeURIComponent(
+          dashboardId
+        )}/studioResource/${encodeURIComponent(res['@id'])}`;
+        history.push(newPath);
+      }
+    }
+    history.push(newPath);
+  };
+
+  const unSelectResource = () => {
+    setSelectedResource(undefined);
+  };
+
+  React.useEffect(() => {
+    nexus.View.sparqlQuery(
+      orgLabel,
+      projectLabel,
+      encodeURIComponent(viewId),
+      dataQuery
+    ).then((result: SparqlViewQueryResponse) => {
+      const data: SelectQueryResponse = result as SelectQueryResponse;
+      const tempHeaderProperties: {
+        title: string;
+        dataIndex: string;
+      }[] = data.head.vars
+        .filter(
+          // we don't want to display total or self url in result table
+          (headVar: string) => !(headVar === 'total' || headVar === 'self')
+        )
+        .map((headVar: string) => ({
+          title: camelCaseToLabelString(headVar), // TODO: get the matching title from somewhere?
+          dataIndex: headVar,
+        }));
+      setHeaderProperties(tempHeaderProperties);
+      // build items
+      const tempItems = data.results.bindings
+        // we only want resources
+        .filter((binding: Binding) => binding.self)
+        .map((binding: Binding, index: number) => {
+          // let's get the value for each headerProperties
+          const properties = tempHeaderProperties.reduce(
+            (prev, curr) => ({
+              ...prev,
+              [curr.dataIndex]:
+                (binding[curr.dataIndex] && binding[curr.dataIndex].value) ||
+                undefined,
+            }),
+            {}
+          );
+          // return item data
+          return {
+            ...properties, // our properties
+            id: index.toString(), // id is used by antd component
+            self: binding.self, // used in order to load details or resource once selected
+            key: index.toString(), // used by react component (unique key)
+          };
+        });
+
+      const currentResource = data.results.bindings
+        .filter((binding: Binding) => binding.self)
+        .find((binding: Binding) => {
+          return binding.self.value.includes(studioResourceId);
+        });
+      if (selectedResource === undefined && currentResource !== undefined) {
+        selectResource(currentResource.self.value, false);
+      }
+      setItems(tempItems);
+    }).catch(e => {
+      setError(e);
+    });
+  }, [orgLabel, projectLabel, dataQuery, viewId]);
+
+  if (error) {
+    return (
+      <Alert
+        message="Error loading dashboard"
+        description={`Something went wrong: ${error.message || error}`}
+        type="error"
+      />
+    );
+  }
+
+  return (
+    <Spin spinning={selectedResource || items ? false : true}>
+      {selectedResource ? (
+        <div className="studio-resource">
+          <Button
+            type="primary"
+            size="small"
+            className={'studio-back-button'}
+            icon="caret-left"
+            onClick={unSelectResource}
+          >
+            {' '}
+            Back{' '}
+          </Button>
+          <ResourceCardComponent resource={selectedResource} />
+        </div>
+      ) : (
+        <ResultsTable
+          headerProperties={headerProperties}
+          items={items ? (items as Item[]) : []}
+          handleClick={selectResource}
+        />
+      )}
+    </Spin>
+  );
+};
+
+export default DashboardResultsContainer;

--- a/src/shared/containers/StudioContainer.tsx
+++ b/src/shared/containers/StudioContainer.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import { Resource } from '@bbp/nexus-sdk';
+import { useNexusContext } from '@bbp/react-nexus';
+import WorkspaceList from './WorkspaceListContainer';
+
+type StudioContainerProps = {
+  orgLabel: string;
+  projectLabel: string;
+  studioId: string;
+  workspaceId: string;
+  dashboardId: string;
+  studioResourceId: string;
+};
+
+type StudioResource = Resource<{
+  label: string;
+  description?: string;
+  workspaces: [string];
+}>;
+
+const StudioContainer: React.FunctionComponent<StudioContainerProps> = ({
+  orgLabel,
+  projectLabel,
+  studioId,
+  workspaceId,
+  dashboardId,
+  studioResourceId,
+}) => {
+  const [
+    studioResource,
+    setStudioResource,
+  ] = React.useState<StudioResource | null>(null);
+  const [workspaceIds, setWorkspaceIds] = React.useState<string[]>([]);
+  const nexus = useNexusContext();
+  React.useEffect(() => {
+    nexus.Resource.get(orgLabel, projectLabel, studioId)
+      .then(value => {
+        if (value['@type'] === 'Studio') {
+          const studioResource: StudioResource = value as StudioResource;
+          setStudioResource(studioResource);
+          const workspaceIds: string[] = studioResource['workspaces'];
+          setWorkspaceIds(workspaceIds);
+        }
+      })
+      .catch(e => {
+        // TODO: show a meaningful error to the user.
+      });
+  }, [orgLabel, projectLabel, studioId]);
+  return (
+    <>
+      {studioResource ? (
+        <>
+          <h1 className="title">{studioResource.label}</h1>
+          {studioResource.description && (
+            <p className="description">{studioResource.description}</p>
+          )}
+          <WorkspaceList
+            orgLabel={orgLabel}
+            projectLabel={projectLabel}
+            workspaceIds={workspaceIds}
+            workspaceId={workspaceId}
+            dashboardId={dashboardId}
+            studioResourceId={studioResourceId}
+          />
+        </>
+      ) : (
+        <h4>The Resource is not a Studio</h4>
+      )}
+    </>
+  );
+};
+
+export default StudioContainer;

--- a/src/shared/containers/StudioListContainer.tsx
+++ b/src/shared/containers/StudioListContainer.tsx
@@ -1,0 +1,117 @@
+import * as React from 'react';
+import { useHistory } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import { useAsyncEffect } from 'use-async-effect';
+import { useNexusContext } from '@bbp/react-nexus';
+import { Resource } from '@bbp/nexus-sdk';
+
+import { RootState } from '../store/reducers';
+import StudioList from '../components/Studio/StudioList';
+
+const DEFAULT_STUDIO_TYPE =
+  'https://bluebrainnexus.io/studio/vocabulary/Studio';
+
+const StudioListContainer: React.FunctionComponent<{
+  orgLabel: string;
+  projectLabel: string;
+}> = ({ orgLabel, projectLabel }) => {
+  const nexus = useNexusContext();
+  const history = useHistory();
+  const basePath = useSelector((state: RootState) => state.config.basePath);
+  const [
+    { busy, error, resources, total, next },
+    setResources,
+  ] = React.useState<{
+    busy: boolean;
+    error: Error | null;
+    resources: Resource<{ label: string; description?: string }>[];
+    next: string | null;
+    total: number;
+  }>({
+    next: null,
+    busy: false,
+    error: null,
+    resources: [],
+    total: 0,
+  });
+
+  const makeStudioUri = (resourceId: string) => {
+    return `${basePath}/${orgLabel}/${projectLabel}/studios/${encodeURIComponent(
+      resourceId
+    )}`;
+  };
+
+  const goToStudio = (resourceId: string) => {
+    history.push(makeStudioUri(resourceId));
+  };
+
+  useAsyncEffect(
+    async isMounted => {
+      if (!isMounted()) {
+        return;
+      }
+      try {
+        setResources({
+          next,
+          resources,
+          total,
+          busy: true,
+          error: null,
+        });
+
+        // get all resources of type studio
+        const response = await nexus.Resource.list(orgLabel, projectLabel, {
+          type: DEFAULT_STUDIO_TYPE,
+        });
+        // we need to get the metadata for each of them
+        const studios = await Promise.all(
+          response._results.map(resource =>
+            nexus.Resource.get(
+              orgLabel,
+              projectLabel,
+              encodeURIComponent(resource['@id'])
+            )
+          )
+        );
+        setResources({
+          next: response._next || null,
+          resources: studios as Resource<{
+            label: string;
+            description?: string;
+          }>[],
+          total: response._total,
+          busy: false,
+          error: null,
+        });
+      } catch (error) {
+        setResources({
+          next,
+          error,
+          resources,
+          total,
+          busy: false,
+        });
+      }
+    },
+    [
+      // Reset pagination and reload based on these props
+      orgLabel,
+      projectLabel,
+    ]
+  );
+
+  return (
+    <StudioList
+      studios={resources.map(r => ({
+        id: r['@id'],
+        name: r.label,
+        description: r.description,
+      }))}
+      busy={busy}
+      error={error}
+      goToStudio={(id: string) => goToStudio(id)}
+    ></StudioList>
+  );
+};
+
+export default StudioListContainer;

--- a/src/shared/containers/WorkspaceListContainer.tsx
+++ b/src/shared/containers/WorkspaceListContainer.tsx
@@ -1,0 +1,108 @@
+import * as React from 'react';
+import { Resource } from '@bbp/nexus-sdk';
+import { useNexusContext } from '@bbp/react-nexus';
+import TabList from '../components/Tabs/TabList';
+import DashboardList from './DashboardListContainer';
+import { useHistory } from 'react-router-dom';
+
+type WorkspaceListProps = {
+  workspaceIds: string[];
+  orgLabel: string;
+  projectLabel: string;
+  workspaceId: string;
+  dashboardId: string;
+  studioResourceId: string;
+};
+
+const WorkspaceList: React.FunctionComponent<WorkspaceListProps> = ({
+  workspaceIds,
+  orgLabel,
+  projectLabel,
+  workspaceId,
+  dashboardId,
+  studioResourceId,
+}) => {
+  const [workspaces, setWorkspaces] = React.useState<Resource[]>([]);
+  const [selectedWorkspace, setSelectedWorkspace] = React.useState<Resource>();
+  const nexus = useNexusContext();
+  const history = useHistory();
+  const selectWorkspace = (id: string, values: Resource[]) => {
+    const w = values.find(w => w['@id'] === id);
+    setSelectedWorkspace(w);
+    const path = history.location.pathname.split('/workspaces');
+    const newPath = `${path[0]}/workspaces/${encodeURIComponent(id)}`;
+    if (!history.location.pathname.includes(newPath)) {
+      history.push(newPath);
+    }
+  };
+
+  React.useEffect(() => {
+    Promise.all(
+      workspaceIds.map(workspaceId => {
+        return nexus.httpGet({
+          path: workspaceId,
+        });
+      })
+    )
+      .then(values => {
+        setWorkspaces(values);
+        let w;
+        if (
+          workspaceId !== undefined &&
+          (selectedWorkspace === undefined ||
+            selectedWorkspace['@id'] !== decodeURIComponent(workspaceId))
+        ) {
+          const id = decodeURIComponent(workspaceId);
+          w = values.find(w => w['@id'] === id);
+        } else {
+          w = values[0];
+        }
+        setSelectedWorkspace(w);
+      })
+      .catch(e => {
+        // TODO: show a meaningful error to the user.
+      });
+  }, [workspaceIds, workspaceId]);
+
+  return (
+    <>
+      {workspaces.length > 0 ? (
+        <TabList
+          items={workspaces.map(w => ({
+            label: w.label,
+            description: w.description,
+            id: w['@id'],
+          }))}
+          onSelected={(id: string) => {
+            selectWorkspace(id, workspaces);
+          }}
+          defaultActiveId={
+            workspaceId ? decodeURIComponent(workspaceId) : workspaces[0]['@id']
+          }
+          position="top"
+        >
+          {selectedWorkspace ? (
+            <div className="workspace">
+              <DashboardList
+                orgLabel={orgLabel}
+                projectLabel={projectLabel}
+                dashboards={selectedWorkspace['dashboards']}
+                workspaceId={
+                  workspaceId
+                    ? workspaceId
+                    : encodeURIComponent(selectedWorkspace['@id'])
+                }
+                dashboardId={dashboardId}
+                studioResourceId={studioResourceId}
+              />{' '}
+            </div>
+          ) : null}
+        </TabList>
+      ) : (
+        'No Workspaces are available for this Studio'
+      )}
+    </>
+  );
+};
+
+export default WorkspaceList;

--- a/src/shared/routes.ts
+++ b/src/shared/routes.ts
@@ -9,6 +9,7 @@ import ElasticSearchQueryView from './views/ElasticSearchQueryView';
 import SparqlQueryView from './views/SparqlQueryView';
 import ACLsView from './views/ACLsView';
 import UserView from './views/UserView';
+import StudioView from './views/StudioView';
 
 const routes: RouteProps[] = [
   {
@@ -37,6 +38,28 @@ const routes: RouteProps[] = [
   {
     path: '/:orgLabel/:projectLabel/resources/:resourceId',
     component: ResourceView,
+  },
+  {
+    path: '/:orgLabel/:projectLabel/studios/:studioId',
+    exact: true,
+    component: StudioView,
+  },
+  {
+    path: '/:orgLabel/:projectLabel/studios/:studioId/workspaces/:workspaceId',
+    exact: true,
+    component: StudioView,
+  },
+  {
+    path:
+      '/:orgLabel/:projectLabel/studios/:studioId/workspaces/:workspaceId/dashboards/:dashboardId',
+    exact: true,
+    component: StudioView,
+  },
+  {
+    path:
+      '/:orgLabel/:projectLabel/studios/:studioId/workspaces/:workspaceId/dashboards/:dashboardId/studioResource/:studioResourceId',
+    exact: true,
+    component: StudioView,
   },
   {
     path: '/:orgLabel/:projectLabel/:viewId/_search',

--- a/src/shared/utils/__tests__/index.spec.ts
+++ b/src/shared/utils/__tests__/index.spec.ts
@@ -6,6 +6,7 @@ import {
   stripBasename,
   getLogoutUrl,
   hasExpired,
+  camelCaseToLabelString,
   camelCaseToTitleCase,
 } from '..';
 
@@ -137,6 +138,22 @@ describe('utils functions', () => {
     });
     it('should NOT be expired', () => {
       expect(hasExpired(future)).toBeFalsy();
+    });
+  });
+  describe('camelCaseToLabelString()', () => {
+    const camelCaseString = 'somethingWonderful';
+    const notCamelCase = 'What is going on';
+    const almostCamelCase = 'FineAnyway';
+    it('should format a camelCaseString to Camel Case String', () => {
+      expect(camelCaseToLabelString(camelCaseString)).toEqual(
+        'Something Wonderful'
+      );
+    });
+    it('just return the original string', () => {
+      expect(camelCaseToLabelString(notCamelCase)).toEqual(notCamelCase);
+    });
+    it('should format the almost CamelCaseString anyway', () => {
+      expect(camelCaseToLabelString(almostCamelCase)).toEqual('Fine Anyway');
     });
   });
 });

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -262,6 +262,37 @@ export function getResourceLabelsAndIdsFromSelf(self: string) {
 }
 
 /**
+ * Returns a project and org labels from url
+ *
+ * @param {projectUrl} string
+ * @returns {
+ * [org: string, proj: string]
+ * }
+ */
+export const parseProjectUrl = (projectUrl: string) => {
+  const projectUrlR = /projects\/([\w-]+)\/([\w-]+)\/?$/;
+  const [, org, proj] = projectUrl.match(projectUrlR) as string[];
+  return [org, proj];
+};
+
+/**
+ * this function changes cameCasedString to Camel Cased String
+ * @author https://stackoverflow.com/questions/4149276/how-to-convert-camelcase-to-camel-case
+ * @param labelString String in camelCase
+ */
+export const camelCaseToLabelString = (labelString: string): string => {
+  return (
+    labelString
+      // insert a space before all caps
+      .replace(/([A-Z])/g, ' $1')
+      // upper case the first character
+      .replace(/^./, str => str.toUpperCase())
+      // remove potential white spaces from both sides of the string
+      .trim()
+  );
+};
+
+/*
  * Converts camelCase strings to Camel Case titles
  *
  * @param {string} camelCase string

--- a/src/shared/views/ElasticSearchQueryView.tsx
+++ b/src/shared/views/ElasticSearchQueryView.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { match } from 'react-router';
+import { Link } from 'react-router-dom';
 import * as queryString from 'query-string';
 import { Menu, Dropdown, Icon, Tooltip } from 'antd';
 import { ViewList, View } from '@bbp/nexus-sdk';
@@ -7,8 +8,8 @@ import { useNexusContext } from '@bbp/react-nexus';
 
 import ViewStatisticsProgress from '../components/Views/ViewStatisticsProgress';
 import ElasticSearchQueryContainer from '../containers/ElasticSearchQuery';
+import HomeIcon from '../components/HomeIcon';
 import { getResourceLabel, labelOf } from '../utils';
-import { Link } from 'react-router-dom';
 
 const ElasticSearchQueryView: React.FunctionComponent<{
   match: match<{ orgLabel: string; projectLabel: string; viewId: string }>;
@@ -68,11 +69,7 @@ const ElasticSearchQueryView: React.FunctionComponent<{
         <div className="label">
           <h1 className="name">
             <span>
-              <Link to="/">
-                <Tooltip title="Back to all organizations" placement="right">
-                  <Icon type="home" />
-                </Tooltip>
-              </Link>
+              <HomeIcon />
               {' | '}
               <Link to={`/${orgLabel}`}>{orgLabel}</Link>
               {' | '}

--- a/src/shared/views/ProjectView.tsx
+++ b/src/shared/views/ProjectView.tsx
@@ -5,7 +5,7 @@ import {
   DEFAULT_ELASTIC_SEARCH_VIEW_ID,
 } from '@bbp/nexus-sdk';
 import { useNexusContext, AccessControl } from '@bbp/react-nexus';
-import { notification, Popover, Divider, Tooltip, Icon, Switch } from 'antd';
+import { notification, Popover, Divider, Switch } from 'antd';
 import { Link } from 'react-router-dom';
 
 import ViewStatisticsContainer from '../components/Views/ViewStatisticsProgress';
@@ -13,6 +13,8 @@ import SideMenu from '../components/Menu/SideMenu';
 import FileUploadContainer from '../containers/FileUploadContainer';
 import ResourceFormContainer from '../containers/ResourceFormContainer';
 import ResourceListBoardContainer from '../containers/ResourceListBoardContainer';
+import StudioListContainer from '../containers/StudioListContainer';
+import HomeIcon from '../components/HomeIcon';
 
 const ProjectView: React.FunctionComponent<{
   match: match<{ orgLabel: string; projectLabel: string }>;
@@ -45,7 +47,7 @@ const ProjectView: React.FunctionComponent<{
       { pollIntervalMs: 300 }
     ).subscribe(data => {
       if (!totalEvents) {
-        totalEvents = data.totalEvents;         
+        totalEvents = data.totalEvents;
       } else if (data.totalEvents !== totalEvents) {
         setRefreshLists(!refreshLists);
         subscription.unsubscribe();
@@ -67,7 +69,8 @@ const ProjectView: React.FunctionComponent<{
           busy: false,
           error: null,
         });
-      }).catch(error => {
+      })
+      .catch(error => {
         notification.error({
           message: `Could not load project ${projectLabel}`,
           description: error.message,
@@ -78,9 +81,7 @@ const ProjectView: React.FunctionComponent<{
           busy: false,
         });
       });
-    },
-    [orgLabel, projectLabel]
-  );
+  }, [orgLabel, projectLabel]);
 
   return (
     <div className="project-view">
@@ -89,11 +90,7 @@ const ProjectView: React.FunctionComponent<{
           <div className="project-banner">
             <div className="label">
               <h1 className="name">
-                <Link to="/">
-                  <Tooltip title="Back to all organizations" placement="right">
-                    <Icon type="home" />
-                  </Tooltip>
-                </Link>
+                <HomeIcon />
                 {' | '}
                 <span>
                   <Link to={`/${orgLabel}`}>{orgLabel}</Link>
@@ -173,11 +170,18 @@ const ProjectView: React.FunctionComponent<{
               </SideMenu>
             </div>
           </div>
-          <ResourceListBoardContainer
-            orgLabel={orgLabel}
-            projectLabel={projectLabel}
-            refreshLists={refreshLists}
-          />
+          <div className="list-board">
+            <div className="wrapper">
+              <ResourceListBoardContainer
+                orgLabel={orgLabel}
+                projectLabel={projectLabel}
+              />
+              <StudioListContainer
+                orgLabel={orgLabel}
+                projectLabel={projectLabel}
+              />
+            </div>
+          </div>
         </>
       )}
     </div>

--- a/src/shared/views/ResourceView.tsx
+++ b/src/shared/views/ResourceView.tsx
@@ -20,6 +20,7 @@ import ResourceEditorContainer from '../containers/ResourceEditor';
 import ImagePreviewContainer from '../containers/ImagePreviewContainer';
 import useMeasure from '../hooks/useMeasure';
 import SchemaLinkContainer from '../containers/SchemaLink';
+import HomeIcon from '../components/HomeIcon';
 
 const TabPane = Tabs.TabPane;
 export const DEFAULT_ACTIVE_TAB_KEY = '#JSON';
@@ -196,6 +197,8 @@ const ResourceView: React.FunctionComponent<ResourceViewProps> = props => {
           {!!resource && !!latestResource && !error && (
             <>
               <h1 className="name">
+                <HomeIcon />
+                {' | '}
                 <span>
                   <a onClick={() => goToOrg(orgLabel)}>{orgLabel}</a> |{' '}
                   <a onClick={() => goToProject(orgLabel, projectLabel)}>

--- a/src/shared/views/SparqlQueryView.tsx
+++ b/src/shared/views/SparqlQueryView.tsx
@@ -1,13 +1,14 @@
 import * as React from 'react';
 import { match } from 'react-router';
+import { Link } from 'react-router-dom';
 import * as queryString from 'query-string';
-import { Menu, Dropdown, Icon, notification, Tooltip } from 'antd';
+import { Menu, Dropdown, Icon, notification } from 'antd';
 import { ViewList, View } from '@bbp/nexus-sdk';
 import { useNexusContext } from '@bbp/react-nexus';
-import { Link } from 'react-router-dom';
 
 import ViewStatisticsProgress from '../components/Views/ViewStatisticsProgress';
 import SparqlQueryContainer from '../containers/SparqlQuery';
+import HomeIcon from '../components/HomeIcon';
 import { getResourceLabel, labelOf } from '../utils';
 
 const SparqlQueryView: React.FunctionComponent<{
@@ -69,11 +70,7 @@ const SparqlQueryView: React.FunctionComponent<{
         <div className="label">
           <h1 className="name">
             <span>
-              <Link to="/">
-                <Tooltip title="Back to all organizations" placement="right">
-                  <Icon type="home" />
-                </Tooltip>
-              </Link>
+              <HomeIcon />
               {' | '}
               <Link to={`/${orgLabel}`}>{orgLabel}</Link>
               {' | '}

--- a/src/shared/views/StudioView.tsx
+++ b/src/shared/views/StudioView.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import { match } from 'react-router';
+import { Link } from 'react-router-dom';
+import { Tooltip, Icon } from 'antd';
+
+import StudioContainer from '../containers/StudioContainer';
+
+type StudioViewProps = {
+  match: match<{
+    orgLabel: string;
+    projectLabel: string;
+    studioId: string;
+    workspaceId: string;
+    dashboardId: string;
+    studioResourceId: string;
+  }>;
+};
+
+const StudioView: React.FunctionComponent<StudioViewProps> = props => {
+  const { match } = props;
+  const {
+    params: {
+      orgLabel,
+      projectLabel,
+      studioId,
+      workspaceId,
+      dashboardId,
+      studioResourceId,
+    },
+  } = match;
+  return (
+    <>
+      <div className="project-banner no-bg" style={{ marginBottom: 20 }}>
+        <div className="label">
+          <h1 className="name">
+            <span>
+              <Link to="/">
+                <Tooltip title="Back to all organizations" placement="right">
+                  <Icon type="home" />
+                </Tooltip>
+              </Link>
+              {' | '}
+              <Link to={`/${orgLabel}`}>{orgLabel}</Link>
+              {' | '}
+              <Link to={`/${orgLabel}/${projectLabel}`}>{projectLabel}</Link>
+            </span>
+          </h1>
+        </div>
+      </div>
+      <div className="studio-view">
+        <StudioContainer
+          orgLabel={orgLabel}
+          projectLabel={projectLabel}
+          studioId={studioId}
+          workspaceId={workspaceId}
+          dashboardId={dashboardId}
+          studioResourceId={studioResourceId}
+        />
+      </div>
+    </>
+  );
+};
+
+export default StudioView;


### PR DESCRIPTION
* 799 cancel button (#431)

* Add a cancel button to ResourceEditor

Allow user to cancel the edit and go back to non-edit view.

* 806 add home logo to views (#432)

* Add home button to resource view

* Add home icon to sparql query view

* Update elastic search view

* Fix indentation

* Feature/816 studio master (#436)

* create studio list component (#356)

* create studiolist compoent. Fixes BlueBrain/nexus#855

* don't use infinite search anymore + container that handles business logic. Fixes BlueBrain/nexus#856

* adding studiolist on project page

* styling and css

* reverting a520a10ccbc95847d2a1a9fccc30d89a09c10e83 and 29ba2e01a6fb470af1f0842c369bd7a81fb191af (can't commit directly to feature branch, oops. I've changed github's settings

* fetch metadata for all resources (#361)

* eneable studio list view and tweak styling (#363)

* remove unsused overflow rule (#365)

* Add studio view and studios path (#366)

- Added a route for studios under project path.
- Added an empty View for studio.

* Add WorkSpaceList and DashBoardList (#372)

* Add WorkSpaceList and DashBoardList

 Add containers and components to display work spaces and their
 dashboards.

tslint

* Refactor test

* Update src/shared/containers/DashBoardList.tsx

Co-Authored-By: Julien Machon <julienmachon@gmail.com>

* Update src/shared/views/StudioView.tsx

Co-Authored-By: Julien Machon <julienmachon@gmail.com>

* Addressed PR comments.

* - nested style for  studio

- Added StudioContainer

* display studio name and description + add breadcrumb

* use Resource.get, not httpGet

* remove comment

* remove comment

* make sure dashboards don't get refreshed multiple times on tab change

* address github comments

* rename variable without camlcase

* remove unused imports

* List Dashboard Resources as a Table (#388)

* List Dashboard Resources as a Table

Adds container/component to list resources in a Dashboard.

* 890 remove useAsyncEffect (#397)

* Refactor with React.UseEffect and remove UseAsyncEffect

Removes UseAsyncEffect from DashboardList, StudioContainer and
WorkspaceList.

* 834 display resource details (#394)

* Navigate to Resource Details from Dashboard Results

When user clicks on result row, navigate to resuorce details.

* Refactor handle click

* refactor history

* Remove basepath

* Display Reasource Details in place

Instead of linking to resource page, display this in place.

* remove unused imports

* 834 display resource details with routes (#429)

* Added routes to studio

Added routes to studio, to allow URL to directly load a studio resource.

* move the style up to view (#437)