### PR TITLE
Fix/ Display groups better in User Page

### DIFF
--- a/src/shared/views/UserView.tsx
+++ b/src/shared/views/UserView.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { useSelector } from 'react-redux';
 import { notification, Button, Descriptions, List, Typography } from 'antd';
 import { useNexusContext } from '@bbp/react-nexus';
-import { push } from 'connected-react-router';
 
 import { RootState } from '../store/reducers';
 import { useHistory } from 'react-router';


### PR DESCRIPTION
feedback from @umbreak 

With groups:
![Screenshot 2020-01-29 at 17 25 50](https://user-images.githubusercontent.com/5485824/73376072-1eba4f00-42bd-11ea-91fa-acdd33be1585.png)

Without groups (super boring):
![Screenshot 2020-01-29 at 17 26 34](https://user-images.githubusercontent.com/5485824/73376080-21b53f80-42bd-11ea-86ba-e7b31787df5f.png)

Anonymous:
![Screenshot 2020-01-29 at 17 28 22](https://user-images.githubusercontent.com/5485824/73376084-24b03000-42bd-11ea-978d-42834e23b0a8.png)
