### PR TITLE
Place studio in Project Action Menu

### DIFF
--- a/src/shared/components/Studio/Studio.less
+++ b/src/shared/components/Studio/Studio.less
@@ -1,11 +1,6 @@
 @import '../../lib.less';
 
 .studio-list {
-  .cardlike();
-  background-color: @primary-card;
-  width: @default-card-width;
-  min-width: @default-card-width;
-  resize: horizontal;
   display: flex;
   flex-direction: column;
   max-height: 100%;

--- a/src/shared/components/Studio/StudioList.tsx
+++ b/src/shared/components/Studio/StudioList.tsx
@@ -53,7 +53,6 @@ const StudioList: React.FC<{
           onLoadMore={onLoadMore}
           hasMore={hasMore}
           height={500}
-          // height={wrapperHeight - 200} // additional padding for extra chonky list items
           defaultSearchValue={searchQuery}
         >
           {studios.map(studio => {

--- a/src/shared/components/Studio/StudioList.tsx
+++ b/src/shared/components/Studio/StudioList.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { Empty, Spin } from 'antd';
-import useMeasure from '../../hooks/useMeasure';
 
 import ListItem from '../List/Item';
+import InfiniteSearch from '../List/InfiniteSearch';
 
 import './Studio.less';
 
@@ -21,50 +21,59 @@ const StudioItem: React.FC<StudioItemProps> = ({ name, description }) => {
   );
 };
 
-const LIST_HEADER_HEIGHT = 100;
-
 const StudioList: React.FC<{
   studios: StudioItemProps[];
   busy?: boolean;
   error?: Error | null;
   goToStudio?(studioId: string): void;
   createStudioButton?: React.ReactElement;
+  onLoadMore({ searchValue }: { searchValue: string }): void;
+  makeResourceUri(resourceId: string): string;
+  total: number;
+  searchQuery: string;
 }> = ({
   studios,
   busy,
   error,
   goToStudio = () => {},
   createStudioButton = null,
+  onLoadMore,
+  makeResourceUri,
+  total,
+  searchQuery,
 }) => {
-  const [{ ref: wrapperHeightRef }, { height: wrapperHeight }] = useMeasure();
-  const noStudios = studios.length === 0;
-
+  const hasMore = studios.length < Number(total || 0);
   return (
-    <div className="resource-list-height-tester" ref={wrapperHeightRef}>
-      <div className="studio-list">
-        <h3>Studios</h3>
-        <Spin spinning={busy}>
-          {error && (
-            <Empty description={error.message || 'An error occurred'} />
-          )}
-          {!error && noStudios && <Empty description="No studios available" />}
-          {createStudioButton}
-          {!noStudios && (
-            <div
-              style={{
-                overflowY: 'auto',
-                height: wrapperHeight - LIST_HEADER_HEIGHT,
-              }}
-            >
-              {studios.map(studio => (
-                <ListItem onClick={() => goToStudio(studio.id)} key={studio.id}>
+    <div className="studio-list">
+      <Spin spinning={busy}>
+        {createStudioButton}
+        <br />
+        <InfiniteSearch
+          dataLength={studios.length}
+          onLoadMore={onLoadMore}
+          hasMore={hasMore}
+          height={500}
+          // height={wrapperHeight - 200} // additional padding for extra chonky list items
+          defaultSearchValue={searchQuery}
+        >
+          {studios.map(studio => {
+            return (
+              <a
+                href={makeResourceUri(studio.id)}
+                key={studio.id}
+                onClick={e => {
+                  e.preventDefault();
+                  goToStudio(studio.id);
+                }}
+              >
+                <ListItem key={studio.id}>
                   <StudioItem {...studio} />
                 </ListItem>
-              ))}
-            </div>
-          )}
-        </Spin>
-      </div>
+              </a>
+            );
+          })}
+        </InfiniteSearch>
+      </Spin>
     </div>
   );
 };

--- a/src/shared/containers/StudioListContainer.tsx
+++ b/src/shared/containers/StudioListContainer.tsx
@@ -149,8 +149,6 @@ const StudioListContainer: React.FunctionComponent<{
       });
   }, [orgLabel, projectLabel, searchQuery]);
 
-  console.log({ resources });
-
   return (
     <StudioList
       studios={resources.map(r => ({

--- a/src/shared/containers/StudioListContainer.tsx
+++ b/src/shared/containers/StudioListContainer.tsx
@@ -2,10 +2,11 @@ import * as React from 'react';
 import { useHistory } from 'react-router-dom';
 import { useAsyncEffect } from 'use-async-effect';
 import { useNexusContext } from '@bbp/react-nexus';
-import { Resource } from '@bbp/nexus-sdk';
+import { Resource, PaginatedList } from '@bbp/nexus-sdk';
 
 import StudioList from '../components/Studio/StudioList';
 import CreateStudioContainer from './CreateStudioContainer';
+import { response } from 'express';
 
 const DEFAULT_STUDIO_TYPE =
   'https://bluebrainnexus.io/studio/vocabulary/Studio';
@@ -16,6 +17,7 @@ const StudioListContainer: React.FunctionComponent<{
 }> = ({ orgLabel, projectLabel }) => {
   const nexus = useNexusContext();
   const history = useHistory();
+  const [searchQuery, setSearchQuery] = React.useState();
   const [
     { busy, error, resources, total, next },
     setResources,
@@ -43,27 +45,78 @@ const StudioListContainer: React.FunctionComponent<{
     history.push(makeStudioUri(resourceId));
   };
 
-  useAsyncEffect(
-    async isMounted => {
-      if (!isMounted()) {
-        return;
-      }
-      try {
-        setResources({
-          next,
-          resources,
-          total,
-          busy: true,
-          error: null,
-        });
+  const handleLoadMore = async ({ searchValue }: { searchValue: string }) => {
+    if (searchValue !== searchQuery) {
+      return setSearchQuery(searchValue);
+    }
+    if (busy || !next) {
+      return;
+    }
+    try {
+      setResources({
+        next,
+        resources,
+        total,
+        busy: true,
+        error: null,
+      });
+      const response = await nexus.httpGet({
+        path: next,
+      });
+      const newResources = await Promise.all(
+        response._results.map((resource: Resource) =>
+          nexus.Resource.get(
+            orgLabel,
+            projectLabel,
+            encodeURIComponent(resource['@id'])
+          )
+        )
+      );
+      setResources({
+        next: response._next || null,
+        resources: [
+          ...resources,
+          ...(newResources as Resource<{
+            label: string;
+            description: string;
+          }>[]),
+        ],
+        total: response._total,
+        busy: false,
+        error: null,
+      });
+    } catch (error) {
+      setResources({
+        next,
+        error,
+        resources,
+        total,
+        busy: false,
+      });
+    }
+  };
 
-        // get all resources of type studio
-        const response = await nexus.Resource.list(orgLabel, projectLabel, {
-          type: DEFAULT_STUDIO_TYPE,
-          deprecated: false,
-        });
-        // we need to get the metadata for each of them
-        const studios = await Promise.all(
+  React.useEffect(() => {
+    setResources({
+      next,
+      resources,
+      total,
+      busy: true,
+      error: null,
+    });
+
+    let response: PaginatedList<Resource>;
+
+    // get all resources of type studio
+    nexus.Resource.list(orgLabel, projectLabel, {
+      type: DEFAULT_STUDIO_TYPE,
+      deprecated: false,
+      size: 10,
+      q: searchQuery,
+    })
+      .then(studioResponse => {
+        response = studioResponse;
+        return Promise.all(
           response._results.map(resource =>
             nexus.Resource.get(
               orgLabel,
@@ -72,6 +125,8 @@ const StudioListContainer: React.FunctionComponent<{
             )
           )
         );
+      })
+      .then(studios => {
         setResources({
           next: response._next || null,
           resources: studios as Resource<{
@@ -82,7 +137,8 @@ const StudioListContainer: React.FunctionComponent<{
           busy: false,
           error: null,
         });
-      } catch (error) {
+      })
+      .catch(error => {
         setResources({
           next,
           error,
@@ -90,14 +146,10 @@ const StudioListContainer: React.FunctionComponent<{
           total,
           busy: false,
         });
-      }
-    },
-    [
-      // Reset pagination and reload based on these props
-      orgLabel,
-      projectLabel,
-    ]
-  );
+      });
+  }, [orgLabel, projectLabel, searchQuery]);
+
+  console.log({ resources });
 
   return (
     <StudioList
@@ -106,6 +158,10 @@ const StudioListContainer: React.FunctionComponent<{
         name: r.label,
         description: r.description,
       }))}
+      onLoadMore={handleLoadMore}
+      searchQuery={searchQuery}
+      makeResourceUri={makeStudioUri}
+      total={total}
       busy={busy}
       error={error}
       goToStudio={(id: string) => goToStudio(id)}

--- a/src/shared/views/ProjectView.tsx
+++ b/src/shared/views/ProjectView.tsx
@@ -5,7 +5,7 @@ import {
   DEFAULT_ELASTIC_SEARCH_VIEW_ID,
 } from '@bbp/nexus-sdk';
 import { useNexusContext, AccessControl } from '@bbp/react-nexus';
-import { notification, Popover, Divider, Switch } from 'antd';
+import { notification, Popover, Divider, Switch, Tabs, Icon } from 'antd';
 import { Link } from 'react-router-dom';
 
 import ViewStatisticsContainer from '../components/Views/ViewStatisticsProgress';
@@ -15,6 +15,8 @@ import ResourceFormContainer from '../containers/ResourceFormContainer';
 import ResourceListBoardContainer from '../containers/ResourceListBoardContainer';
 import StudioListContainer from '../containers/StudioListContainer';
 import HomeIcon from '../components/HomeIcon';
+
+const { TabPane } = Tabs;
 
 const ProjectView: React.FunctionComponent<{
   match: match<{ orgLabel: string; projectLabel: string }>;
@@ -36,6 +38,9 @@ const ProjectView: React.FunctionComponent<{
 
   const [menuVisible, setMenuVisible] = React.useState(true);
   const [refreshLists, setRefreshLists] = React.useState(false);
+  const [activeResourceMenuTab, setActiveResourceMenuTab] = React.useState(
+    'Resources'
+  );
 
   React.useEffect(() => {
     setState({
@@ -103,54 +108,69 @@ const ProjectView: React.FunctionComponent<{
               )}
             </div>
             <div className="actions">
+              Resources & Studios{' '}
               <Switch
                 size="small"
                 checked={menuVisible}
                 onChange={setMenuVisible}
-              ></Switch>
+                checkedChildren={<Icon type="menu-unfold" />}
+                unCheckedChildren={<Icon type="menu-fold" />}
+              />
               <SideMenu
                 visible={menuVisible}
-                title="Resources"
                 onClose={() => setMenuVisible(false)}
               >
-                <p>
-                  View resources in your project using pre-defined query-helper
-                  lists.
-                </p>
-                <div style={{ display: 'flex', flexDirection: 'column' }}>
-                  <AccessControl
-                    path={`/${orgLabel}/${projectLabel}`}
-                    permissions={['resources/write']}
-                  >
-                    <ResourceFormContainer
+                <Tabs
+                  onChange={(key: string) => setActiveResourceMenuTab(key)}
+                  activeKey={activeResourceMenuTab}
+                >
+                  <TabPane tab="Resources" key="Resources">
+                    <p>
+                      View resources in your project using pre-defined
+                      query-helper lists.
+                    </p>
+                    <div style={{ display: 'flex', flexDirection: 'column' }}>
+                      <AccessControl
+                        path={`/${orgLabel}/${projectLabel}`}
+                        permissions={['resources/write']}
+                      >
+                        <ResourceFormContainer
+                          orgLabel={orgLabel}
+                          projectLabel={projectLabel}
+                        />
+                      </AccessControl>
+                      <Link
+                        to={`/${orgLabel}/${projectLabel}/nxv:defaultSparqlIndex/sparql`}
+                      >
+                        Sparql Query Editor
+                      </Link>
+                      <Link
+                        to={`/${orgLabel}/${projectLabel}/nxv:defaultElasticSearchIndex/_search`}
+                      >
+                        ElasticSearch Query Editor
+                      </Link>
+                      <Link to={`/${orgLabel}/${projectLabel}/_settings/acls`}>
+                        View Project's permissions
+                      </Link>
+                    </div>
+                    <AccessControl
+                      path={`/${orgLabel}/${projectLabel}`}
+                      permissions={['files/write']}
+                    >
+                      <Divider />
+                      <FileUploadContainer
+                        projectLabel={projectLabel}
+                        orgLabel={orgLabel}
+                      />
+                    </AccessControl>
+                  </TabPane>
+                  <TabPane tab="Studios" key="Studios">
+                    <StudioListContainer
                       orgLabel={orgLabel}
                       projectLabel={projectLabel}
                     />
-                  </AccessControl>
-                  <Link
-                    to={`/${orgLabel}/${projectLabel}/nxv:defaultSparqlIndex/sparql`}
-                  >
-                    Sparql Query Editor
-                  </Link>
-                  <Link
-                    to={`/${orgLabel}/${projectLabel}/nxv:defaultElasticSearchIndex/_search`}
-                  >
-                    ElasticSearch Query Editor
-                  </Link>
-                  <Link to={`/${orgLabel}/${projectLabel}/_settings/acls`}>
-                    View Project's permissions
-                  </Link>
-                </div>
-                <AccessControl
-                  path={`/${orgLabel}/${projectLabel}`}
-                  permissions={['files/write']}
-                >
-                  <Divider />
-                  <FileUploadContainer
-                    projectLabel={projectLabel}
-                    orgLabel={orgLabel}
-                  />
-                </AccessControl>
+                  </TabPane>
+                </Tabs>
               </SideMenu>
             </div>
           </div>
@@ -160,10 +180,6 @@ const ProjectView: React.FunctionComponent<{
                 orgLabel={orgLabel}
                 projectLabel={projectLabel}
                 refreshLists={refreshLists}
-              />
-              <StudioListContainer
-                orgLabel={orgLabel}
-                projectLabel={projectLabel}
               />
             </div>
           </div>


### PR DESCRIPTION
Mops up the project page a big by:
- placing studio list in Action Menu

Fixes Studio List By:
- using infinite scroll (now you can see if there are more studios in projects)
- using infinite search (search for studios)

![Studio List](https://user-images.githubusercontent.com/5485824/74926624-78063180-53d6-11ea-9a42-2221442b516c.gif)
