### PR TITLE
Bugfix/945 studio workspace id list

### DIFF
--- a/src/shared/components/Studio/EditStudio.tsx
+++ b/src/shared/components/Studio/EditStudio.tsx
@@ -4,11 +4,17 @@ import { Button, Modal, Tooltip } from 'antd';
 
 import StudioEditorForm from './StudioEditorForm';
 
-type StudioResource = Resource<{
+export type StudioResource = Resource<{
   label: string;
   description?: string;
-  workspaces?: [string];
+  workspaces?: { '@id': string }[];
 }>;
+
+export type StudioResourceResponse = Resource & {
+  label: StudioResource['label'];
+  description?: StudioResource['description'];
+  workspaces?: string[];
+};
 
 const EditStudio: React.FC<{
   studio: StudioResource | null;
@@ -19,12 +25,18 @@ const EditStudio: React.FC<{
   const handleUpdate = (label: string, desription?: string) => {
     setShowModal(false);
     onSave && onSave(label, desription);
-  }
+  };
 
   return (
     <>
       <Tooltip placement="topLeft" title="Edit Studio" arrowPointAtCenter>
-        <Button className="studio-button" icon="edit" onClick={() => setShowModal(true)}>Edit Studio</Button>
+        <Button
+          className="studio-button"
+          icon="edit"
+          onClick={() => setShowModal(true)}
+        >
+          Edit Studio
+        </Button>
       </Tooltip>
       <Modal
         title="Edit Studio"
@@ -33,9 +45,9 @@ const EditStudio: React.FC<{
         onCancel={() => setShowModal(false)}
       >
         <StudioEditorForm saveStudio={handleUpdate} studio={studio} />
-      </Modal>  
+      </Modal>
     </>
   );
-}
+};
 
 export default EditStudio;

--- a/src/shared/components/Studio/StudioEditorForm.tsx
+++ b/src/shared/components/Studio/StudioEditorForm.tsx
@@ -2,17 +2,12 @@ import * as React from 'react';
 import { Resource } from '@bbp/nexus-sdk';
 import { Input, Form, Tooltip, Icon, Button } from 'antd';
 import { WrappedFormUtils } from 'antd/lib/form/Form';
-
-type StudioResource = Resource<{
-  label: string;
-  description?: string;
-  workspaces?: [string];
-}>;
+import { StudioResource } from './EditStudio';
 
 const StudioEditorForm: React.FC<{
   form: WrappedFormUtils;
   saveStudio?(label: string, description?: string): void;
-  studio?: StudioResource | null; 
+  studio?: StudioResource | null;
 }> = ({ form, saveStudio, studio }) => {
   const { getFieldDecorator } = form;
 
@@ -78,7 +73,7 @@ const StudioEditorForm: React.FC<{
       </Button>
     </Form>
   );
-}
+};
 
 export default Form.create<{
   form: WrappedFormUtils;

--- a/src/shared/containers/AddWorkspaceContainer.tsx
+++ b/src/shared/containers/AddWorkspaceContainer.tsx
@@ -65,7 +65,6 @@ const AddWorkspaceContainer: React.FC<{
           studioSource.workspaces
         ),
       };
-      console.log({ studioUpdatePayload });
       await nexus.Resource.update(
         orgLabel,
         projectLabel,

--- a/src/shared/containers/CreateStudioContainer.tsx
+++ b/src/shared/containers/CreateStudioContainer.tsx
@@ -21,6 +21,7 @@ const CreateStudioContainer: React.FC<{
     description,
     '@context': STUDIO_CONTEXT['@id'],
     '@type': DEFAULT_STUDIO_TYPE,
+    workspaces: [],
   });
 
   const makeStudioContext = async () => {
@@ -32,11 +33,7 @@ const CreateStudioContainer: React.FC<{
       );
     } catch (error) {
       if (error['@type'] === 'NotFound') {
-        // @ts-ignore TODO: update resource type in SDK to allow nested objects
-        // https://github.com/BlueBrain/nexus/issues/937
-        await nexus.Resource.create(orgLabel, projectLabel, {
-          ...STUDIO_CONTEXT,
-        });
+        await nexus.Resource.create(orgLabel, projectLabel, STUDIO_CONTEXT);
         return;
       }
       throw error;

--- a/src/shared/containers/WorkspaceListContainer.tsx
+++ b/src/shared/containers/WorkspaceListContainer.tsx
@@ -28,7 +28,6 @@ const WorkspaceList: React.FunctionComponent<WorkspaceListProps> = ({
   studioResource,
   onListUpdate,
 }) => {
-  console.log({ workspaceIds });
   const [workspaces, setWorkspaces] = React.useState<Resource[]>([]);
   const [selectedWorkspace, setSelectedWorkspace] = React.useState<Resource>();
   const nexus = useNexusContext();

--- a/src/shared/containers/WorkspaceListContainer.tsx
+++ b/src/shared/containers/WorkspaceListContainer.tsx
@@ -5,15 +5,10 @@ import TabList from '../components/Tabs/TabList';
 import DashboardList from './DashboardListContainer';
 import { useHistory } from 'react-router-dom';
 import AddWorkspaceContainer from './AddWorkspaceContainer';
-
-type StudioResource = Resource<{
-  label: string;
-  description?: string;
-  workspaces?: [string];
-}>;
+import { StudioResource } from '../components/Studio/EditStudio';
 
 type WorkspaceListProps = {
-  workspaceIds: string[];
+  workspaceIds: { '@id': string }[];
   orgLabel: string;
   projectLabel: string;
   workspaceId: string;
@@ -33,6 +28,7 @@ const WorkspaceList: React.FunctionComponent<WorkspaceListProps> = ({
   studioResource,
   onListUpdate,
 }) => {
+  console.log({ workspaceIds });
   const [workspaces, setWorkspaces] = React.useState<Resource[]>([]);
   const [selectedWorkspace, setSelectedWorkspace] = React.useState<Resource>();
   const nexus = useNexusContext();
@@ -49,7 +45,7 @@ const WorkspaceList: React.FunctionComponent<WorkspaceListProps> = ({
 
   React.useEffect(() => {
     Promise.all(
-      workspaceIds.map(workspaceId => {
+      workspaceIds.map(({ '@id': workspaceId }) => {
         return nexus.Resource.get(
           orgLabel,
           projectLabel,


### PR DESCRIPTION
- updates studio using the source, so it won't add the metadata 
- removes duplicate instances of `StudioResource`
- updates studio with a `workspaces` property as a value of ```{"@id": string}[]``` to be graph-compliant

fixes: https://github.com/BlueBrain/nexus/issues/945