### PR TITLE
Download image of graph

### DIFF
--- a/src/shared/components/Graph/GraphControlPanel.tsx
+++ b/src/shared/components/Graph/GraphControlPanel.tsx
@@ -4,22 +4,42 @@ import { Alert, Button } from 'antd';
 import { DEFAULT_LAYOUT, LAYOUTS } from './LayoutDefinitions';
 
 import './GraphControlPanel.less';
+import { downloadCanvasAsImage } from '../../utils/download';
 
 const GraphControlPanel: React.FunctionComponent<{
-    onReset?(): void;
-    onCollapse?(): void;
-    collapsed?: boolean;
-    onLayoutChange?(type: string): void;
-    layout?: string;
-    loading: boolean;
-    onRecenter?(): void;
-  }> = ({ onReset, onCollapse, collapsed, onLayoutChange, layout = DEFAULT_LAYOUT, loading, onRecenter }) => {
+  label: string;
+  onReset?(): void;
+  onCollapse?(): void;
+  collapsed?: boolean;
+  onLayoutChange?(type: string): void;
+  layout?: string;
+  loading: boolean;
+  onRecenter?(): void;
+}> = ({
+  label,
+  onReset,
+  onCollapse,
+  collapsed,
+  onLayoutChange,
+  layout = DEFAULT_LAYOUT,
+  loading,
+  onRecenter,
+}) => {
   const [showAlert, setShowAlert] = React.useState(true);
 
   const handleLayoutClick = (type: string) => () => {
     onLayoutChange && onLayoutChange(type);
   };
-  
+
+  const handleDownload = () => {
+    const canvas = document.querySelector(
+      'canvas[data-id="layer2-node"]' // cytoscape canvas
+    ) as HTMLCanvasElement;
+    if (canvas) {
+      downloadCanvasAsImage(`${label} Graph`, canvas);
+    }
+  };
+
   return (
     <div className="graph-control-panel">
       <div className="controls">
@@ -38,6 +58,9 @@ const GraphControlPanel: React.FunctionComponent<{
           })}
         </div>
         <div>
+          <Button icon="download" size="small" onClick={handleDownload}>
+            Save Image
+          </Button>
           <Button
             type={collapsed ? 'primary' : 'default'}
             size="small"
@@ -71,6 +94,6 @@ const GraphControlPanel: React.FunctionComponent<{
       )}
     </div>
   );
-}
+};
 
 export default GraphControlPanel;

--- a/src/shared/containers/GraphContainer/index.tsx
+++ b/src/shared/containers/GraphContainer/index.tsx
@@ -241,13 +241,14 @@ const GraphContainer: React.FunctionComponent<{
 
   const handleRecenter = () => {
     setCentered(!centered);
-  }
+  };
 
   if (error) return null;
 
   return (
     <>
       <GraphControlPanel
+        label={getResourceLabel(resource)}
         onReset={handleReset}
         collapsed={collapsed}
         onCollapse={handleCollapse}

--- a/src/shared/utils/download.ts
+++ b/src/shared/utils/download.ts
@@ -11,3 +11,15 @@ export const download = (filename: string, mediaType: string, data: any) => {
     document.body.removeChild(elem);
   }
 };
+
+export const downloadCanvasAsImage = (
+  filename: string,
+  canvas: HTMLCanvasElement
+) => {
+  const link = document.createElement('a');
+  link.download = filename;
+  const img = canvas.toDataURL('image/png');
+  link.href = img;
+  link.click();
+  link.remove();
+};


### PR DESCRIPTION
fixes https://github.com/BlueBrain/nexus/issues/916

Downloads a PNG image (with a transparent background) of the graph, 
the name being `${myResourceLabel} Graph.png`

![Screenshot 2019-12-11 at 15 44 27](https://user-images.githubusercontent.com/5485824/70631316-4e3dcb00-1c2d-11ea-98b9-22870add33fd.png)

![700a3c32-d005-4fae-a6a0-04b26f8fabf8 Graph](https://user-images.githubusercontent.com/5485824/70631433-73cad480-1c2d-11ea-8b73-b29a3934c3ba.png)

