### PR TITLE
Bugfix/simplify gtm

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "react": "^16.8.6",
     "react-codemirror2": "^5.1.0",
     "react-dom": "^16.8.6",
-    "react-google-tag-manager": "^2.2.1",
     "react-helmet": "^5.2.0",
     "react-image-lightbox": "^5.1.0",
     "react-infinite-scroll-component": "^4.5.3",

--- a/src/shared/containers/ConsentContainer.tsx
+++ b/src/shared/containers/ConsentContainer.tsx
@@ -1,25 +1,32 @@
 import * as React from 'react';
-import gtmParts from 'react-google-tag-manager';
 import { Modal } from 'antd';
 import { ConsentType } from '../layouts/MainLayout';
 import { useSelector } from 'react-redux';
 import { RootState } from '../store/reducers';
 
-const enableTracking = (trackingCode: string) => {
-  const gtm = gtmParts({
-    id: trackingCode,
-    dataLayerName: 'dataLayer',
-    additionalEvents: {},
-    previewVariables: false,
-    scheme: 'https:',
-  });
+declare global {
+  interface Window {
+    [key: string]: any;
+  }
+}
 
-  return (
-    <div>
-      <div>{gtm.noScriptAsReact()}</div>
-      <div id="react-google-tag-manager-gtm">{gtm.scriptAsReact()}</div>
-    </div>
-  );
+const DATA_LAYER = 'dataLayer';
+
+const enableTracking = (trackingCode: string) => {
+  window[DATA_LAYER] = window[DATA_LAYER] || [];
+  window[`ga-disable-${trackingCode}-1`] = false;
+  window[DATA_LAYER].push({
+    'gtm.start': new Date().getTime(),
+    event: 'gtm.js',
+  });
+  const gTagNode = document.createElement('div');
+  gTagNode.id = 'gTagNode';
+  document.head.prepend(gTagNode);
+  const j = document.createElement('script');
+  const dl = DATA_LAYER != 'dataLayer' ? '&l=' + DATA_LAYER : '';
+  j.async = true;
+  j.src = `https://www.googletagmanager.com/gtm.js?id=${trackingCode}${dl}`;
+  gTagNode.prepend(j);
 };
 
 const ConsentContainer: React.FunctionComponent<{
@@ -42,6 +49,7 @@ const ConsentContainer: React.FunctionComponent<{
         consentToTracking: false,
         hasSetPreferences: true,
       });
+    location.reload();
   };
 
   if (!gtmCode) {
@@ -63,7 +71,7 @@ const ConsentContainer: React.FunctionComponent<{
   }
 
   if (consent && consent.consentToTracking) {
-    return enableTracking(gtmCode);
+    enableTracking(gtmCode);
   }
 
   return null;

--- a/src/shared/containers/ConsentContainer.tsx
+++ b/src/shared/containers/ConsentContainer.tsx
@@ -23,7 +23,7 @@ const enableTracking = (trackingCode: string) => {
   gTagNode.id = 'gTagNode';
   document.head.prepend(gTagNode);
   const j = document.createElement('script');
-  const dl = DATA_LAYER != 'dataLayer' ? '&l=' + DATA_LAYER : '';
+  const dl = DATA_LAYER !== 'dataLayer' ? `&l=${DATA_LAYER}` : '';
   j.async = true;
   j.src = `https://www.googletagmanager.com/gtm.js?id=${trackingCode}${dl}`;
   gTagNode.prepend(j);

--- a/yarn.lock
+++ b/yarn.lock
@@ -8917,11 +8917,6 @@ react-focus-lock@^1.18.3:
     prop-types "^15.6.2"
     react-clientside-effect "^1.2.0"
 
-react-google-tag-manager@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/react-google-tag-manager/-/react-google-tag-manager-2.2.1.tgz#b0659c7b19d9263c7cb45d3c019f506529af9077"
-  integrity sha512-8yPbEE3r2z0OWRvJYg1HegKQktH2fIJ2hHCFzAk7+GeOHIK7Vcq+dA0wo2Wf81oHSPMHiOY7nhXIviSVJFV64w==
-
 react-helmet-async@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/react-helmet-async/-/react-helmet-async-1.0.4.tgz#079ef10b7fefcaee6240fefd150711e62463cc97"


### PR DESCRIPTION
- fixes gtm flow by executing code directly in `enableTracking()`
- removes unnecessary package
- simplifies things a bit by triggering page reload when user wants to disable tracking

## How to test?
open this locally with ENV var `GTM_CODE=AnActualGTMCode` (make sure the GTM code is real)
- if you consent to tracking, the code should append script tags to the document before the `head` tag.
- if you dis-allow tracking, the page should reload
- clicking allow when you didn't allow things previously should not trigger a reload