### PR TITLE
Bugfix/refresh notifcations

### DIFF
--- a/src/shared/components/Views/ViewStatisticsProgress.tsx
+++ b/src/shared/components/Views/ViewStatisticsProgress.tsx
@@ -10,9 +10,7 @@ type ViewStatisticsProgressProps = {
   lastIndexed: string; // UTC Date
 };
 
-export const ViewStatisticsProgress: React.FunctionComponent<
-  ViewStatisticsProgressProps
-> = props => {
+export const ViewStatisticsProgress: React.FunctionComponent<ViewStatisticsProgressProps> = props => {
   const percent = Math.floor((props.processedEvents / props.totalEvents) * 100);
   const label =
     percent === 100
@@ -35,9 +33,7 @@ export type ViewStatisticsContainerProps = {
   onClickRefresh?: VoidFunction;
 };
 
-export const ViewStatisticsContainer: React.FunctionComponent<
-  ViewStatisticsContainerProps
-> = props => {
+export const ViewStatisticsContainer: React.FunctionComponent<ViewStatisticsContainerProps> = props => {
   const nexus = useNexusContext();
   const [eventsAtMount, setEventsAtMount] = React.useState();
   const [{ loading, error, data }, setState] = React.useState<{
@@ -51,7 +47,8 @@ export const ViewStatisticsContainer: React.FunctionComponent<
   });
 
   const indexCompleteNotification = () => {
-    const key = `open${Date.now()}`;
+    const key = 'IndexComplete';
+    const time = Date.now();
     const btn = props.onClickRefresh ? (
       <Button
         type="primary"
@@ -77,7 +74,15 @@ export const ViewStatisticsContainer: React.FunctionComponent<
     notification.open({
       btn,
       key,
-      message: 'This project has finished indexing new Resources',
+      message: 'This project has finished indexing new Resources ',
+      description: (
+        <div>
+          Last updated{' '}
+          <span className="flash" key={`${Date.now()}`}>
+            {moment(time).format('h:mm:ss a')}
+          </span>
+        </div>
+      ),
       duration: null, // don't auto-close
       onClose: close,
     });

--- a/src/shared/components/Views/ViewStatisticsProgress.tsx
+++ b/src/shared/components/Views/ViewStatisticsProgress.tsx
@@ -82,7 +82,7 @@ export const ViewStatisticsContainer: React.FunctionComponent<
       description: (
         <div>
           Last updated{' '}
-          <span className="flash" key={`${Date.now()}`}>
+          <span className="flash" key={time}>
             {moment(time).format('h:mm:ss a')}
           </span>
         </div>

--- a/src/shared/components/Views/ViewStatisticsProgress.tsx
+++ b/src/shared/components/Views/ViewStatisticsProgress.tsx
@@ -10,7 +10,9 @@ type ViewStatisticsProgressProps = {
   lastIndexed: string; // UTC Date
 };
 
-export const ViewStatisticsProgress: React.FunctionComponent<ViewStatisticsProgressProps> = props => {
+export const ViewStatisticsProgress: React.FunctionComponent<
+  ViewStatisticsProgressProps
+> = props => {
   const percent = Math.floor((props.processedEvents / props.totalEvents) * 100);
   const label =
     percent === 100
@@ -33,7 +35,9 @@ export type ViewStatisticsContainerProps = {
   onClickRefresh?: VoidFunction;
 };
 
-export const ViewStatisticsContainer: React.FunctionComponent<ViewStatisticsContainerProps> = props => {
+export const ViewStatisticsContainer: React.FunctionComponent<
+  ViewStatisticsContainerProps
+> = props => {
   const nexus = useNexusContext();
   const [eventsAtMount, setEventsAtMount] = React.useState();
   const [{ loading, error, data }, setState] = React.useState<{

--- a/src/shared/lib.less
+++ b/src/shared/lib.less
@@ -120,6 +120,10 @@ h1 {
   margin: 0 auto;
 }
 
+.flash {
+  animation: TextFlash 1s ease-out;
+}
+
 .scrollBar() {
   /* width */
   ::-webkit-scrollbar {
@@ -136,6 +140,17 @@ h1 {
   /* Handle on hover */
   ::-webkit-scrollbar-thumb:hover {
     background: #555;
+  }
+}
+
+@keyframes TextFlash {
+  0% {
+    text-shadow: 0px 0px 6px @warning-color;
+    color: white;
+  }
+  100% {
+    text-shadow: 0px 0px 0px @warning-color;
+    color: @text-color-secondary;
   }
 }
 


### PR DESCRIPTION
addresses feedback from @umbreak 
- only shows the index refresh notification once
- now shows the time when the last index finished (roughly)
- 📸 flashes with a mysterious glow whenever the view is re-indexed!

![Jan-29-2020 15-31-04](https://user-images.githubusercontent.com/5485824/73365348-6edce580-42ac-11ea-8e32-457df5703669.gif)
