### PR TITLE
976 resource list refresh notification

### DIFF
--- a/src/shared/components/Views/ViewStatisticsProgress.tsx
+++ b/src/shared/components/Views/ViewStatisticsProgress.tsx
@@ -75,10 +75,10 @@ export const ViewStatisticsContainer: React.FunctionComponent<
       </Button>
     );
     notification.open({
-      message: 'This project has finished indexing new Resources',
-      duration: null, // don't auto-close
       btn,
       key,
+      message: 'This project has finished indexing new Resources',
+      duration: null, // don't auto-close
       onClose: close,
     });
   };

--- a/src/shared/views/ProjectView.tsx
+++ b/src/shared/views/ProjectView.tsx
@@ -37,25 +37,6 @@ const ProjectView: React.FunctionComponent<{
   const [menuVisible, setMenuVisible] = React.useState(true);
   const [refreshLists, setRefreshLists] = React.useState(false);
 
-  const handleResourceCreated = () => {
-    let totalEvents: number;
-
-    const subscription = nexus.View.pollStatistics(
-      orgLabel,
-      projectLabel,
-      DEFAULT_ELASTIC_SEARCH_VIEW_ID,
-      { pollIntervalMs: 300 }
-    ).subscribe(({ _results }) => {
-      const data = _results[0];
-      if (!totalEvents) {
-        totalEvents = data.totalEvents;
-      } else if (data.totalEvents !== totalEvents) {
-        setRefreshLists(!refreshLists);
-        subscription.unsubscribe();
-      }
-    });
-  };
-
   React.useEffect(() => {
     setState({
       project,
@@ -105,6 +86,9 @@ const ProjectView: React.FunctionComponent<{
                   orgLabel={orgLabel}
                   projectLabel={project._label}
                   resourceId={DEFAULT_ELASTIC_SEARCH_VIEW_ID}
+                  onClickRefresh={() => {
+                    setRefreshLists(!refreshLists);
+                  }}
                 />
               </div>
               {!!project.description && (
@@ -141,7 +125,6 @@ const ProjectView: React.FunctionComponent<{
                     <ResourceFormContainer
                       orgLabel={orgLabel}
                       projectLabel={projectLabel}
-                      onResourceCreated={handleResourceCreated}
                     />
                   </AccessControl>
                   <Link
@@ -176,6 +159,7 @@ const ProjectView: React.FunctionComponent<{
               <ResourceListBoardContainer
                 orgLabel={orgLabel}
                 projectLabel={projectLabel}
+                refreshLists={refreshLists}
               />
               <StudioListContainer
                 orgLabel={orgLabel}


### PR DESCRIPTION
fixes https://github.com/BlueBrain/nexus/issues/976

Updates `ViewStatisticsProgress` container to emit a notification when a new Resource has entered the project and indexing has finished. Allows for a callback when the notification is dismissed which is used in the ProjectView to refresh the list.

<img width="702" alt="Screenshot 2020-01-17 at 10 43 42" src="https://user-images.githubusercontent.com/5485824/72602042-e4dd6600-3916-11ea-834c-198b5016e470.png">

Also works in the query editor view, without the refresh callback.

<img width="713" alt="Screenshot 2020-01-17 at 10 44 36" src="https://user-images.githubusercontent.com/5485824/72602038-e444cf80-3916-11ea-9d6d-811c69258779.png">
