### PR TITLE
Bugfix/977 janky studio

### DIFF
--- a/src/shared/containers/DashboardEditor/CreateDashboardContainer.tsx
+++ b/src/shared/containers/DashboardEditor/CreateDashboardContainer.tsx
@@ -47,22 +47,20 @@ const CreateDashboardContainer: React.FunctionComponent<{
         '@context': STUDIO_CONTEXT['@id'],
         '@type': DASHBOARD_TYPE,
       });
-
       // Add dashboard to workspace
       const workspace = await nexus.Resource.get<Resource>(
         orgLabel,
         projectLabel,
-        workspaceId
+        encodeURIComponent(workspaceId)
       );
-
       const workspaceSource = await nexus.Resource.getSource<{
         [key: string]: any;
-      }>(orgLabel, projectLabel, workspaceId);
+      }>(orgLabel, projectLabel, encodeURIComponent(workspaceId));
       if (workspace) {
         await nexus.Resource.update(
           orgLabel,
           projectLabel,
-          workspaceId,
+          encodeURIComponent(workspaceId),
           workspace._rev,
           {
             ...workspaceSource,
@@ -76,7 +74,6 @@ const CreateDashboardContainer: React.FunctionComponent<{
           }
         );
       }
-
       notification.success({
         message: `Dashboard ${dashboardPayload.label} was created successfully`,
         duration: 5,

--- a/src/shared/containers/DashboardListContainer.tsx
+++ b/src/shared/containers/DashboardListContainer.tsx
@@ -61,11 +61,28 @@ const DashboardList: React.FunctionComponent<DashboardListProps> = ({
           orgLabel,
           projectLabel,
           encodeURIComponent(dashboardObject.dashboard)
-        );
+        ) as Promise<
+          Resource<{
+            label: string;
+            description?: string;
+            dataQuery: string;
+            plugins: string[];
+          }>
+        >;
       })
     )
       .then(values => {
-        setDashboardResources(values);
+        setDashboardResources(
+          values.sort(({ label: a }, { label: b }) => {
+            if (a < b) {
+              return -1;
+            }
+            if (a > b) {
+              return 1;
+            }
+            return 0;
+          })
+        );
         if (
           dashboardId &&
           values[selectedDashboardIndex]['@id'] !== dashboardId
@@ -119,21 +136,11 @@ const DashboardList: React.FunctionComponent<DashboardListProps> = ({
         ></DashboardEditorContainer>
       )}
       <TabList
-        items={dashboardResources
-          .map((w, index) => ({
-            label: w.label,
-            description: w.description,
-            id: `${index}`, // must be a string
-          }))
-          .sort(({ label: a }, { label: b }) => {
-            if (a < b) {
-              return -1;
-            }
-            if (a > b) {
-              return 1;
-            }
-            return 0;
-          })}
+        items={dashboardResources.map((w, index) => ({
+          label: w.label,
+          description: w.description,
+          id: `${index}`, // must be a string
+        }))}
         onSelected={(stringiedIndex: string) => {
           selectDashboard(Number(stringiedIndex));
         }}

--- a/src/shared/containers/DashboardListContainer.tsx
+++ b/src/shared/containers/DashboardListContainer.tsx
@@ -3,20 +3,20 @@ import { Resource, DEFAULT_SPARQL_VIEW_ID } from '@bbp/nexus-sdk';
 import { useNexusContext } from '@bbp/react-nexus';
 import TabList from '../components/Tabs/TabList';
 import DashboardResultsContainer from './DashboardResultsContainer';
-import { useHistory } from 'react-router-dom';
 import DashboardEditorContainer from './DashboardEditor/DashboardEditorContainer';
 import CreateDashboardContainer from './DashboardEditor/CreateDashboardContainer';
+import useQueryString from '../hooks/useQueryString';
 
-type Dashboard = {
+export type Dashboard = {
   dashboard: string;
   view: string;
 };
+
 interface DashboardListProps {
   dashboards: Dashboard[];
   orgLabel: string;
   projectLabel: string;
   workspaceId: string;
-  dashboardId: string;
   studioResourceId: string;
   refreshList?(): void;
 }
@@ -26,11 +26,11 @@ const DashboardList: React.FunctionComponent<DashboardListProps> = ({
   orgLabel,
   projectLabel,
   workspaceId,
-  dashboardId,
   studioResourceId,
   refreshList,
 }) => {
-  const history = useHistory();
+  const [queryParams, setQueryString] = useQueryString();
+  const { dashboardId } = queryParams;
   const [dashboardResources, setDashboardResources] = React.useState<
     Resource[]
   >([]);
@@ -48,16 +48,10 @@ const DashboardList: React.FunctionComponent<DashboardListProps> = ({
     setSelectedDashboardIndex(dashboardIndex);
     const dashboard = dashboardResources[dashboardIndex];
     const id = dashboard['@id'];
-    const path = history.location.pathname.split('/dashboards');
-    let newPath;
-    if (path[0].includes('/workspaces')) {
-      newPath = `${path[0]}/dashboards/${encodeURIComponent(id)}`;
-    } else {
-      newPath = `${
-        path[0]
-      }/workspaces/${workspaceId}/dashboards/${encodeURIComponent(id)}`;
-    }
-    history.push(newPath);
+    setQueryString({
+      ...queryParams,
+      dashboardId: id,
+    });
   };
 
   const fetchAndSetupDashboards = () => {
@@ -76,9 +70,8 @@ const DashboardList: React.FunctionComponent<DashboardListProps> = ({
           dashboardId &&
           values[selectedDashboardIndex]['@id'] !== dashboardId
         ) {
-          const id = decodeURIComponent(dashboardId);
           const selectedDashboardIndex = dashboards.findIndex(
-            d => d.dashboard === id
+            d => d.dashboard === dashboardId
           );
           setSelectedDashboardIndex(selectedDashboardIndex);
         }
@@ -146,26 +139,21 @@ const DashboardList: React.FunctionComponent<DashboardListProps> = ({
         }
         onEditClick={handleElementClick}
       >
-        {!!dashboardResources.length && (
-          <DashboardResultsContainer
-            orgLabel={orgLabel}
-            projectLabel={projectLabel}
-            viewId={
-              (dashboards[selectedDashboardIndex] &&
-                dashboards[selectedDashboardIndex].view) ||
-              DEFAULT_SPARQL_VIEW_ID
-            }
-            workspaceId={workspaceId}
-            dashboardId={
-              dashboardId
-                ? dashboardId
-                : dashboardResources[selectedDashboardIndex]['@id']
-            }
-            studioResourceId={studioResourceId}
-            dataQuery={dashboardResources[selectedDashboardIndex].dataQuery}
-            plugins={dashboardResources[selectedDashboardIndex].plugins}
-          />
-        )}
+        {!!dashboardResources.length &&
+          !!dashboardResources[selectedDashboardIndex] && (
+            <DashboardResultsContainer
+              orgLabel={orgLabel}
+              projectLabel={projectLabel}
+              viewId={
+                (dashboards[selectedDashboardIndex] &&
+                  dashboards[selectedDashboardIndex].view) ||
+                DEFAULT_SPARQL_VIEW_ID
+              }
+              studioResourceId={studioResourceId}
+              dataQuery={dashboardResources[selectedDashboardIndex].dataQuery}
+              plugins={dashboardResources[selectedDashboardIndex].plugins}
+            />
+          )}
       </TabList>
     </div>
   );

--- a/src/shared/containers/DashboardListContainer.tsx
+++ b/src/shared/containers/DashboardListContainer.tsx
@@ -119,11 +119,21 @@ const DashboardList: React.FunctionComponent<DashboardListProps> = ({
         ></DashboardEditorContainer>
       )}
       <TabList
-        items={dashboardResources.map((w, index) => ({
-          label: w.label,
-          description: w.description,
-          id: `${index}`, // must be a string
-        }))}
+        items={dashboardResources
+          .map((w, index) => ({
+            label: w.label,
+            description: w.description,
+            id: `${index}`, // must be a string
+          }))
+          .sort(({ label: a }, { label: b }) => {
+            if (a < b) {
+              return -1;
+            }
+            if (a > b) {
+              return 1;
+            }
+            return 0;
+          })}
         onSelected={(stringiedIndex: string) => {
           selectDashboard(Number(stringiedIndex));
         }}

--- a/src/shared/containers/DashboardResultsContainer.tsx
+++ b/src/shared/containers/DashboardResultsContainer.tsx
@@ -141,7 +141,6 @@ const DashboardResultsContainer: React.FunctionComponent<{
         setItems(tempItems);
       })
       .catch(e => {
-        console.error(e);
         setError(e);
       });
   }, [orgLabel, projectLabel, dataQuery, viewId]);

--- a/src/shared/containers/DashboardResultsContainer.tsx
+++ b/src/shared/containers/DashboardResultsContainer.tsx
@@ -53,6 +53,7 @@ const DashboardResultsContainer: React.FunctionComponent<{
   const [items, setItems] = React.useState<any[]>();
   const [headerProperties, setHeaderProperties] = React.useState<any[]>();
   const nexus = useNexusContext();
+
   const selectResource = (selfUrl: string, setHistory = true) => {
     if (error) {
       setError(undefined);
@@ -144,6 +145,7 @@ const DashboardResultsContainer: React.FunctionComponent<{
         setItems(tempItems);
       })
       .catch(e => {
+        console.error(e);
         setError(e);
       });
   }, [orgLabel, projectLabel, dataQuery, viewId]);

--- a/src/shared/containers/DashboardResultsContainer.tsx
+++ b/src/shared/containers/DashboardResultsContainer.tsx
@@ -8,9 +8,9 @@ import {
   SparqlViewQueryResponse,
 } from '@bbp/nexus-sdk';
 import ResourceCardComponent from '../components/ResourceCard';
-import { useHistory } from 'react-router-dom';
 import { useNexusContext } from '@bbp/react-nexus';
 import { NexusPlugin } from './NexusPlugin';
+import useQueryString from '../hooks/useQueryString';
 
 export type Binding = {
   [key: string]: {
@@ -36,8 +36,6 @@ const DashboardResultsContainer: React.FunctionComponent<{
   orgLabel: string;
   projectLabel: string;
   viewId: string;
-  workspaceId: string;
-  dashboardId: string;
   studioResourceId: string;
   plugins?: string[];
 }> = ({
@@ -45,12 +43,11 @@ const DashboardResultsContainer: React.FunctionComponent<{
   projectLabel,
   dataQuery,
   viewId,
-  workspaceId,
-  dashboardId,
   studioResourceId,
   plugins = [],
 }) => {
-  const history = useHistory();
+  const [queryParams, setQueryString] = useQueryString();
+  const { resourceId } = queryParams;
   const [selectedResource, setSelectedResource] = React.useState<Resource>();
   const [error, setError] = React.useState<NexusSparqlError | Error>();
   const [items, setItems] = React.useState<any[]>();
@@ -75,27 +72,11 @@ const DashboardResultsContainer: React.FunctionComponent<{
       });
   };
 
-  const updateResourcePath = (res: Resource) => {
-    const path = history.location.pathname.split('/studioResource');
-    let newPath;
-    if (path[0].includes('/workspaces') && path[0].includes('/dashboards')) {
-      newPath = `${path[0]}/studioResource/${encodeURIComponent(res['@id'])}`;
-      history.push(newPath);
-    } else {
-      if (path[0].includes('/dashboards')) {
-        newPath = `${
-          path[0]
-        }/workspaces/${workspaceId}/dashboards/${encodeURIComponent(
-          dashboardId
-        )}/studioResource/${encodeURIComponent(res['@id'])}`;
-      } else {
-        newPath = `${path[0]}/dashboards/${encodeURIComponent(
-          dashboardId
-        )}/studioResource/${encodeURIComponent(res['@id'])}`;
-        history.push(newPath);
-      }
-    }
-    history.push(newPath);
+  const updateResourcePath = (resource: Resource) => {
+    setQueryString({
+      ...queryParams,
+      workspaceId: resource['@id'],
+    });
   };
 
   const unSelectResource = () => {

--- a/src/shared/containers/StudioContainer.tsx
+++ b/src/shared/containers/StudioContainer.tsx
@@ -3,7 +3,6 @@ import { Resource } from '@bbp/nexus-sdk';
 import { useNexusContext } from '@bbp/react-nexus';
 import { notification, Empty } from 'antd';
 
-import WorkspaceList from './WorkspaceListContainer';
 import EditStudio from '../components/Studio/EditStudio';
 import StudioHeader from '../components/Studio/StudioHeader';
 
@@ -11,9 +10,11 @@ type StudioContainerProps = {
   orgLabel: string;
   projectLabel: string;
   studioId: string;
-  workspaceId: string;
-  dashboardId: string;
-  studioResourceId: string;
+  workspaceListComponent(workspaceComponentProps: {
+    workspaceIds: string[];
+    reloadWorkspaces: VoidFunction;
+    studioResource: StudioResource;
+  }): React.ReactElement;
 };
 
 type StudioResource = Resource<{
@@ -26,9 +27,7 @@ const StudioContainer: React.FunctionComponent<StudioContainerProps> = ({
   orgLabel,
   projectLabel,
   studioId,
-  workspaceId,
-  dashboardId,
-  studioResourceId,
+  workspaceListComponent,
 }) => {
   const [
     studioResource,
@@ -87,7 +86,7 @@ const StudioContainer: React.FunctionComponent<StudioContainerProps> = ({
     }
   };
 
-  const realoadWorkspaces = () => {
+  const reloadWorkspaces = () => {
     fetchAndSetupStudio();
   };
 
@@ -101,16 +100,11 @@ const StudioContainer: React.FunctionComponent<StudioContainerProps> = ({
           >
             <EditStudio studio={studioResource} onSave={updateStudio} />
           </StudioHeader>
-          <WorkspaceList
-            orgLabel={orgLabel}
-            projectLabel={projectLabel}
-            workspaceIds={workspaceIds}
-            workspaceId={workspaceId}
-            dashboardId={dashboardId}
-            studioResourceId={studioResourceId}
-            studioResource={studioResource}
-            onListUpdate={realoadWorkspaces}
-          />
+          {workspaceListComponent({
+            workspaceIds,
+            reloadWorkspaces,
+            studioResource,
+          })}
         </>
       ) : (
         <Empty />

--- a/src/shared/containers/WorkspaceListContainer.tsx
+++ b/src/shared/containers/WorkspaceListContainer.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { Resource } from '@bbp/nexus-sdk';
 import { useNexusContext } from '@bbp/react-nexus';
+
 import TabList from '../components/Tabs/TabList';
-import DashboardList from './DashboardListContainer';
-import { useHistory } from 'react-router-dom';
 import AddWorkspaceContainer from './AddWorkspaceContainer';
 import WorkspaceForm from './WorkspaceFormContainer';
+import { Dashboard } from './DashboardListContainer';
+import useQueryString from '../hooks/useQueryString';
 
 type StudioResource = Resource<{
   label: string;
@@ -17,29 +18,29 @@ type WorkspaceListProps = {
   workspaceIds: string[];
   orgLabel: string;
   projectLabel: string;
-  workspaceId: string;
-  dashboardId: string;
-  studioResourceId: string;
   studioResource: StudioResource;
   onListUpdate?(): void;
+  dashboardListComponent(dashboardListComponentProps: {
+    dashboards: Dashboard[]; // TODO add Dashboard type
+    workspaceId: string;
+  }): React.ReactElement;
 };
 
 const WorkspaceList: React.FunctionComponent<WorkspaceListProps> = ({
   workspaceIds = [],
   orgLabel,
   projectLabel,
-  workspaceId,
-  dashboardId,
-  studioResourceId,
   studioResource,
   onListUpdate,
+  dashboardListComponent,
 }) => {
+  const [queryParams, setQueryString] = useQueryString();
+  const { workspaceId } = queryParams;
   const [workspaces, setWorkspaces] = React.useState<Resource[]>([]);
   const [selectedWorkspace, setSelectedWorkspace] = React.useState<Resource>();
   const [showEdit, setShowEdit] = React.useState<boolean>(false);
   const [workspaceToEdit, setWorkSpaceToEdit] = React.useState<string>();
   const nexus = useNexusContext();
-  const history = useHistory();
   const dashboards =
     selectedWorkspace && selectedWorkspace['dashboards']
       ? selectedWorkspace['dashboards']
@@ -47,11 +48,10 @@ const WorkspaceList: React.FunctionComponent<WorkspaceListProps> = ({
   const selectWorkspace = (id: string, values: Resource[]) => {
     const w = values.find(w => w['@id'] === id);
     setSelectedWorkspace(w);
-    const path = history.location.pathname.split('/workspaces');
-    const newPath = `${path[0]}/workspaces/${encodeURIComponent(id)}`;
-    if (!history.location.pathname.includes(newPath)) {
-      history.push(newPath);
-    }
+    setQueryString({
+      ...queryParams,
+      workspaceId: id,
+    });
   };
 
   React.useEffect(() => {
@@ -72,7 +72,6 @@ const WorkspaceList: React.FunctionComponent<WorkspaceListProps> = ({
           const id = decodeURIComponent(workspaceId);
           w = values.find(w => w['@id'] === id);
         }
-
         if (w) {
           setSelectedWorkspace(w);
         }
@@ -116,19 +115,12 @@ const WorkspaceList: React.FunctionComponent<WorkspaceListProps> = ({
       >
         {selectedWorkspace ? (
           <div className="workspace">
-            <DashboardList
-              orgLabel={orgLabel}
-              projectLabel={projectLabel}
-              dashboards={dashboards}
-              workspaceId={
-                workspaceId
-                  ? workspaceId
-                  : encodeURIComponent(selectedWorkspace['@id'])
-              }
-              dashboardId={dashboardId}
-              studioResourceId={studioResourceId}
-              refreshList={onListUpdate}
-            />{' '}
+            {dashboardListComponent({
+              dashboards,
+              workspaceId: workspaceId
+                ? workspaceId
+                : encodeURIComponent(selectedWorkspace['@id']),
+            })}{' '}
           </div>
         ) : null}
       </TabList>

--- a/src/shared/containers/WorkspaceListContainer.tsx
+++ b/src/shared/containers/WorkspaceListContainer.tsx
@@ -51,6 +51,11 @@ const WorkspaceList: React.FunctionComponent<WorkspaceListProps> = ({
     setQueryString({
       ...queryParams,
       workspaceId: id,
+      // Make sure to deselect dashboards
+      // Some workspaces may share a dashboard with the same @id
+      // remove keys using undefined
+      // https://www.npmjs.com/package/query-string#falsy-values
+      dashboardId: undefined,
     });
   };
 

--- a/src/shared/containers/WorkspaceListContainer.tsx
+++ b/src/shared/containers/WorkspaceListContainer.tsx
@@ -88,11 +88,21 @@ const WorkspaceList: React.FunctionComponent<WorkspaceListProps> = ({
           setWorkSpaceToEdit(workspaceId);
           setShowEdit(true);
         }}
-        items={workspaces.map(w => ({
-          label: w.label,
-          description: w.description,
-          id: w['@id'],
-        }))}
+        items={workspaces
+          .map(w => ({
+            label: w.label,
+            description: w.description,
+            id: w['@id'],
+          }))
+          .sort(({ label: a }, { label: b }) => {
+            if (a < b) {
+              return -1;
+            }
+            if (a > b) {
+              return 1;
+            }
+            return 0;
+          })}
         onSelected={(id: string) => {
           selectWorkspace(id, workspaces);
         }}

--- a/src/shared/hooks/useQueryString.ts
+++ b/src/shared/hooks/useQueryString.ts
@@ -2,7 +2,7 @@ import * as queryString from 'query-string';
 import { useHistory } from 'react-router';
 
 export type QueryParams = {
-  [key: string]: any; // string | string[] | null | undefined;
+  [key: string]: any;
 };
 
 export default function useQueryString() {

--- a/src/shared/hooks/useQueryString.ts
+++ b/src/shared/hooks/useQueryString.ts
@@ -1,0 +1,23 @@
+import * as queryString from 'query-string';
+import { useHistory } from 'react-router';
+
+export type QueryParams = {
+  [key: string]: any; // string | string[] | null | undefined;
+};
+
+export default function useQueryString() {
+  const history = useHistory();
+  const queryParams: QueryParams =
+    queryString.parse(history.location.search) || {};
+
+  const setQueryString = (newQueryParams: QueryParams) => {
+    history.push(
+      `${history.location.pathname}?${queryString.stringify(newQueryParams)}`
+    );
+  };
+
+  return [queryParams, setQueryString] as [
+    QueryParams,
+    (newQueryParams: QueryParams) => void
+  ];
+}

--- a/src/shared/views/StudioView.tsx
+++ b/src/shared/views/StudioView.tsx
@@ -1,33 +1,15 @@
 import * as React from 'react';
-import { match } from 'react-router';
+import { useParams } from 'react-router';
 import { Link } from 'react-router-dom';
 import { Tooltip, Icon } from 'antd';
 
 import StudioContainer from '../containers/StudioContainer';
+import WorkspaceList from '../containers/WorkspaceListContainer';
+import DashboardList from '../containers/DashboardListContainer';
 
-type StudioViewProps = {
-  match: match<{
-    orgLabel: string;
-    projectLabel: string;
-    studioId: string;
-    workspaceId: string;
-    dashboardId: string;
-    studioResourceId: string;
-  }>;
-};
+const StudioView: React.FunctionComponent<{}> = () => {
+  const { orgLabel, projectLabel, studioId } = useParams();
 
-const StudioView: React.FunctionComponent<StudioViewProps> = props => {
-  const { match } = props;
-  const {
-    params: {
-      orgLabel,
-      projectLabel,
-      studioId,
-      workspaceId,
-      dashboardId,
-      studioResourceId,
-    },
-  } = match;
   return (
     <>
       <div className="project-banner no-bg" style={{ marginBottom: 20 }}>
@@ -48,14 +30,40 @@ const StudioView: React.FunctionComponent<StudioViewProps> = props => {
         </div>
       </div>
       <div className="studio-view">
-        <StudioContainer
-          orgLabel={orgLabel}
-          projectLabel={projectLabel}
-          studioId={studioId}
-          workspaceId={workspaceId}
-          dashboardId={dashboardId}
-          studioResourceId={studioResourceId}
-        />
+        {orgLabel && projectLabel && studioId && (
+          <StudioContainer
+            orgLabel={orgLabel}
+            projectLabel={projectLabel}
+            studioId={studioId}
+            workspaceListComponent={({
+              workspaceIds,
+              reloadWorkspaces,
+              studioResource,
+            }) => {
+              return (
+                <WorkspaceList
+                  orgLabel={orgLabel}
+                  projectLabel={projectLabel}
+                  workspaceIds={workspaceIds}
+                  studioResource={studioResource}
+                  onListUpdate={reloadWorkspaces}
+                  dashboardListComponent={({ dashboards, workspaceId }) => {
+                    return (
+                      <DashboardList
+                        orgLabel={orgLabel}
+                        projectLabel={projectLabel}
+                        dashboards={dashboards}
+                        workspaceId={workspaceId}
+                        studioResourceId={studioResource['@id']}
+                        refreshList={reloadWorkspaces}
+                      />
+                    );
+                  }}
+                />
+              );
+            }}
+          />
+        )}
       </div>
     </>
   );


### PR DESCRIPTION
fixes: https://github.com/BlueBrain/nexus/issues/977

resolves jankiness by: 
- moving routing state to query params
- sorts workspace and dashboard results alphabetically, because the ordering is random, which causes jankiness when re-rendering tabs
- removes unnecessary re-rendering by moving components to be direct children of StudioView as a render function (see [here](https://github.com/BlueBrain/nexus-web/compare/Bugfix/977-janky-studio?expand=1#diff-ea6bdbcf23c5771fd39fc5aa667e45a1R38))

adds a `userQueryString` helper hook