### PR TITLE
Update regex to handle microseconds

### DIFF
--- a/src/shared/utils/__tests__/index.spec.ts
+++ b/src/shared/utils/__tests__/index.spec.ts
@@ -186,9 +186,14 @@ describe('utils functions', () => {
   describe('isISODate', () => {
     const isoString = '2019-07-29T10:26:06.543Z';
     const otherString = 'randomString';
+    const anotherTimeString = '2019-11-21T10:09:49.531037';
 
     it('returns true if a string is an ISO date', () => {
       expect(isISODate(isoString)).toEqual(true);
+    });
+
+    it('returns true if a string is an ISO date', () => {
+      expect(isISODate(anotherTimeString)).toEqual(true);
     });
 
     it('returns false if a string is not an ISO date', () => {

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -328,7 +328,7 @@ export const matchResultUrls = (entry: string) => {
  * @returns {boolean} if a string is an ISO date or not
  */
 export const isISODate = (date: string) => {
-  const isoDateRegex = /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z)/;
+  const isoDateRegex = /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.[0-9Z+]{1,9}/;
 
   return isoDateRegex.test(date);
 };


### PR DESCRIPTION
Fixes BlueBrain/nexus#1052

- Handles cases when ISO time contains microseconds