### PR TITLE
951 nexus plugin component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .cache/
 .DS_Store
 dist/
+plugins/
 node_modules/
 storybook-static/
 coverage/

--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ docker build . --tag=nexus-web
 - `GTAG`: The Google Analytics Identifier. GA won't be present unless an ID is specified.
 - `SENTRY_DSN`: The sentry URL Nexus Web needs to report errors to. Default is undefined.
 
+## Documentation
+
+### Nexus Plugins
+
+In development mode, you can copy/paste your plugins in the `/plugins` folder. If you want to develop your own plugins, have a look a the [plugin development documentation](./docs/pluginDevelopment.md).
+
 ## Getting involved
 
 Issue tracking is centralized into [the main Blue Brain Nexus repository](https://github.com/BlueBrain/nexus).

--- a/docs/pluginDevelopment.md
+++ b/docs/pluginDevelopment.md
@@ -1,0 +1,18 @@
+# Nexus Plugins development
+
+Your plugin need to export a default function with the following signature:
+
+```typescript
+export default ({ ref: HTMLElement, nexusClient: NexusClient, resource: Resource<T> }) => {
+  return () => {
+    // optional callback   when your plugin is unmounted from the page
+  };
+};
+```
+
+Nexus Plugin uses [SystemJS](https://github.com/systemjs/systemjs).
+
+You have to transpile and bundle your code using SystemJS as output:
+
+- with [rollup](https://rollupjs.org/guide/en/#outputformat): use `system` as output format
+- with [webpack](https://webpack.js.org/configuration/output/#outputlibrarytarget): use `system` as `outputTarget`

--- a/package.json
+++ b/package.json
@@ -54,7 +54,9 @@
     "redux-oidc": "^3.1.2",
     "redux-thunk": "^2.3.0",
     "resize-observer-polyfill": "^1.5.1",
+    "systemjs": "^6.1.7",
     "ts-debounce": "^1.0.0",
+    "ts-invariant": "^0.4.4",
     "use-async-effect": "^2.2.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "redux-oidc": "^3.1.2",
     "redux-thunk": "^2.3.0",
     "resize-observer-polyfill": "^1.5.1",
-    "systemjs": "^6.1.7",
     "ts-debounce": "^1.0.0",
     "ts-invariant": "^0.4.4",
     "use-async-effect": "^2.2.1"

--- a/src/server/html.ts
+++ b/src/server/html.ts
@@ -24,6 +24,7 @@ const html = ({
       ${helmet.meta.toString()}
       ${helmet.link.toString()}
       <link rel="shortcut icon" type="image/png" href="${icon}"/>
+      <script src="https://www.unpkg.com/systemjs@6.1.7/dist/system.js"></script>
       ${
         process.env.NODE_ENV !== 'production'
           ? ''

--- a/src/server/html.ts
+++ b/src/server/html.ts
@@ -30,10 +30,7 @@ const html = ({
       {
         "imports": {
           "react": "https://unpkg.com/react@16.12.0/umd/react.development.js",
-          "react-dom": "https://unpkg.com/react-dom@16/umd/react-dom.development.js",
-          "lodash": "https://unpkg.com/lodash@4.17.10/lodash.js",
-          "vue": "https://unpkg.com/vue@2.6.10/dist/vue.js",
-          "vue-runtime-helpers": "https://unpkg.com/vue-runtime-helpers@1.1.2/dist/index.mjs"
+          "react-dom": "https://unpkg.com/react-dom@16/umd/react-dom.development.js"
         }
       }
     </script>

--- a/src/server/html.ts
+++ b/src/server/html.ts
@@ -25,6 +25,18 @@ const html = ({
       ${helmet.link.toString()}
       <link rel="shortcut icon" type="image/png" href="${icon}"/>
       <script src="https://www.unpkg.com/systemjs@6.1.7/dist/system.js"></script>
+      <script src="https://www.unpkg.com/systemjs@6.1.7/dist/extras/named-exports.js"></script>
+      <script type="systemjs-importmap">
+      {
+        "imports": {
+          "react": "https://unpkg.com/react@16.12.0/umd/react.development.js",
+          "react-dom": "https://unpkg.com/react-dom@16/umd/react-dom.development.js",
+          "lodash": "https://unpkg.com/lodash@4.17.10/lodash.js",
+          "vue": "https://unpkg.com/vue@2.6.10/dist/vue.js",
+          "vue-runtime-helpers": "https://unpkg.com/vue-runtime-helpers@1.1.2/dist/index.mjs"
+        }
+      }
+    </script>
       ${
         process.env.NODE_ENV !== 'production'
           ? ''

--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { resolve, join } from 'path';
 import * as express from 'express';
 import * as cookieParser from 'cookie-parser';
 import * as morgan from 'morgan';
@@ -30,6 +30,10 @@ app.use(`${base}/public`, express.static(join(__dirname, 'public')));
 // if in Dev mode, setup HMR and all the fancy stuff
 if (process.env.NODE_ENV !== 'production') {
   const { setupDevEnvironment } = require('./dev');
+  app.use(
+    `${base}/public/plugins`,
+    express.static(resolve(__dirname, '../plugins'))
+  );
   setupDevEnvironment(app);
 }
 

--- a/src/shared/containers/NexusPlugin.tsx
+++ b/src/shared/containers/NexusPlugin.tsx
@@ -30,7 +30,6 @@ export default class RenderRemoteComponent extends React.Component<
   }
 
   componentDidCatch(e: Error) {
-    console.error(e);
     this.setState({ hasError: true, loading: false });
   }
 
@@ -38,21 +37,22 @@ export default class RenderRemoteComponent extends React.Component<
     // @ts-ignore
     window.System.import(this.props.url)
       .then(
-        (module: { default: (ref: HTMLDivElement | null) => () => void }) => {
+        (module: {
+          default: ({ ref }: { ref: HTMLDivElement | null }) => () => void;
+        }) => {
           this.setState({
             hasError: false,
             loading: false,
           });
-          this.pluginCallback = module.default(this.container.current);
+          this.pluginCallback = module.default({ ref: this.container.current });
         }
       )
       .catch((error: Error) => {
-        console.error(error);
         this.setState({ hasError: true, loading: false });
       });
   }
 
-  componentWillMount() {
+  componentWillUnmount() {
     this.pluginCallback();
   }
 

--- a/src/shared/containers/NexusPlugin.tsx
+++ b/src/shared/containers/NexusPlugin.tsx
@@ -1,0 +1,68 @@
+/**
+ * This component requires SystemJS to be available globally (in window)
+ */
+import * as React from 'react';
+import invariant from 'ts-invariant';
+
+const warningMessage =
+  'SystemJS not found. ' +
+  'To load plugins, Nexus Web requires SystemJS to be available globally.' +
+  ' You can find out more here https://github.com/systemjs/systemjs';
+
+export type NexusPluginProps = {
+  url: string;
+};
+
+export default class RenderRemoteComponent extends React.Component<
+  NexusPluginProps,
+  { hasError: boolean; loading: boolean }
+> {
+  private container: React.RefObject<HTMLDivElement>;
+  private pluginCallback: () => void;
+
+  constructor(props: NexusPluginProps) {
+    super(props);
+    this.state = { hasError: false, loading: true };
+    this.container = React.createRef();
+    this.pluginCallback = () => {};
+    // @ts-ignore
+    invariant(window.System, warningMessage);
+  }
+
+  componentDidCatch(e: Error) {
+    console.error(e);
+    this.setState({ hasError: true, loading: false });
+  }
+
+  componentDidMount() {
+    // @ts-ignore
+    window.System.import(this.props.url)
+      .then(
+        (module: { default: (ref: HTMLDivElement | null) => () => void }) => {
+          this.setState({
+            hasError: false,
+            loading: false,
+          });
+          this.pluginCallback = module.default(this.container.current);
+        }
+      )
+      .catch((error: Error) => {
+        console.error(error);
+        this.setState({ hasError: true, loading: false });
+      });
+  }
+
+  componentWillMount() {
+    this.pluginCallback();
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <p>Error loading plugin {this.props.url}</p>;
+    }
+    if (this.state.loading) {
+      return <p>loading plugin {this.props.url}...</p>;
+    }
+    return <div className="remote-component" ref={this.container}></div>;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6607,7 +6607,6 @@ levn@~0.3.0:
 lint-staged@^9.5.0:
   version "9.5.0"
   resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-9.5.0.tgz#290ec605252af646d9b74d73a0fa118362b05a33"
-  integrity sha512-nawMob9cb/G1J98nb8v3VC/E8rcX1rryUYXVZ69aT9kde6YWX+uvNOEHY5yf2gcWcTJGiD0kqXmCnS3oD75GIA==
   dependencies:
     chalk "^2.4.2"
     commander "^2.20.0"
@@ -10187,6 +10186,10 @@ symbol.prototype.description@^1.0.0:
     es-abstract "^1.16.0"
     has-symbols "^1.0.0"
 
+systemjs@^6.1.7:
+  version "6.1.7"
+  resolved "https://registry.yarnpkg.com/systemjs/-/systemjs-6.1.7.tgz#631474f8d0d33412be215ab39a294663a90157d9"
+
 tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
@@ -10406,6 +10409,12 @@ ts-debounce@^1.0.0:
 ts-invariant@0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.4.1.tgz#2612cb76626cf7c6debf59e6d284d0abd9caae07"
+  dependencies:
+    tslib "^1.9.3"
+
+ts-invariant@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.4.4.tgz#97a523518688f93aafad01b0e80eb803eb2abd86"
   dependencies:
     tslib "^1.9.3"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10186,10 +10186,6 @@ symbol.prototype.description@^1.0.0:
     es-abstract "^1.16.0"
     has-symbols "^1.0.0"
 
-systemjs@^6.1.7:
-  version "6.1.7"
-  resolved "https://registry.yarnpkg.com/systemjs/-/systemjs-6.1.7.tgz#631474f8d0d33412be215ab39a294663a90157d9"
-
 tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"


### PR DESCRIPTION
We can now loading plugins like so:

```tsx
<NexusPlugin url="/public/plugins/nexus-plugin-react-example/index.js" />
```

We can add the `resource` and `nexusClient` later when we actually use it in studio