### PR TITLE
Add a route

### DIFF
--- a/src/shared/routes.ts
+++ b/src/shared/routes.ts
@@ -10,6 +10,7 @@ import SparqlQueryView from './views/SparqlQueryView';
 import ACLsView from './views/ACLsView';
 import UserView from './views/UserView';
 import StudioView from './views/StudioView';
+import StudioResourceView from './views/StudioResourceView';
 
 const routes: RouteProps[] = [
   {
@@ -38,6 +39,10 @@ const routes: RouteProps[] = [
   {
     path: '/:orgLabel/:projectLabel/resources/:resourceId',
     component: ResourceView,
+  },
+  {
+    path: '/:orgLabel/:projectLabel/studio-resources/:resourceId',
+    component: StudioResourceView,
   },
   {
     path: '/:orgLabel/:projectLabel/studios/:studioId',

--- a/src/shared/views/StudioResourceView.tsx
+++ b/src/shared/views/StudioResourceView.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { useParams } from 'react-router';
+
+const StudioResourceView: React.FunctionComponent<{}> = () => {
+  const { orgLabel, projectLabel, resourceId } = useParams();
+
+  console.log(
+    'orgLabel, projectLabel, resourceId',
+    orgLabel,
+    projectLabel,
+    resourceId
+  );
+
+  return <div>Studio Resource View</div>;
+};
+
+export default StudioResourceView;


### PR DESCRIPTION
Added a new route:
`/:orgLabel/:projectLabel/studio-resources/:resourceId`
that renders new StudioResourceView component, which is empty at the moment.

Part of BlueBrain/nexus#1001