### PR TITLE
Update derived vlaues on change of rawData

### DIFF
--- a/src/shared/components/ResourceEditor/index.tsx
+++ b/src/shared/components/ResourceEditor/index.tsx
@@ -60,6 +60,8 @@ const ResourceEditor: React.FunctionComponent<ResourceEditorProps> = props => {
 
   React.useEffect(() => {
     setEditing(false);
+    setStringValue(JSON.stringify(rawData, null, 2));
+    setParsedValue(rawData);
   }, [rawData]); // only runs when Editor receives new resource to edit
 
   const handleChange = (editor: any, data: any, value: any) => {


### PR DESCRIPTION
This PR fixes a bug caused in #431 . The expand/show metadata stopped working after that PR. 