### PR TITLE
bugfix/ pass background to goToStudioResource

### DIFF
--- a/src/shared/views/StudioResourceView.tsx
+++ b/src/shared/views/StudioResourceView.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useParams, useHistory } from 'react-router';
+import { useParams, useHistory, useLocation } from 'react-router';
 import { useNexusContext } from '@bbp/react-nexus';
 import { Resource } from '@bbp/nexus-sdk';
 import { notification, Empty } from 'antd';
@@ -24,6 +24,8 @@ const StudioResourceView: React.FunctionComponent<{}> = () => {
   const { resourceSelfUri = '' } = useParams();
 
   const history = useHistory();
+  const location = useLocation();
+
   const queryParams: QueryParams =
     queryString.parse(history.location.search) || {};
   const dashboardUrl = queryParams.dashboard;
@@ -74,7 +76,7 @@ const StudioResourceView: React.FunctionComponent<{}> = () => {
     const base64EncodedUri = btoa(selfUrl);
     const studioResourceViewLink = `/studios/studio-resources/${base64EncodedUri}?dashboard=${dashboardUrl}`;
 
-    history.push(studioResourceViewLink);
+    history.push(studioResourceViewLink, { background: location });
   };
 
   if (!dashboard || !resource) return null;


### PR DESCRIPTION
Fix a bug where a studio resource link inside the StudioResourceView would open up in the expanded view instead of the modal view. 