### PR TITLE
958 Add destroyOnClose prop to modal

### DIFF
--- a/src/shared/components/Studio/EditStudio.tsx
+++ b/src/shared/components/Studio/EditStudio.tsx
@@ -37,6 +37,7 @@ const EditStudio: React.FC<{
         visible={showModal}
         footer={null}
         onCancel={() => setShowModal(false)}
+        destroyOnClose={true}
       >
         <StudioEditorForm saveStudio={handleUpdate} studio={studio} />
       </Modal>

--- a/src/shared/containers/AddWorkspaceContainer.tsx
+++ b/src/shared/containers/AddWorkspaceContainer.tsx
@@ -103,6 +103,7 @@ const AddWorkspaceContainer: React.FC<{
         visible={showModal}
         footer={null}
         onCancel={() => setShowModal(false)}
+        destroyOnClose={true}
       >
         <WorkspaceEditorForm saveWorkspace={saveWorkspace} />
       </Modal>

--- a/src/shared/containers/CreateStudioContainer.tsx
+++ b/src/shared/containers/CreateStudioContainer.tsx
@@ -83,6 +83,7 @@ const CreateStudioContainer: React.FC<{
         visible={showModal}
         footer={null}
         onCancel={() => setShowModal(false)}
+        destroyOnClose={true}
       >
         <StudioEditorForm saveStudio={saveStudio} />
       </Modal>

--- a/src/shared/containers/DashboardEditor/CreateDashboardContainer.tsx
+++ b/src/shared/containers/DashboardEditor/CreateDashboardContainer.tsx
@@ -111,6 +111,7 @@ const CreateDashboardContainer: React.FunctionComponent<{
         okText={busy ? 'Saving' : 'Save'}
         style={{ minWidth: '75%' }}
         confirmLoading={busy}
+        destroyOnClose={true}
       >
         <DashboardConfigEditor
           wrappedComponentRef={formRef}

--- a/src/shared/containers/DashboardEditor/DashboardEditorContainer.tsx
+++ b/src/shared/containers/DashboardEditor/DashboardEditorContainer.tsx
@@ -95,6 +95,7 @@ const DashboardEditorContainer: React.FunctionComponent<{
       okText={busy ? 'Saving' : 'Save'}
       style={{ minWidth: '75%' }}
       confirmLoading={busy}
+      destroyOnClose={true}
     >
       <DashboardConfigEditor
         wrappedComponentRef={formRef}


### PR DESCRIPTION
Fixes BlueBrain/nexus#958

### How to test:

- Open the Dashboard editor modal by clicking the 'Edit' button
- Leave Label input field empty, click 'Save', and notice 'Please input a label!' error
- Close the modal
- Reopen the modal and notice that the error is not there anymore
- Same for Add dashboard form, Workspace forms and Studio forms

![Screenshot 2019-12-20 at 11 07 48](https://user-images.githubusercontent.com/23080476/71247391-fb44d180-2318-11ea-97f3-859f10ab0482.png)

