### PR TITLE
Persistent lists

### DIFF
--- a/src/shared/components/ResourceList/ResourceList.less
+++ b/src/shared/components/ResourceList/ResourceList.less
@@ -1,5 +1,15 @@
 @import '../../lib.less';
 
+.resource-list-height-tester {
+  margin: 0 0.5em;
+  &:first-of-type {
+    margin-left: 0;
+  }
+  &:last-of-type {
+    margin-right: 0;
+  }
+}
+
 .resource-list {
   .cardlike();
   background-color: @primary-card;

--- a/src/shared/components/ResourceList/index.tsx
+++ b/src/shared/components/ResourceList/index.tsx
@@ -133,7 +133,7 @@ const ResourceListComponent: React.FunctionComponent<{
       <div className="resource-list">
         <h3 className={`header ${busy ? '-fetching' : ''}`}>
           <RenameableItem
-            defaultValue={!!name ? name : 'Unnamed List'}
+            defaultValue={name || 'Unnamed List'}
             onChange={handleUpdate}
             size="small"
           />

--- a/src/shared/components/ResourceList/index.tsx
+++ b/src/shared/components/ResourceList/index.tsx
@@ -21,6 +21,7 @@ import TypesIconList from '../Types/TypesIcon';
 import useMeasure from '../../hooks/useMeasure';
 
 import './ResourceList.less';
+import Copy from '../Copy';
 
 export type ResourceBoardList = {
   name: string;
@@ -58,6 +59,7 @@ const ResourceListComponent: React.FunctionComponent<{
   onSortBy(option: string): void;
   makeResourceUri(resourceId: string): string;
   goToResource(resourceId: string): void;
+  shareableLink: string;
 }> = ({
   busy,
   list,
@@ -74,6 +76,7 @@ const ResourceListComponent: React.FunctionComponent<{
   goToResource,
   children,
   schemaLinkContainer,
+  shareableLink,
 }) => {
   const [{ ref: wrapperHeightRef }, { height: wrapperHeight }] = useMeasure();
   const { name } = list;
@@ -130,7 +133,7 @@ const ResourceListComponent: React.FunctionComponent<{
       <div className="resource-list">
         <h3 className={`header ${busy ? '-fetching' : ''}`}>
           <RenameableItem
-            defaultValue={name}
+            defaultValue={!!name ? name : 'Unnamed List'}
             onChange={handleUpdate}
             size="small"
           />
@@ -146,6 +149,22 @@ const ResourceListComponent: React.FunctionComponent<{
           <Icon type="close" className="close-button" onClick={handleDelete} />
         </h3>
         <div className="controls -squished">
+          <Copy
+            textToCopy={shareableLink}
+            render={(copySuccess, triggerCopy) => (
+              <a
+                href={shareableLink}
+                onClick={e => {
+                  e.preventDefault();
+                  triggerCopy();
+                }}
+              >
+                <Tooltip title={copySuccess ? 'Copied' : 'Copy shareable link'}>
+                  <Button icon="link" />
+                </Tooltip>
+              </a>
+            )}
+          />
           {!list.query.q && (
             <Dropdown overlay={sortOptions} trigger={['hover', 'click']}>
               <Tooltip title="Sort resources">

--- a/src/shared/components/Studio/StudioList.tsx
+++ b/src/shared/components/Studio/StudioList.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Empty, Spin } from 'antd';
-import useMeasure from '../../hooks/useMeasure';
 
+import useMeasure from '../../hooks/useMeasure';
 import ListItem from '../List/Item';
 
 import './Studio.less';

--- a/src/shared/containers/ResourceListBoardContainer.tsx
+++ b/src/shared/containers/ResourceListBoardContainer.tsx
@@ -5,7 +5,9 @@ import { DEFAULT_ELASTIC_SEARCH_VIEW_ID } from '@bbp/nexus-sdk';
 
 import { uuidv4 } from '../utils';
 import ResourceListBoardComponent from '../components/ResourceListBoard';
-import ResourceListContainer from './ResourceListContainer';
+import ResourceListContainer, {
+  decodeShareableList,
+} from './ResourceListContainer';
 import { ResourceBoardList } from '../components/ResourceList';
 import useLocalStorage from '../hooks/useLocalStorage';
 import { RootState } from '../store/reducers';
@@ -42,9 +44,16 @@ const ResourceListBoardContainer: React.FunctionComponent<{
   >(`resource-lists-${userId}`, [makeDefaultList()]);
 
   React.useEffect(() => {
-    const sharedList = shareList && JSON.parse(atob(shareList));
+    const sharedList = shareList && decodeShareableList(shareList);
+
     if (sharedList) {
-      setResourceLists([sharedList, ...resourceLists]);
+      setResourceLists([
+        {
+          ...sharedList,
+          id: uuidv4(),
+        },
+        ...resourceLists,
+      ]);
       message.success(
         <span>
           Added a new shared query list called <em>{sharedList.name}</em>

--- a/src/shared/containers/ResourceListContainer.tsx
+++ b/src/shared/containers/ResourceListContainer.tsx
@@ -13,22 +13,23 @@ import SchemaLinkContainer from './SchemaLink';
 const ResourceListContainer: React.FunctionComponent<{
   orgLabel: string;
   projectLabel: string;
-  defaultList: ResourceBoardList;
   refreshList?: boolean;
   onDeleteList: (id: string) => void;
   onCloneList: (list: ResourceBoardList) => void;
+  list: ResourceBoardList;
+  setList: (list: ResourceBoardList) => void;
 }> = ({
-  defaultList,
   orgLabel,
   projectLabel,
   onDeleteList,
   onCloneList,
+  list,
+  setList,
   refreshList,
 }) => {
   const nexus = useNexusContext();
   const history = useHistory();
   const location = useLocation();
-  const [list, setList] = React.useState<ResourceBoardList>(defaultList);
   const [toggleForceReload, setToggleForceReload] = React.useState(false);
   const [
     { busy, error, resources, total, next },

--- a/src/shared/containers/ResourceListContainer.tsx
+++ b/src/shared/containers/ResourceListContainer.tsx
@@ -193,6 +193,10 @@ const ResourceListContainer: React.FunctionComponent<{
     });
   };
 
+  const shareableLink = `${window.location.href}?shareList=${btoa(
+    JSON.stringify(list)
+  )}`;
+
   return (
     <ResourceListComponent
       busy={busy}
@@ -209,18 +213,21 @@ const ResourceListContainer: React.FunctionComponent<{
       makeResourceUri={makeResourceUri}
       goToResource={goToResource}
       schemaLinkContainer={SchemaLinkContainer}
+      shareableLink={shareableLink}
     >
       <TypeDropdownFilterContainer
         deprecated={!!list.query.deprecated}
         orgLabel={orgLabel}
         projectLabel={projectLabel}
         onChange={handleTypeChange}
+        value={list.query.type}
       />
       <SchemaDropdownFilterContainer
         deprecated={!!list.query.deprecated}
         orgLabel={orgLabel}
         projectLabel={projectLabel}
         onChange={handleSchemaChange}
+        value={list.query.schema}
       />
     </ResourceListComponent>
   );

--- a/src/shared/containers/ResourceListContainer.tsx
+++ b/src/shared/containers/ResourceListContainer.tsx
@@ -10,6 +10,14 @@ import TypeDropdownFilterContainer from './TypeDropdownFilter';
 import SchemaDropdownFilterContainer from './SchemaDropdownFilters';
 import SchemaLinkContainer from './SchemaLink';
 
+// Emojis cannot be base64 encoded without URI encoding
+export const encodeShareableList = (list: ResourceBoardList) => {
+  return btoa(encodeURIComponent(JSON.stringify(list)));
+};
+export const decodeShareableList = (base64string: string) => {
+  return JSON.parse(decodeURIComponent(atob(base64string)));
+};
+
 const ResourceListContainer: React.FunctionComponent<{
   orgLabel: string;
   projectLabel: string;
@@ -193,9 +201,9 @@ const ResourceListContainer: React.FunctionComponent<{
     });
   };
 
-  const shareableLink = `${window.location.href}?shareList=${btoa(
-    JSON.stringify(list)
-  )}`;
+  const shareableLink = `${
+    window.location.href
+  }?shareList=${encodeShareableList(list)}`;
 
   return (
     <ResourceListComponent

--- a/src/shared/containers/SchemaDropdownFilters.tsx
+++ b/src/shared/containers/SchemaDropdownFilters.tsx
@@ -15,7 +15,8 @@ const SchemaDropdownFilterContainer: React.FunctionComponent<{
   projectLabel: string;
   deprecated: boolean;
   onChange(value: string): void;
-}> = ({ orgLabel, projectLabel, onChange, deprecated }) => {
+  value?: string;
+}> = ({ orgLabel, projectLabel, onChange, deprecated, value }) => {
   const { loading: busy, data, error } = useNexus<
     ElasticSearchViewQueryResponse<any>
   >(nexus =>
@@ -55,6 +56,7 @@ const SchemaDropdownFilterContainer: React.FunctionComponent<{
           )) ||
         []
       }
+      defaultSelected={value}
       onChange={onChange}
       placeholder={'Filter by Schema'}
     />

--- a/src/shared/containers/TypeDropdownFilter.tsx
+++ b/src/shared/containers/TypeDropdownFilter.tsx
@@ -15,8 +15,9 @@ const TypeDropdownFilterContainer: React.FunctionComponent<{
   orgLabel: string;
   projectLabel: string;
   deprecated: boolean;
+  value?: string;
   onChange(value: string): void;
-}> = ({ orgLabel, projectLabel, onChange, deprecated }) => {
+}> = ({ orgLabel, projectLabel, onChange, deprecated, value }) => {
   const { loading: busy, data, error } = useNexus<
     ElasticSearchViewQueryResponse<any>
   >(nexus =>
@@ -56,6 +57,7 @@ const TypeDropdownFilterContainer: React.FunctionComponent<{
           )) ||
         []
       }
+      defaultSelected={value}
       onChange={onChange}
       placeholder={'Filter by Type'}
       dropdownItem={TypeDropdownItem}

--- a/src/shared/hooks/useLocalStorage.ts
+++ b/src/shared/hooks/useLocalStorage.ts
@@ -1,9 +1,12 @@
 import * as React from 'react';
 
-export default function useLocalStorage<T = any>(key: string) {
+export default function useLocalStorage<T = any>(
+  key: string,
+  defaultValue?: T
+) {
   const val = localStorage.getItem(key);
   const [value, setValue] = React.useState<T | undefined>(
-    !!val && JSON.parse(val)
+    !!val ? JSON.parse(val) : defaultValue
   );
 
   const setLocalStorage = (value: T | undefined) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "rootDir": "./",
     "outDir": "./dist",
     "module": "commonjs",
-    "target": "esnext",
+    "target": "es2018",
     "moduleResolution": "node",
     "jsx": "react",
     "experimentalDecorators": true,


### PR DESCRIPTION
Makes resource query lists persistent on your browser

Enables sharing of resource query lists

fixes some bugs from the query list, like if you removed its name.

Changes tsconfig to allow some neat features in typescript like `myMaybeUndefinedObjectPropery?.nowImSafe`