### PR TITLE
fix problem loading plugins if only one is selected

### DIFF
--- a/src/shared/views/StudioResourceView.tsx
+++ b/src/shared/views/StudioResourceView.tsx
@@ -79,7 +79,12 @@ const StudioResourceView: React.FunctionComponent<{}> = () => {
 
   if (!dashboard || !resource) return null;
 
-  const { plugins } = dashboard;
+  const plugins: string[] = !!dashboard.plugins
+    ? Array.isArray(dashboard.plugins)
+      ? dashboard.plugins
+      : [dashboard.plugins]
+    : [];
+
   const label = getResourceLabel(resource);
 
   return (


### PR DESCRIPTION
fixes a problem where, because of json-ld reasons, a single entry under the plugins property of dashboards would not be treated as an array, crashing the app because it cannot be mapped. 