### PR TITLE
Implement resource list sorting

### DIFF
--- a/src/shared/components/ResourceList/ResourceList.less
+++ b/src/shared/components/ResourceList/ResourceList.less
@@ -48,6 +48,7 @@
     flex-wrap: wrap;
     &.-squished {
       justify-content: flex-end;
+      align-items: center;
     }
   }
   & > .controls > .dropdown-filter {
@@ -89,5 +90,12 @@
     &:hover {
       background-color: fade(black, 50%);
     }
+  }
+
+  .sort-options {
+    display: flex;
+    justify-content: flex-end;
+    margin: 0 0 10px 0;
+    opacity: 0.8;
   }
 }

--- a/src/shared/components/ResourceList/ResourceList.less
+++ b/src/shared/components/ResourceList/ResourceList.less
@@ -91,11 +91,4 @@
       background-color: fade(black, 50%);
     }
   }
-
-  .sort-options {
-    display: flex;
-    justify-content: flex-end;
-    margin: 0 0 10px 0;
-    opacity: 0.8;
-  }
 }

--- a/src/shared/components/ResourceList/index.tsx
+++ b/src/shared/components/ResourceList/index.tsx
@@ -76,7 +76,6 @@ const ResourceListComponent: React.FunctionComponent<{
 }) => {
   const [{ ref: wrapperHeightRef }, { height: wrapperHeight }] = useMeasure();
   const { name } = list;
-  const [sortOptionsToggleOn, toggleSortOptions] = React.useState(false);
   const [sortOption, setSortOption] = React.useState('-_createdAt');
 
   const handleUpdate = (value: string) => {
@@ -109,12 +108,9 @@ const ResourceListComponent: React.FunctionComponent<{
     onRefresh();
   };
 
-  const onClickSort = () => {
-    toggleSortOptions(!sortOptionsToggleOn);
-  };
-
   const onChangeSort = (option: any) => {
     const { key } = option;
+
     setSortOption(key);
     onSortBy(key);
   };
@@ -149,9 +145,9 @@ const ResourceListComponent: React.FunctionComponent<{
           <Icon type="close" className="close-button" onClick={handleDelete} />
         </h3>
         <div className="controls -squished">
-          <Dropdown overlay={sortOptions}>
+          <Dropdown overlay={sortOptions} trigger={['hover', 'click']}>
             <Tooltip title="Sort resources">
-              <Button icon="sort-ascending" onClick={onClickSort} />
+              <Button icon="sort-ascending" />
             </Tooltip>
           </Dropdown>
           <Tooltip title="Clear filters">

--- a/src/shared/components/ResourceList/index.tsx
+++ b/src/shared/components/ResourceList/index.tsx
@@ -121,7 +121,12 @@ const ResourceListComponent: React.FunctionComponent<{
         </h3>
         <div className="controls -squished">
           <Tooltip title="Sort by date">
-            <Button icon="arrow-down" onClick={onSort} />
+            <Button
+              icon={
+                list.query.sort === '-_createdAt' ? 'arrow-down' : 'arrow-up'
+              }
+              onClick={onSort}
+            />
           </Tooltip>
           <Tooltip title="Clear filters">
             <Button icon="close-circle" onClick={handleClear} />

--- a/src/shared/components/ResourceList/index.tsx
+++ b/src/shared/components/ResourceList/index.tsx
@@ -7,7 +7,8 @@ import {
   Switch,
   Empty,
   Popover,
-  Radio,
+  Menu,
+  Dropdown,
 } from 'antd';
 import { ResourceList, Resource } from '@bbp/nexus-sdk';
 
@@ -112,14 +113,20 @@ const ResourceListComponent: React.FunctionComponent<{
     toggleSortOptions(!sortOptionsToggleOn);
   };
 
-  const onChangeSort = (event: any) => {
-    const { value } = event.target;
-
-    setSortOption(value);
-    onSortBy(value);
+  const onChangeSort = (option: any) => {
+    const { key } = option;
+    setSortOption(key);
+    onSortBy(key);
   };
 
   const hasMore = resources.length < Number(total || 0);
+
+  const sortOptions = (
+    <Menu onClick={onChangeSort} selectedKeys={[sortOption]}>
+      <Menu.Item key="-_createdAt">Newest</Menu.Item>
+      <Menu.Item key="_createdAt">Oldest</Menu.Item>
+    </Menu>
+  );
 
   return (
     <div className="resource-list-height-tester" ref={wrapperHeightRef}>
@@ -142,9 +149,11 @@ const ResourceListComponent: React.FunctionComponent<{
           <Icon type="close" className="close-button" onClick={handleDelete} />
         </h3>
         <div className="controls -squished">
-          <Tooltip title="Sort by date">
-            <Button icon="sort-ascending" onClick={onClickSort} />
-          </Tooltip>
+          <Dropdown overlay={sortOptions}>
+            <Tooltip title="Sort resources">
+              <Button icon="sort-ascending" onClick={onClickSort} />
+            </Tooltip>
+          </Dropdown>
           <Tooltip title="Clear filters">
             <Button icon="close-circle" onClick={handleClear} />
           </Tooltip>
@@ -169,18 +178,6 @@ const ResourceListComponent: React.FunctionComponent<{
             />
           </Tooltip>
         </div>
-        {sortOptionsToggleOn && (
-          <div className="sort-options">
-            <Radio.Group
-              onChange={event => onChangeSort(event)}
-              value={sortOption}
-            >
-              <Radio value="-_createdAt">Newest</Radio>
-              <Radio value="_createdAt">Oldest</Radio>
-              <Radio value="-@id">By id</Radio>
-            </Radio.Group>
-          </div>
-        )}
         <div className="controls">{children}</div>
         <Spin spinning={busy}>
           {!!error && <Empty description={error.message} />}

--- a/src/shared/components/ResourceList/index.tsx
+++ b/src/shared/components/ResourceList/index.tsx
@@ -1,5 +1,14 @@
 import * as React from 'react';
-import { Icon, Tooltip, Button, Spin, Switch, Empty, Popover } from 'antd';
+import {
+  Icon,
+  Tooltip,
+  Button,
+  Spin,
+  Switch,
+  Empty,
+  Popover,
+  Radio,
+} from 'antd';
 import { ResourceList, Resource } from '@bbp/nexus-sdk';
 
 import RenameableItem from '../Renameable';
@@ -44,7 +53,7 @@ const ResourceListComponent: React.FunctionComponent<{
   onUpdate(list: ResourceBoardList): void;
   onLoadMore({ searchValue }: { searchValue: string }): void;
   onRefresh(): void;
-  onSort(): void;
+  onSortBy(option: string): void;
   makeResourceUri(resourceId: string): string;
   goToResource(resourceId: string): void;
 }> = ({
@@ -58,7 +67,7 @@ const ResourceListComponent: React.FunctionComponent<{
   onDelete,
   onClone,
   onRefresh,
-  onSort,
+  onSortBy,
   makeResourceUri,
   goToResource,
   children,
@@ -66,6 +75,8 @@ const ResourceListComponent: React.FunctionComponent<{
 }) => {
   const [{ ref: wrapperHeightRef }, { height: wrapperHeight }] = useMeasure();
   const { name } = list;
+  const [sortOptionsToggleOn, toggleSortOptions] = React.useState(false);
+  const [sortOption, setSortOption] = React.useState('-_createdAt');
 
   const handleUpdate = (value: string) => {
     onUpdate({ ...list, name: value });
@@ -97,6 +108,17 @@ const ResourceListComponent: React.FunctionComponent<{
     onRefresh();
   };
 
+  const onClickSort = () => {
+    toggleSortOptions(!sortOptionsToggleOn);
+  };
+
+  const onChangeSort = (event: any) => {
+    const { value } = event.target;
+
+    setSortOption(value);
+    onSortBy(value);
+  };
+
   const hasMore = resources.length < Number(total || 0);
 
   return (
@@ -121,12 +143,7 @@ const ResourceListComponent: React.FunctionComponent<{
         </h3>
         <div className="controls -squished">
           <Tooltip title="Sort by date">
-            <Button
-              icon={
-                list.query.sort === '-_createdAt' ? 'arrow-down' : 'arrow-up'
-              }
-              onClick={onSort}
-            />
+            <Button icon="sort-ascending" onClick={onClickSort} />
           </Tooltip>
           <Tooltip title="Clear filters">
             <Button icon="close-circle" onClick={handleClear} />
@@ -152,6 +169,18 @@ const ResourceListComponent: React.FunctionComponent<{
             />
           </Tooltip>
         </div>
+        {sortOptionsToggleOn && (
+          <div className="sort-options">
+            <Radio.Group
+              onChange={event => onChangeSort(event)}
+              value={sortOption}
+            >
+              <Radio value="-_createdAt">Newest</Radio>
+              <Radio value="_createdAt">Oldest</Radio>
+              <Radio value="-@id">By id</Radio>
+            </Radio.Group>
+          </div>
+        )}
         <div className="controls">{children}</div>
         <Spin spinning={busy}>
           {!!error && <Empty description={error.message} />}

--- a/src/shared/components/ResourceList/index.tsx
+++ b/src/shared/components/ResourceList/index.tsx
@@ -26,6 +26,7 @@ export type ResourceBoardList = {
     updatedBy?: string;
     schema?: string;
     q?: string;
+    sort?: string | string[];
   };
 };
 
@@ -43,6 +44,7 @@ const ResourceListComponent: React.FunctionComponent<{
   onUpdate(list: ResourceBoardList): void;
   onLoadMore({ searchValue }: { searchValue: string }): void;
   onRefresh(): void;
+  onSort(): void;
   makeResourceUri(resourceId: string): string;
   goToResource(resourceId: string): void;
 }> = ({
@@ -56,6 +58,7 @@ const ResourceListComponent: React.FunctionComponent<{
   onDelete,
   onClone,
   onRefresh,
+  onSort,
   makeResourceUri,
   goToResource,
   children,
@@ -117,6 +120,9 @@ const ResourceListComponent: React.FunctionComponent<{
           <Icon type="close" className="close-button" onClick={handleDelete} />
         </h3>
         <div className="controls -squished">
+          <Tooltip title="Sort by date">
+            <Button icon="arrow-down" onClick={onSort} />
+          </Tooltip>
           <Tooltip title="Clear filters">
             <Button icon="close-circle" onClick={handleClear} />
           </Tooltip>

--- a/src/shared/containers/ResourceListBoardContainer.tsx
+++ b/src/shared/containers/ResourceListBoardContainer.tsx
@@ -13,6 +13,7 @@ export const DEFAULT_LIST: ResourceBoardList = {
   query: {
     size: 100,
     deprecated: false,
+    sort: '-_createdAt',
   },
 };
 

--- a/src/shared/containers/ResourceListContainer.tsx
+++ b/src/shared/containers/ResourceListContainer.tsx
@@ -174,6 +174,17 @@ const ResourceListContainer: React.FunctionComponent<{
     });
   };
 
+  const sortList = () => {
+    setList({
+      ...list,
+      query: {
+        ...list.query,
+        // @ts-ignore
+        sort: '_createdAt',
+      },
+    });
+  };
+
   return (
     <ResourceListComponent
       busy={busy}
@@ -186,6 +197,7 @@ const ResourceListContainer: React.FunctionComponent<{
       onDelete={handleDelete}
       onClone={handleClone}
       onRefresh={handleRefreshList}
+      onSort={sortList}
       makeResourceUri={makeResourceUri}
       goToResource={goToResource}
       schemaLinkContainer={SchemaLinkContainer}

--- a/src/shared/containers/ResourceListContainer.tsx
+++ b/src/shared/containers/ResourceListContainer.tsx
@@ -174,13 +174,13 @@ const ResourceListContainer: React.FunctionComponent<{
     });
   };
 
-  const sortList = () => {
+  const sortList = (option: string) => {
     setList({
       ...list,
       query: {
         ...list.query,
         // @ts-ignore
-        sort: list.query.sort === '-_createdAt' ? '_createdAt' : '-_createdAt',
+        sort: option,
       },
     });
   };
@@ -197,7 +197,7 @@ const ResourceListContainer: React.FunctionComponent<{
       onDelete={handleDelete}
       onClone={handleClone}
       onRefresh={handleRefreshList}
-      onSort={sortList}
+      onSortBy={sortList}
       makeResourceUri={makeResourceUri}
       goToResource={goToResource}
       schemaLinkContainer={SchemaLinkContainer}

--- a/src/shared/containers/ResourceListContainer.tsx
+++ b/src/shared/containers/ResourceListContainer.tsx
@@ -179,7 +179,6 @@ const ResourceListContainer: React.FunctionComponent<{
       ...list,
       query: {
         ...list.query,
-        // @ts-ignore
         sort: option,
       },
     });

--- a/src/shared/containers/ResourceListContainer.tsx
+++ b/src/shared/containers/ResourceListContainer.tsx
@@ -180,7 +180,7 @@ const ResourceListContainer: React.FunctionComponent<{
       query: {
         ...list.query,
         // @ts-ignore
-        sort: list.query.sort == '-_createdAt' ? '_createdAt' : '-_createdAt',
+        sort: list.query.sort === '-_createdAt' ? '_createdAt' : '-_createdAt',
       },
     });
   };

--- a/src/shared/containers/ResourceListContainer.tsx
+++ b/src/shared/containers/ResourceListContainer.tsx
@@ -180,7 +180,7 @@ const ResourceListContainer: React.FunctionComponent<{
       query: {
         ...list.query,
         // @ts-ignore
-        sort: '_createdAt',
+        sort: list.query.sort == '-_createdAt' ? '_createdAt' : '-_createdAt',
       },
     });
   };


### PR DESCRIPTION
Fixes BlueBrain/nexus#810

The Resource List is now sorted by date by default (newest on top)

### If you really want to test:

- Open the Resource list
- Click 'Sort' button
- Select 'Oldest', notice the list gets updated.

Selected sort options should stay when you use filter, for example, by type.

![Screenshot 2020-01-13 at 16 41 11](https://user-images.githubusercontent.com/23080476/72269375-c4b25c00-3623-11ea-9a82-c70791f47a2c.png)
