### PR TITLE
fetch plugin mapping config from plugin manifest service

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ docker build . --tag=nexus-web
 The following concern Plugins. [See how to manage plugin deployments](./docs/plugins.md)
 
 - `PLUGINS_MANIFEST_PATH`: Remote end point where plugins and manifest can be found. for example, `https://bbp-nexus.epfl.ch/plugins`
-- `PLUGINS_CONFIG_PATH`: A full file path where a plugins configuration can be found.
 
 ## Deployment
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -2,9 +2,9 @@
 
 ## Plugin Manifest
 
-The plugin manifest should be available at the same remote endpoint as the plugins. This is so Nexus can find the plugins and apply them dynamically. 
+The plugin manifest should be available at the same remote endpoint as the plugins. This is so Nexus can find the plugins and apply them dynamically.
 
-The plugin manifest is a json object with keys that correspond to the plugin name with a value that corresponds to a descriptive payload of where to find the manifest, as well as some information about it's development. It's similar to a package.json file. 
+The plugin manifest is a json object with keys that correspond to the plugin name with a value that corresponds to a descriptive payload of where to find the manifest, as well as some information about it's development. It's similar to a package.json file.
 
 ```{
     "circuit": {
@@ -14,31 +14,50 @@ The plugin manifest is a json object with keys that correspond to the plugin nam
       "version": "",
       "tags": [],
       "author": "",
-      "license": ""
+      "license": "",
+      "mapping": {}
     }
 }
 ```
 
 ## Plugin Config
 
-The plugin config should be available as an adjacent file next to your running Nexus Web instance. It's a json file that describes which resource should be represented by each plugin. 
+The plugin config should be available as an object under the `mapping` key of the plugin manifest. This tells nexus when a plugin should be displayed, by matching a resource to a shape.
 
 ### Matching all resources
 
-The following will show `nexus-plugin-test` for *every* resource inside Nexus Web.
+The following will show `nexus-plugin-test` for _every_ resource inside Nexus Web.
 
 ```
 {
-    "nexus-plugin-test" : {}
+    "nexus-plugin-test": {
+      "modulePath": "nexus-plugin-test.js",
+      "name": "Nexus Plugin Test",
+      "description": "",
+      "version": "",
+      "tags": [],
+      "author": "",
+      "license": "",
+      "mapping": {}
+    }
 }
 ```
 
 ### Matching a resource with a specific type and shape
+
 The following will show `nexus-plugin-test` for any resource of type `File` but only if they have a `distribution.encodingFormat` property that's `application/swc`
 
 ```
 {
-    "nexus-plugin-test" : {
+    "nexus-plugin-test": {
+      "modulePath": "nexus-plugin-test.js",
+      "name": "Nexus Plugin Test",
+      "description": "",
+      "version": "",
+      "tags": [],
+      "author": "",
+      "license": "",
+      "mapping": {
         "@type": "File",
         "distribution:" {
             "encodingFormat": "application/swc"

--- a/src/server/config/config.ts
+++ b/src/server/config/config.ts
@@ -1,1 +1,0 @@
-export const pluginsMap = require('../../../plugin.config.json');

--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -20,20 +20,6 @@ const rawBase: string = process.env.BASE_PATH || '';
 const pluginsManifestPath =
   process.env.PLUGINS_MANIFEST_PATH || '/public/plugins';
 
-const pluginsConfigPath =
-  process.env.PLUGINS_CONFIG_PATH ||
-  join(__dirname, '/public/plugins/plugins.config.json');
-
-const getpluginsConfig = () => {
-  let pluginsConfig;
-  try {
-    pluginsConfig = JSON.parse(readFileSync(pluginsConfigPath).toString());
-  } catch (e) {
-    console.error(e);
-  }
-  return pluginsConfig || {};
-};
-
 // remove trailing slash
 const base: string = rawBase.replace(/\/$/, '');
 // enable logs
@@ -68,8 +54,6 @@ app.get('*', async (req: express.Request, res: express.Response) => {
     auth: {},
     config: {
       pluginsManifestPath,
-
-      pluginsMap: getpluginsConfig(),
       apiEndpoint: process.env.API_ENDPOINT || '/',
       basePath: base,
       clientId: process.env.CLIENT_ID || 'nexus-web',

--- a/src/shared/containers/ResourcePlugins.tsx
+++ b/src/shared/containers/ResourcePlugins.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
-import { useSelector } from 'react-redux';
 import { Resource } from '@bbp/nexus-sdk';
-import { RootState } from '../store/reducers';
 import NexusPlugin from '../containers/NexusPlugin';
 import { matchPlugins } from '../utils';
 import usePlugins from '../hooks/usePlugins';
 import { Collapse } from 'antd';
 const { Panel } = Collapse;
+
+export type PluginMapping = {
+  [pluginKey: string]: object;
+};
 
 const ResourcePlugins: React.FunctionComponent<{
   resource?: Resource;
@@ -15,14 +17,23 @@ const ResourcePlugins: React.FunctionComponent<{
 }> = ({ resource, goToResource, empty = null }) => {
   const pluginManifest = usePlugins();
   const availablePlugins = Object.keys(pluginManifest || {});
-  const pluginMap = useSelector((state: RootState) => state.config.pluginsMap);
+  const pluginsMap = Object.keys(pluginManifest || {}).reduce(
+    (mapping, pluginManifestKey) => {
+      if (!pluginManifest) {
+        return mapping;
+      }
+      mapping[pluginManifestKey] = pluginManifest[pluginManifestKey].mapping;
+      return mapping;
+    },
+    {} as PluginMapping
+  );
 
   if (!resource) {
     return null;
   }
 
   const filteredPlugins =
-    pluginMap && matchPlugins(pluginMap, availablePlugins, resource);
+    pluginManifest && matchPlugins(pluginsMap, availablePlugins, resource);
 
   return filteredPlugins && filteredPlugins.length > 0 ? (
     <Collapse

--- a/src/shared/hooks/usePlugins.ts
+++ b/src/shared/hooks/usePlugins.ts
@@ -14,6 +14,7 @@ export type RemotePluginManifest = {
     tags: string[];
     author: string;
     license: string;
+    mapping: object;
   };
 };
 

--- a/src/shared/store/reducers/config.ts
+++ b/src/shared/store/reducers/config.ts
@@ -9,7 +9,6 @@ export interface ConfigState {
   sentryDsn?: string;
   pluginsManifestPath: string;
   gtmCode?: string;
-  pluginsMap?: Object;
 }
 
 const initialState: ConfigState = {


### PR DESCRIPTION
Instead of fetching the plugins config from a file inside the nexus web instance, the config will be fetched from the plugin manifest service. 

This removes the need for the `PLUGINS_CONFIG_PATH` env var and removes the logic to fetch this file on the server side. 

With this change, plugins can be configured by the plugin developer and deployed with each plugin service change, instead of configured by the nexus-web service administrator. 

https://github.com/BlueBrain/nexus/issues/1086

## How to test

1. start your app: 
``API_ENDPOINT=https://{devenv}/v1 PLUGINS_MANIFEST_PATH=https://{devenv}/plugins/manifest.json yarn start```

2. go to a resource

3. using the redux devtool, notice that there is no more pluginMapping state in state.config. 
Instead, you should see a request being made to the manifest.json url with that information. 