### PR TITLE
Fix window reload

### DIFF
--- a/src/shared/containers/DashboardEditor/CreateDashboardContainer.tsx
+++ b/src/shared/containers/DashboardEditor/CreateDashboardContainer.tsx
@@ -56,7 +56,7 @@ const CreateDashboardContainer: React.FunctionComponent<{
         const workspace = await nexus.Resource.get<Resource>(
           orgLabel,
           projectLabel,
-          workspaceId
+          workspaceId,
         );
         const workspaceSource = await nexus.Resource.getSource<{
           [key: string]: any;
@@ -83,8 +83,8 @@ const CreateDashboardContainer: React.FunctionComponent<{
         // TODO: find a better way to trigger dashboard reloads
         // So that recently edited dashboards can appear
         // having the correct values
-        console.log('done!');
-        
+        setBusy(false);
+        setShowCreateModal(false);
         !!onSuccess && onSuccess();
       } catch (error) {
         notification.error({
@@ -92,9 +92,9 @@ const CreateDashboardContainer: React.FunctionComponent<{
           description: error.reason || error.message,
         });
       } finally {
-        console.log('done!');
-        
+        setBusy(false);
         !!onSuccess && onSuccess();
+        setShowCreateModal(false);
       }
     }
   };

--- a/src/shared/containers/DashboardEditor/CreateDashboardContainer.tsx
+++ b/src/shared/containers/DashboardEditor/CreateDashboardContainer.tsx
@@ -29,6 +29,12 @@ const CreateDashboardContainer: React.FunctionComponent<{
   const nexus = useNexusContext();
   const [busy, setBusy] = React.useState(false);
 
+  const onSubmit = () => {
+    setBusy(false);
+    setShowCreateModal(false);
+    !!onSuccess && onSuccess();
+  }
+
   const handleSubmit = async () => {
     if (formRef.current && formRef.current.form) {
       formRef.current.form.validateFields();
@@ -79,22 +85,14 @@ const CreateDashboardContainer: React.FunctionComponent<{
             }
           );
         }
-
-        // TODO: find a better way to trigger dashboard reloads
-        // So that recently edited dashboards can appear
-        // having the correct values
-        setBusy(false);
-        setShowCreateModal(false);
-        !!onSuccess && onSuccess();
+        onSubmit();
       } catch (error) {
         notification.error({
           message: `Could not create dashboard`,
           description: error.reason || error.message,
         });
       } finally {
-        setBusy(false);
-        !!onSuccess && onSuccess();
-        setShowCreateModal(false);
+        onSubmit();
       }
     }
   };

--- a/src/shared/containers/DashboardEditor/CreateDashboardContainer.tsx
+++ b/src/shared/containers/DashboardEditor/CreateDashboardContainer.tsx
@@ -16,11 +16,13 @@ const CreateDashboardContainer: React.FunctionComponent<{
   projectLabel: string;
   workspaceId: string;
   viewId?: string;
+  onSuccess?(): void;
 }> = ({
   orgLabel,
   projectLabel,
   workspaceId,
   viewId = DEFAULT_SPARQL_VIEW_ID,
+  onSuccess,
 }) => {
   const [showCreateModal, setShowCreateModal] = React.useState(false);
   const formRef = React.useRef<DashboardConfigEditorProps>(null);
@@ -81,14 +83,18 @@ const CreateDashboardContainer: React.FunctionComponent<{
         // TODO: find a better way to trigger dashboard reloads
         // So that recently edited dashboards can appear
         // having the correct values
-        location.reload();
+        console.log('done!');
+        
+        !!onSuccess && onSuccess();
       } catch (error) {
         notification.error({
           message: `Could not create dashboard`,
           description: error.reason || error.message,
         });
       } finally {
-        setBusy(false);
+        console.log('done!');
+        
+        !!onSuccess && onSuccess();
       }
     }
   };

--- a/src/shared/containers/DashboardListContainer.tsx
+++ b/src/shared/containers/DashboardListContainer.tsx
@@ -60,7 +60,7 @@ const DashboardList: React.FunctionComponent<DashboardListProps> = ({
     history.push(newPath);
   };
 
-  React.useEffect(() => {
+  React.useEffect(() => {    
     Promise.all(
       dashboards.map(dashboardObject => {
         return nexus.Resource.get(
@@ -86,7 +86,7 @@ const DashboardList: React.FunctionComponent<DashboardListProps> = ({
       .catch(e => {
         // TODO: show a meaningful error to the user.
       });
-  }, [orgLabel, projectLabel, dashboardId]);
+  }, [orgLabel, projectLabel, dashboardId, dashboards]);
 
   const handleElementClick = (stringifiedIndex: string) => {
     const dashboard = dashboardResources[Number(stringifiedIndex)];

--- a/src/shared/containers/DashboardListContainer.tsx
+++ b/src/shared/containers/DashboardListContainer.tsx
@@ -60,7 +60,7 @@ const DashboardList: React.FunctionComponent<DashboardListProps> = ({
     history.push(newPath);
   };
 
-  React.useEffect(() => {    
+  React.useEffect(() => {
     Promise.all(
       dashboards.map(dashboardObject => {
         return nexus.Resource.get(

--- a/src/shared/containers/DashboardListContainer.tsx
+++ b/src/shared/containers/DashboardListContainer.tsx
@@ -18,6 +18,7 @@ interface DashboardListProps {
   workspaceId: string;
   dashboardId: string;
   studioResourceId: string;
+  onAddDashboard?(): void;
 }
 
 const DashboardList: React.FunctionComponent<DashboardListProps> = ({
@@ -27,6 +28,7 @@ const DashboardList: React.FunctionComponent<DashboardListProps> = ({
   workspaceId,
   dashboardId,
   studioResourceId,
+  onAddDashboard,
 }) => {
   const history = useHistory();
   const [dashboardResources, setDashboardResources] = React.useState<
@@ -128,6 +130,7 @@ const DashboardList: React.FunctionComponent<DashboardListProps> = ({
             orgLabel={orgLabel}
             projectLabel={projectLabel}
             workspaceId={workspaceId}
+            onSuccess={onAddDashboard}
           />
         }
         onEditClick={handleElementClick}

--- a/src/shared/containers/DashboardResultsContainer.tsx
+++ b/src/shared/containers/DashboardResultsContainer.tsx
@@ -154,7 +154,7 @@ const DashboardResultsContainer: React.FunctionComponent<{
     });
   }, [orgLabel, projectLabel, dataQuery, viewId]);
 
-  if (error) {    
+  if (error) {
     return (
       <Alert
         message="Error loading dashboard"

--- a/src/shared/containers/DashboardResultsContainer.tsx
+++ b/src/shared/containers/DashboardResultsContainer.tsx
@@ -26,6 +26,10 @@ type Item = {
   [key: string]: any;
 };
 
+type NexusSparqlError = {
+  reason: string;
+};
+
 const DashboardResultsContainer: React.FunctionComponent<{
   dataQuery: string;
   orgLabel: string;
@@ -45,7 +49,7 @@ const DashboardResultsContainer: React.FunctionComponent<{
 }) => {
   const history = useHistory();
   const [selectedResource, setSelectedResource] = React.useState<Resource>();
-  const [error, setError] = React.useState<Error>();
+  const [error, setError] = React.useState<NexusSparqlError | Error>();
   const [items, setItems] = React.useState<any[]>();
   const [headerProperties, setHeaderProperties] = React.useState<any[]>();
   const nexus = useNexusContext();
@@ -150,11 +154,11 @@ const DashboardResultsContainer: React.FunctionComponent<{
     });
   }, [orgLabel, projectLabel, dataQuery, viewId]);
 
-  if (error) {
+  if (error) {    
     return (
       <Alert
         message="Error loading dashboard"
-        description={`Something went wrong: ${error.message || error}`}
+        description={`Something went wrong. ${(error as NexusSparqlError).reason || (error as Error).message}`}
         type="error"
       />
     );

--- a/src/shared/containers/WorkspaceListContainer.tsx
+++ b/src/shared/containers/WorkspaceListContainer.tsx
@@ -47,7 +47,7 @@ const WorkspaceList: React.FunctionComponent<WorkspaceListProps> = ({
     }
   };
 
-  React.useEffect(() => {
+  React.useEffect(() => {    
     Promise.all(
       workspaceIds.map(workspaceId => {
         return nexus.httpGet({

--- a/src/shared/containers/WorkspaceListContainer.tsx
+++ b/src/shared/containers/WorkspaceListContainer.tsx
@@ -116,6 +116,7 @@ const WorkspaceList: React.FunctionComponent<WorkspaceListProps> = ({
               }
               dashboardId={dashboardId}
               studioResourceId={studioResourceId}
+              onAddDashboard={onListUpdate}
             />{' '}
           </div>
         ) : null}

--- a/src/shared/containers/WorkspaceListContainer.tsx
+++ b/src/shared/containers/WorkspaceListContainer.tsx
@@ -47,7 +47,7 @@ const WorkspaceList: React.FunctionComponent<WorkspaceListProps> = ({
     }
   };
 
-  React.useEffect(() => {    
+  React.useEffect(() => {
     Promise.all(
       workspaceIds.map(workspaceId => {
         return nexus.httpGet({


### PR DESCRIPTION
Recently edited dashboards appear in a list without reloading a whole page

### For testing:
- go to any studio
- click 'add dashboard' and add a new dashboard using a modal
- notice the list is updated as soon as you submit a new dashboard