### PR TITLE
Collapse plugins and mark as experimental

### DIFF
--- a/src/shared/components/DashboardEditor/DashboardConfigEditor.tsx
+++ b/src/shared/components/DashboardEditor/DashboardConfigEditor.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Input, Form, Tooltip, Icon, Transfer, Button } from 'antd';
+import { Input, Form, Tooltip, Icon, Transfer, Button, Collapse } from 'antd';
 import { WrappedFormUtils } from 'antd/lib/form/Form';
 import { ResourceList } from '@bbp/nexus-sdk';
 import { FormComponentProps } from 'antd/es/form';
@@ -38,6 +38,7 @@ const DashboardConfigEditorComponent: React.FunctionComponent<
   const [selectedPlugins, setSelectedPlugins] = React.useState<string[]>(
     plugins
   );
+  const { Panel } = Collapse;
 
   const formatPluginSource = () => {
     if (availablePlugins && availablePlugins.length) {
@@ -120,32 +121,6 @@ const DashboardConfigEditorComponent: React.FunctionComponent<
       <Form.Item
         label={
           <span>
-            Plugins{' '}
-            <Tooltip title="Which plugins should Studio load when viewing a resource.">
-              <Icon type="question-circle-o" />
-            </Tooltip>
-          </span>
-        }
-      >
-        {getFieldDecorator('plugins', {
-          rules: [
-            {
-              required: false,
-            },
-          ],
-        })(
-          <Transfer
-            listStyle={{ width: '350px' }}
-            dataSource={formatPluginSource()}
-            targetKeys={selectedPlugins}
-            render={item => item.title}
-            onChange={handlePluginsChange}
-          />
-        )}
-      </Form.Item>
-      <Form.Item
-        label={
-          <span>
             Sparql Query{' '}
             <Tooltip title="A query that will return the elements of the dashboard.">
               <Icon type="question-circle-o" />
@@ -165,6 +140,44 @@ const DashboardConfigEditorComponent: React.FunctionComponent<
             },
           ],
         })(<SparqlQueryFormInput />)}
+      </Form.Item>
+      <Form.Item>
+        {getFieldDecorator('plugins', {
+          rules: [
+            {
+              required: false,
+            },
+          ],
+        })(
+          <Collapse>
+            <Panel
+              header={
+                <span>
+                  Plugins{' '}
+                  <Tooltip title="Which plugins should Studio load when viewing a resource.">
+                    <Icon type="question-circle-o" />
+                  </Tooltip>{' '}
+                  Experimental{' '}
+                  <a
+                    target="_blank"
+                    href="https://github.com/BlueBrain/nexus-web/blob/master/docs/studio/Dashboards.md#plugins-experimental"
+                  >
+                    (Docs)
+                  </a>
+                </span>
+              }
+              key="1"
+            >
+              <Transfer
+                listStyle={{ width: '350px' }}
+                dataSource={formatPluginSource()}
+                targetKeys={selectedPlugins}
+                render={item => item.title}
+                onChange={handlePluginsChange}
+              />
+            </Panel>
+          </Collapse>
+        )}
       </Form.Item>
       <Form.Item>
         <Button htmlType="submit" type="primary">


### PR DESCRIPTION
Fixes BlueBrain/nexus#978

- Plugins are collapsed by default and moved to the bottom of the Dashboard form
- Marked as a experimental (with the link to Docs)

![Screenshot 2020-01-14 at 15 09 00](https://user-images.githubusercontent.com/23080476/72351060-ee30bd80-36df-11ea-93f2-ea05f0895242.png)
