### PR TITLE
981 Add default sort by id

### DIFF
--- a/src/shared/components/ResourceList/index.tsx
+++ b/src/shared/components/ResourceList/index.tsx
@@ -41,7 +41,7 @@ export type ResourceBoardList = {
 };
 
 const RESOURCE_CARD_MOUSE_ENTER_DELAY = 0.5;
-const DEFAULT_SORT_OPTION = '-_createdAt';
+const DEFAULT_SORT_OPTION = ['-_createdAt'];
 
 const ResourceListComponent: React.FunctionComponent<{
   busy: boolean;
@@ -119,7 +119,7 @@ const ResourceListComponent: React.FunctionComponent<{
   const hasMore = resources.length < Number(total || 0);
 
   const sortOptions = (
-    <Menu onClick={onChangeSort} selectedKeys={[sortOption]}>
+    <Menu onClick={onChangeSort} selectedKeys={sortOption}>
       <Menu.Item key="-_createdAt">Newest</Menu.Item>
       <Menu.Item key="_createdAt">Oldest</Menu.Item>
     </Menu>

--- a/src/shared/components/ResourceList/index.tsx
+++ b/src/shared/components/ResourceList/index.tsx
@@ -41,7 +41,7 @@ export type ResourceBoardList = {
 };
 
 const RESOURCE_CARD_MOUSE_ENTER_DELAY = 0.5;
-const DEFAULT_SORT_OPTION = ['-_createdAt'];
+const DEFAULT_SORT_OPTION = '-_createdAt';
 
 const ResourceListComponent: React.FunctionComponent<{
   busy: boolean;
@@ -119,7 +119,7 @@ const ResourceListComponent: React.FunctionComponent<{
   const hasMore = resources.length < Number(total || 0);
 
   const sortOptions = (
-    <Menu onClick={onChangeSort} selectedKeys={sortOption}>
+    <Menu onClick={onChangeSort} selectedKeys={[sortOption]}>
       <Menu.Item key="-_createdAt">Newest</Menu.Item>
       <Menu.Item key="_createdAt">Oldest</Menu.Item>
     </Menu>

--- a/src/shared/containers/ResourceListContainer.tsx
+++ b/src/shared/containers/ResourceListContainer.tsx
@@ -179,7 +179,7 @@ const ResourceListContainer: React.FunctionComponent<{
       ...list,
       query: {
         ...list.query,
-        sort: option,
+        sort: [option, '@id'],
       },
     });
   };


### PR DESCRIPTION
The Resource list is still sorted from newest by default AND sorted by id now too.
(In case there are also resource created at the same time (edge case)).

Fixes BlueBrain/nexus#981