### PR TITLE
fix JSON viewer and links in resource view

### DIFF
--- a/src/shared/views/ResourceView.tsx
+++ b/src/shared/views/ResourceView.tsx
@@ -142,8 +142,20 @@ const ResourceView: React.FunctionComponent<ResourceViewProps> = props => {
             rev: Number(rev),
           })) as Resource)
         : latestResource;
+      const expandedResource = await nexus.Resource.get(
+        orgLabel,
+        projectLabel,
+        resourceId,
+        { format: 'expanded' }
+      );
       setResource({
-        resource: newResource,
+        // Note: we must fetch the proper, expanded @id. The @id that comes from a normal request or from the URL
+        // could be the contracted one, if the resource was created with a context that has a @base property.
+        // this would make the contracted @id unresolvable. See issue: https://github.com/BlueBrain/nexus/issues/966
+        resource: {
+          ...newResource,
+          '@id': expandedResource['@id'],
+        },
         error: null,
         busy: false,
       });

--- a/src/shared/views/ResourceView.tsx
+++ b/src/shared/views/ResourceView.tsx
@@ -254,7 +254,7 @@ const ResourceView: React.FunctionComponent<ResourceViewProps> = props => {
                 </TabPane>
                 <TabPane tab="History" key="#history">
                   <HistoryContainer
-                    resourceId={latestResource['@id']}
+                    resourceId={resource['@id']}
                     orgLabel={orgLabel}
                     projectLabel={projectLabel}
                     latestRev={latestResource._rev}


### PR DESCRIPTION
fixes: https://github.com/BlueBrain/nexus/issues/966

## How to Test

You can try this by creating a resource with a `@base` in the `@context` such as

```json
{
  "@context": [
    {
      "@base": "https://bluebrainnexus.io/studio/",
    },
    "https://bluebrain.github.io/nexus/contexts/resource.json"
  ],
  "@id": "https://bluebrainnexus.io/studio/StudioContext"
}
```

And try to view this resource in the `Resource View`. Before the JSON viewer, history, and links tab were all broken for such a resource, which you can see on the dev environment. Now they should work normally on your local machine. 