### PR TITLE
fix undefined error for Results Table

### DIFF
--- a/src/shared/components/ResultsTable/ResultsTable.tsx
+++ b/src/shared/components/ResultsTable/ResultsTable.tsx
@@ -75,7 +75,7 @@ const ResultsTable: React.FunctionComponent<ResultTableProps> = ({
           const distinctValues = filteredItems.reduce(
             (memo, item) => {
               const value = item[dataIndex];
-              if (!memo.includes(value)) {
+              if (value && !memo.includes(value)) {
                 memo.push(value);
               }
               return memo;


### PR DESCRIPTION
prevents an error from causing the results table to crash when a filter value of "undefined" is returned from SPARQL