### PR TITLE
Plugins in resource view

### DIFF
--- a/src/shared/containers/ResourcePlugins.tsx
+++ b/src/shared/containers/ResourcePlugins.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import { useSelector } from 'react-redux';
+import { useNexusContext } from '@bbp/react-nexus';
+import { Resource } from '@bbp/nexus-sdk';
+import { RootState } from '../store/reducers';
+import { NexusPlugin } from '../containers/NexusPlugin';
+import { matchPlugins } from '../utils';
+
+const ResourcePlugins: React.FunctionComponent<{
+  resource?: Resource;
+  goToResource?: (selfURL: string) => void;
+  empty?: React.ReactElement;
+}> = ({ resource, goToResource, empty = null }) => {
+  const nexus = useNexusContext();
+  const plugins: string[] = useSelector(
+    (state: RootState) => state.config.plugins
+  );
+  const pluginMap = useSelector((state: RootState) => state.config.pluginsMap);
+
+  if (!resource) {
+    return null;
+  }
+
+  const filteredPlugins =
+    pluginMap && matchPlugins(pluginMap, plugins, resource);
+
+  return filteredPlugins && filteredPlugins.length > 0 ? (
+    <>
+      {filteredPlugins.map(pluginName => (
+        <div className="resource-plugin" key={`plugin-${pluginName}`}>
+          <NexusPlugin
+            url={`/public/plugins/${pluginName}/index.js`}
+            nexusClient={nexus}
+            resource={resource}
+            goToResource={goToResource}
+          />
+        </div>
+      ))}
+    </>
+  ) : (
+    empty
+  );
+};
+
+export default ResourcePlugins;

--- a/src/shared/containers/ResourceViewContainer.tsx
+++ b/src/shared/containers/ResourceViewContainer.tsx
@@ -15,6 +15,7 @@ import ResourceEditorContainer from '../containers/ResourceEditor';
 import ImagePreviewContainer from '../containers/ImagePreviewContainer';
 import SchemaLinkContainer from '../containers/SchemaLink';
 import HomeIcon from '../components/HomeIcon';
+import ResourcePlugins from './ResourcePlugins';
 
 const TabPane = Tabs.TabPane;
 export const DEFAULT_ACTIVE_TAB_KEY = '#JSON';
@@ -45,6 +46,9 @@ const ResourceViewContainer: React.FunctionComponent<{
       revision ? `?rev=${revision}` : ''
     }${expanded ? '&expanded=true' : ''}${tab ? tab : ''}`;
     history.push(pushRoute, location.state);
+  };
+  const goToSelfResource = (selfUrl: string) => {
+    // TODO we need a way to navigate to the correct place via resource SELF URL
   };
   const goToProject = (orgLabel: string, projectLabel: string) =>
     history.push(`/${orgLabel}/${projectLabel}`, location.state);
@@ -234,11 +238,18 @@ const ResourceViewContainer: React.FunctionComponent<{
                   closable
                 />
               )}
-              <ResourceCardComponent
+              <ResourcePlugins
                 resource={resource}
-                preview={<ImagePreviewContainer resource={resource} />}
-                schemaLink={SchemaLinkContainer}
+                goToResource={goToSelfResource}
+                empty={
+                  <ResourceCardComponent
+                    resource={resource}
+                    preview={<ImagePreviewContainer resource={resource} />}
+                    schemaLink={SchemaLinkContainer}
+                  />
+                }
               />
+
               <ResourceActionsContainer resource={resource} />
               <Tabs activeKey={activeTabKey} onChange={handleTabChange}>
                 <TabPane tab="JSON" key="#JSON">

--- a/src/shared/views/StudioResourceView.tsx
+++ b/src/shared/views/StudioResourceView.tsx
@@ -1,21 +1,15 @@
 import * as React from 'react';
-import { useSelector } from 'react-redux';
 import { useParams, useHistory } from 'react-router';
 import { useNexusContext } from '@bbp/react-nexus';
 import { Resource } from '@bbp/nexus-sdk';
 import { notification, Empty } from 'antd';
-import { RootState } from '../store/reducers';
 import { NexusPlugin } from '../containers/NexusPlugin';
-import { getResourceLabel, matchPlugins } from '../utils';
+import { getResourceLabel } from '../utils';
+import ResourcePlugins from '../containers/ResourcePlugins';
 
 const StudioResourceView: React.FunctionComponent<{}> = () => {
   const nexus = useNexusContext();
-  const [filteredPlugins, setFilteredPlugins] = React.useState<string[]>([]);
   const { resourceSelfUri = '' } = useParams();
-  const plugins: string[] = useSelector(
-    (state: RootState) => state.config.plugins
-  );
-  const pluginMap = useSelector((state: RootState) => state.config.pluginsMap);
   const history = useHistory();
   const [resource, setResource] = React.useState<Resource | null>();
 
@@ -32,10 +26,6 @@ const StudioResourceView: React.FunctionComponent<{}> = () => {
       .then(resource => {
         resourceResponse = resource;
         setResource(resourceResponse);
-        if (pluginMap) {
-          const newPlugins = matchPlugins(pluginMap, plugins, resource);
-          setFilteredPlugins(newPlugins);
-        }
       })
       .catch(error => {
         notification.error({
@@ -60,20 +50,11 @@ const StudioResourceView: React.FunctionComponent<{}> = () => {
     <div className="studio-resource-view">
       <h1>{label}</h1>
       <p>{resource.description}</p>
-      {filteredPlugins && filteredPlugins.length > 0 ? (
-        filteredPlugins.map(pluginName => (
-          <div className="studio-resource-plugin" key={`plugin-${pluginName}`}>
-            <NexusPlugin
-              url={`/public/plugins/${pluginName}/index.js`}
-              nexusClient={nexus}
-              resource={resource}
-              goToResource={goToStudioResource}
-            />
-          </div>
-        ))
-      ) : (
-        <Empty description="No plugins configured" />
-      )}
+      <ResourcePlugins
+        resource={resource}
+        goToResource={goToStudioResource}
+        empty={<Empty description="No plugins configured" />}
+      />
     </div>
   );
 };


### PR DESCRIPTION
Uses the same global plugin logic to use plugins in Resource View. If Nothing is found, the normal metadata card will be used in its place.

<img width="1373" alt="Screenshot 2020-02-21 at 15 52 34" src="https://user-images.githubusercontent.com/5485824/75045404-867e4700-54c3-11ea-8eb3-32a4f5291c9a.png">
