### PR TITLE
Bugfix/1030 studio plugin resource navigation

### DIFF
--- a/src/shared/containers/NexusPlugin.tsx
+++ b/src/shared/containers/NexusPlugin.tsx
@@ -39,7 +39,6 @@ export class NexusPlugin extends React.Component<
 
   loadExternalPlugin() {
     // @ts-ignore
-    console.log('reloading plugin');
     window.System.import(this.props.url)
       .then(
         (module: {

--- a/src/shared/containers/NexusPlugin.tsx
+++ b/src/shared/containers/NexusPlugin.tsx
@@ -39,6 +39,7 @@ export class NexusPlugin extends React.Component<
 
   loadExternalPlugin() {
     // @ts-ignore
+    console.log('reloading plugin');
     window.System.import(this.props.url)
       .then(
         (module: {
@@ -77,10 +78,10 @@ export class NexusPlugin extends React.Component<
 
   componentWillUpdate(prevProps: NexusPluginClassProps) {
     // Reload the plugin(and pass in new props to it) when props change
+    // NOTE: will not reload the plugin if nexusClient or goToResource changes
+    // otherwise it will cause too many reloads
     if (
       prevProps.resource !== this.props.resource ||
-      prevProps.nexusClient !== this.props.nexusClient ||
-      prevProps.goToResource !== this.props.goToResource ||
       prevProps.url !== this.props.url
     ) {
       this.loadExternalPlugin();

--- a/src/shared/containers/NexusPlugin.tsx
+++ b/src/shared/containers/NexusPlugin.tsx
@@ -37,11 +37,7 @@ export class NexusPlugin extends React.Component<
     invariant(window.System, warningMessage);
   }
 
-  componentDidCatch(e: Error) {
-    this.setState({ hasError: true, loading: false });
-  }
-
-  componentDidMount() {
+  loadExternalPlugin() {
     // @ts-ignore
     window.System.import(this.props.url)
       .then(
@@ -73,6 +69,26 @@ export class NexusPlugin extends React.Component<
       .catch((error: Error) => {
         this.setState({ hasError: true, loading: false });
       });
+  }
+
+  componentDidCatch(e: Error) {
+    this.setState({ hasError: true, loading: false });
+  }
+
+  componentWillUpdate(prevProps: NexusPluginClassProps) {
+    // Reload the plugin(and pass in new props to it) when props change
+    if (
+      prevProps.resource !== this.props.resource ||
+      prevProps.nexusClient !== this.props.nexusClient ||
+      prevProps.goToResource !== this.props.goToResource ||
+      prevProps.url !== this.props.url
+    ) {
+      this.loadExternalPlugin();
+    }
+  }
+
+  componentDidMount() {
+    this.loadExternalPlugin();
   }
 
   componentWillUnmount() {

--- a/src/shared/views/StudioResourceView.tsx
+++ b/src/shared/views/StudioResourceView.tsx
@@ -89,8 +89,6 @@ const StudioResourceView: React.FunctionComponent<{}> = () => {
 
   const label = getResourceLabel(resource);
 
-  console.log({ resourceSelfUri });
-
   return (
     <div className="studio-resource-view">
       <h1>{label}</h1>

--- a/src/shared/views/StudioResourceView.tsx
+++ b/src/shared/views/StudioResourceView.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useParams, useHistory } from 'react-router';
+import { useParams, useHistory, useLocation } from 'react-router';
 import { useNexusContext } from '@bbp/react-nexus';
 import { Resource } from '@bbp/nexus-sdk';
 import { notification, Empty } from 'antd';
@@ -24,8 +24,10 @@ const StudioResourceView: React.FunctionComponent<{}> = () => {
   const { resourceSelfUri = '' } = useParams();
 
   const history = useHistory();
-  const queryParams: QueryParams =
-    queryString.parse(history.location.search) || {};
+  const location = useLocation();
+
+  const queryParams: QueryParams = queryString.parse(location.search) || {};
+
   const dashboardUrl = queryParams.dashboard;
   const [dashboard, setDashboard] = React.useState<DashboardResource | null>();
   const [resource, setResource] = React.useState<Resource | null>();
@@ -74,7 +76,7 @@ const StudioResourceView: React.FunctionComponent<{}> = () => {
     const base64EncodedUri = btoa(selfUrl);
     const studioResourceViewLink = `/studios/studio-resources/${base64EncodedUri}?dashboard=${dashboardUrl}`;
 
-    history.push(studioResourceViewLink);
+    history.push(studioResourceViewLink, location.state);
   };
 
   if (!dashboard || !resource) return null;
@@ -86,6 +88,8 @@ const StudioResourceView: React.FunctionComponent<{}> = () => {
     : [];
 
   const label = getResourceLabel(resource);
+
+  console.log({ resourceSelfUri });
 
   return (
     <div className="studio-resource-view">


### PR DESCRIPTION
fixes: https://github.com/BlueBrain/nexus/issues/1030

Clicking to a resource from the results table shows a model, and navigating using `goToResource()` from within a plugin now opens the resource in the same modal as well, just as it works in the normal `ResourceVIew`

![route navigation](https://user-images.githubusercontent.com/5485824/74655320-7ba67800-518c-11ea-9535-4134bbd0cf46.gif)
