### PR TITLE
Navigate to in app location for query results

### DIFF
--- a/src/shared/components/ViewForm/SparqlQueryResults.tsx
+++ b/src/shared/components/ViewForm/SparqlQueryResults.tsx
@@ -24,7 +24,6 @@ export type Entry = {
   type: string;
 };
 
-
 const getUrl = (entry: string) => {
   try {
     return matchResultUrls(entry);

--- a/src/shared/components/ViewForm/SparqlQueryResults.tsx
+++ b/src/shared/components/ViewForm/SparqlQueryResults.tsx
@@ -9,7 +9,6 @@ import {
 } from '@bbp/nexus-sdk';
 
 import './view-form.less';
-import { parseProjectUrl } from '../../utils';
 
 export type NexusSparqlError =
   | string
@@ -38,7 +37,6 @@ const getUrl = (entry: string) => {
       if (resourceIdPattern.test(entry)) {
         const resultArray = entry.match(resourceIdPattern) as string[];
         if (resultArray !== null && resultArray.length > 1) {
-          console.log(`${labels[1]}/resources/${resultArray[1]}`);
           return `${labels[1]}/resources/${resultArray[1]}`;
         }
       }

--- a/src/shared/components/ViewForm/SparqlQueryResults.tsx
+++ b/src/shared/components/ViewForm/SparqlQueryResults.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Card, Empty, Table, Tooltip, notification } from 'antd';
 import Column from 'antd/lib/table/Column';
 import * as hash from 'object-hash';
+import { matchResultUrls } from '../../utils';
 import {
   AskQueryResponse,
   SelectQueryResponse,
@@ -23,24 +24,10 @@ export type Entry = {
   type: string;
 };
 
+
 const getUrl = (entry: string) => {
   try {
-    const projectUrlPattern = /projects\/([\w-]+)\/([\w-]+)\/?$/;
-    const resourceUrlPattern = /resources(\/([\w-]+)\/([\w-]+))/;
-    if (projectUrlPattern.test(entry)) {
-      const [, org, proj] = entry.match(projectUrlPattern) as string[];
-      return `${org}/${proj}`;
-    }
-    if (resourceUrlPattern.test(entry)) {
-      const resourceIdPattern = /_\/([\w-|\W-]+)/;
-      const labels = entry.match(resourceUrlPattern) as string[];
-      if (resourceIdPattern.test(entry)) {
-        const resultArray = entry.match(resourceIdPattern) as string[];
-        if (resultArray !== null && resultArray.length > 1) {
-          return `${labels[1]}/resources/${resultArray[1]}`;
-        }
-      }
-    }
+    return matchResultUrls(entry);
   } catch (error) {
     notification.error({
       message: `Could not parse ${entry}`,

--- a/src/shared/utils/__tests__/index.spec.ts
+++ b/src/shared/utils/__tests__/index.spec.ts
@@ -8,6 +8,7 @@ import {
   hasExpired,
   camelCaseToLabelString,
   camelCaseToTitleCase,
+  matchResultUrls,
 } from '..';
 
 const identities: Identity[] = [
@@ -154,6 +155,30 @@ describe('utils functions', () => {
     });
     it('should format the almost CamelCaseString anyway', () => {
       expect(camelCaseToLabelString(almostCamelCase)).toEqual('Fine Anyway');
+    });
+  });
+
+  describe('matchResultUrls()', () => {
+    const projectUrl =
+      'https://staging.nexus.ocp.bbp.epfl.ch/v1/projects/public/graphql-ld';
+    const resourceUrl =
+      'https://staging.nexus.ocp.bbp.epfl.ch/v1/resources/public/graphql-ld/_/https:%2F%2Fbluebrainnexus.io%2Fstudio%2Fcontext';
+    const noMatchUrl =
+      'https://bluebrain.github.io/nexus/schemas/unconstrained.json';
+    it('should match a project url', () => {
+      expect(matchResultUrls(projectUrl)).toEqual('public/graphql-ld');
+    });
+
+    it('should match a resource url', () => {
+      expect(matchResultUrls(resourceUrl)).toEqual(
+        '/public/graphql-ld/resources/https:%2F%2Fbluebrainnexus.io%2Fstudio%2Fcontext'
+      );
+    });
+
+    it('return the input when no match is found', () => {
+      expect(matchResultUrls(noMatchUrl)).toEqual(
+        'https://bluebrain.github.io/nexus/schemas/unconstrained.json'
+      );
     });
   });
 });

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -283,3 +283,30 @@ export const camelCaseToTitleCase = (camelCase: string): string => {
   // capitalize the first letter
   return result.charAt(0).toUpperCase() + result.slice(1);
 };
+
+/*
+ * Tests for project and resource path in a given string.
+ *
+ * @param {string} entry url string
+ * @returns {string} path (either resource pr project path) or the input url.
+ */
+
+export const matchResultUrls = (entry: string) => {
+  const projectUrlPattern = /projects\/([\w-]+)\/([\w-]+)\/?$/;
+  const resourceUrlPattern = /resources(\/([\w-]+)\/([\w-]+))/;
+  if (projectUrlPattern.test(entry)) {
+    const [, org, proj] = entry.match(projectUrlPattern) as string[];
+    return `${org}/${proj}`;
+  }
+  if (resourceUrlPattern.test(entry)) {
+    const resourceIdPattern = /_\/([\w-|\W-]+)/;
+    const labels = entry.match(resourceUrlPattern) as string[];
+    if (resourceIdPattern.test(entry)) {
+      const resultArray = entry.match(resourceIdPattern) as string[];
+      if (resultArray !== null && resultArray.length > 1) {
+        return `${labels[1]}/resources/${resultArray[1]}`;
+      }
+    }
+  }
+  return entry;
+};


### PR DESCRIPTION
Parse urls in query results and point them to an in app location, if
available.

Fixes #BlueBrain/nexus/issues/838