### PR TITLE
1032 Display time values in studio

### DIFF
--- a/src/shared/components/ResultsTable/ResultsTable.tsx
+++ b/src/shared/components/ResultsTable/ResultsTable.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as moment from 'moment';
 import { Input, Table } from 'antd';
 
-import { parseProjectUrl } from '../../utils/index';
+import { parseProjectUrl, isISODate } from '../../utils/index';
 
 import './ResultTable.less';
 
@@ -11,6 +11,7 @@ const { Search } = Input;
 const PAGE_SIZE = 10;
 const MAX_FILTER_LIMIT = 20;
 const MIN_FILTER_LIMIT = 1;
+const DATE_FORMAT = 'DD-MM-YYYY, HH:mm';
 
 type ResultTableProps = {
   headerProperties?: {
@@ -74,6 +75,14 @@ const ResultsTable: React.FunctionComponent<ResultTableProps> = ({
                 const item = items.find(item => item[dataIndex] === value);
                 const base64EncodedUri = btoa(item && item.self.value);
                 const studioResourceViewLink = `/studios/studio-resources/${base64EncodedUri}?dashboard=${dashboardUrl}`;
+
+                if (isISODate(value)) {
+                  return (
+                    <a href={studioResourceViewLink}>
+                      {moment(value).format(DATE_FORMAT)}
+                    </a>
+                  );
+                }
 
                 return <a href={studioResourceViewLink}>{value}</a>;
               };

--- a/src/shared/components/ResultsTable/ResultsTable.tsx
+++ b/src/shared/components/ResultsTable/ResultsTable.tsx
@@ -91,8 +91,7 @@ const ResultsTable: React.FunctionComponent<ResultTableProps> = ({
           }
 
           const distinctValues = filteredItems.reduce((memo, item) => {
-            let value = item[dataIndex];
-
+            const value = item[dataIndex];
             if (value && !memo.includes(value)) {
               memo.push(value);
             }

--- a/src/shared/components/ResultsTable/ResultsTable.tsx
+++ b/src/shared/components/ResultsTable/ResultsTable.tsx
@@ -91,7 +91,8 @@ const ResultsTable: React.FunctionComponent<ResultTableProps> = ({
           }
 
           const distinctValues = filteredItems.reduce((memo, item) => {
-            const value = item[dataIndex];
+            let value = item[dataIndex];
+
             if (value && !memo.includes(value)) {
               memo.push(value);
             }
@@ -104,7 +105,9 @@ const ResultsTable: React.FunctionComponent<ResultTableProps> = ({
               ? {
                   filters: distinctValues.map(value => ({
                     value,
-                    text: value,
+                    text: isISODate(value)
+                      ? moment(value).format(DATE_FORMAT)
+                      : value,
                   })),
                   filterMultiple: false,
                   onFilter: (filterValue: any, item: any) =>

--- a/src/shared/utils/__tests__/index.spec.ts
+++ b/src/shared/utils/__tests__/index.spec.ts
@@ -9,6 +9,7 @@ import {
   camelCaseToLabelString,
   camelCaseToTitleCase,
   matchResultUrls,
+  isISODate,
 } from '..';
 
 const identities: Identity[] = [
@@ -179,6 +180,19 @@ describe('utils functions', () => {
       expect(matchResultUrls(noMatchUrl)).toEqual(
         'https://bluebrain.github.io/nexus/schemas/unconstrained.json'
       );
+    });
+  });
+
+  describe('isISODate', () => {
+    const ISOString = '2019-07-29T10:26:06.543Z';
+    const otherString = 'randomString';
+
+    it('returns true if a string is an ISO date', () => {
+      expect(isISODate(ISOString)).toEqual(true);
+    });
+
+    it('returns false if a string is not an ISO date', () => {
+      expect(isISODate(otherString)).toEqual(false);
     });
   });
 });

--- a/src/shared/utils/__tests__/index.spec.ts
+++ b/src/shared/utils/__tests__/index.spec.ts
@@ -184,11 +184,11 @@ describe('utils functions', () => {
   });
 
   describe('isISODate', () => {
-    const ISOString = '2019-07-29T10:26:06.543Z';
+    const isoString = '2019-07-29T10:26:06.543Z';
     const otherString = 'randomString';
 
     it('returns true if a string is an ISO date', () => {
-      expect(isISODate(ISOString)).toEqual(true);
+      expect(isISODate(isoString)).toEqual(true);
     });
 
     it('returns false if a string is not an ISO date', () => {

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -301,7 +301,6 @@ export const camelCaseToTitleCase = (camelCase: string): string => {
  * @param {string} entry url string
  * @returns {string} path (either resource pr project path) or the input url.
  */
-
 export const matchResultUrls = (entry: string) => {
   const projectUrlPattern = /projects\/([\w-]+)\/([\w-]+)\/?$/;
   const resourceUrlPattern = /resources(\/([\w-]+)\/([\w-]+))/;
@@ -320,4 +319,16 @@ export const matchResultUrls = (entry: string) => {
     }
   }
   return entry;
+};
+
+/*
+ * Tests if a string is an ISO date
+ *
+ * @param {string} string
+ * @returns {boolean} if a string is an ISO date or not
+ */
+export const isISODate = (date: string) => {
+  const iso_date_regex = /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z)/;
+
+  return iso_date_regex.test(date);
 };

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -328,7 +328,7 @@ export const matchResultUrls = (entry: string) => {
  * @returns {boolean} if a string is an ISO date or not
  */
 export const isISODate = (date: string) => {
-  const iso_date_regex = /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z)/;
+  const isoDateRegex = /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z)/;
 
-  return iso_date_regex.test(date);
+  return isoDateRegex.test(date);
 };


### PR DESCRIPTION
Fixes BlueBrain/nexus#1032

- Adds a check if a string an Iso date string and parses it

![Screenshot 2020-02-18 at 11 13 28](https://user-images.githubusercontent.com/23080476/74726673-29269380-5240-11ea-876b-aae0b529929f.png)

![Screenshot 2020-02-18 at 11 08 19](https://user-images.githubusercontent.com/23080476/74726684-2d52b100-5240-11ea-9a37-bf258deebb02.png)
