### PR TITLE
Bugfix/975 Fix Workspace Editor

### DIFF
--- a/src/shared/containers/WorkspaceFormContainer.tsx
+++ b/src/shared/containers/WorkspaceFormContainer.tsx
@@ -252,9 +252,10 @@ const WorkspaceForm: React.FunctionComponent<WorkspaceFormProps> = ({
       />
     );
   }
+
   return (
     <>
-      {workspace && description ? (
+      {workspace ? (
         <Modal
           title={`Edit ${workspace['label']}`}
           visible={true}
@@ -281,12 +282,12 @@ const WorkspaceForm: React.FunctionComponent<WorkspaceFormProps> = ({
               />
             </Form.Item>
             <Form.Item
-              label={'Name'}
+              label={'Label'}
               required
               extra={namePrompt ? 'Name cannot be empty' : ''}
             >
               <Input
-                defaultValue={label}
+                value={label}
                 onChange={e => {
                   if (e.target.value.trim().length > 0) {
                     setLabel(e.target.value);
@@ -299,7 +300,7 @@ const WorkspaceForm: React.FunctionComponent<WorkspaceFormProps> = ({
             </Form.Item>
             <Form.Item label={'Description'}>
               <Input
-                defaultValue={description}
+                value={description}
                 onChange={e => {
                   e.preventDefault();
                   setDescription(e.target.value);

--- a/src/shared/containers/WorkspaceListContainer.tsx
+++ b/src/shared/containers/WorkspaceListContainer.tsx
@@ -132,7 +132,7 @@ const WorkspaceList: React.FunctionComponent<WorkspaceListProps> = ({
           </div>
         ) : null}
       </TabList>
-      {showEdit && workspaceToEdit ? (
+      {showEdit && !!workspaceToEdit ? (
         <WorkspaceForm
           orgLabel={orgLabel}
           projectLabel={projectLabel}


### PR DESCRIPTION
fixes https://github.com/BlueBrain/nexus/issues/975

## Other changes
- fixes a problem where the current `label` and `description` values would not show if they existed
- changes the label for `Label` from `Name` to `Label` to be more consistent. 

## How to Test

Create and edit a workspace. The edit modal should now show up with the proper values. Before the edit modal would not show. 