### PR TITLE
fix resource action styling

### DIFF
--- a/src/shared/components/ResourceActions/ResourceActions.less
+++ b/src/shared/components/ResourceActions/ResourceActions.less
@@ -5,7 +5,6 @@
   padding: @default-pad 0;
   font-size: 0.8rem;
 
-  > .action,
   button {
     margin-right: 5px;
   }

--- a/src/shared/components/ResourceActions/index.tsx
+++ b/src/shared/components/ResourceActions/index.tsx
@@ -100,7 +100,7 @@ const ResourceActions: React.FunctionComponent<{
       });
   }, [resource._self, resource._rev]);
 
-  return <span>{actionButtons}</span>;
+  return <>{actionButtons}</>;
 };
 
 export default ResourceActions;

--- a/src/shared/containers/ResourceActionsContainer.tsx
+++ b/src/shared/containers/ResourceActionsContainer.tsx
@@ -196,17 +196,17 @@ const ResourceActionsContainer: React.FunctionComponent<{
             </Tooltip>
           )}
         />
+        <ResourceDownloadButton
+          orgLabel={orgLabel}
+          projectLabel={projectLabel}
+          resourceId={encodeURIComponent(resourceId)}
+        />
         <ResourceActions
           resource={resource}
           actions={actions}
           actionTypes={actionTypes}
         />
       </div>
-      <ResourceDownloadButton
-        orgLabel={orgLabel}
-        projectLabel={projectLabel}
-        resourceId={encodeURIComponent(resourceId)}
-      />
     </div>
   );
 };


### PR DESCRIPTION
Places each resource action button in the same div for consistent styling

![Screenshot 2020-03-23 at 10 28 59](https://user-images.githubusercontent.com/5485824/77302315-7095b900-6cf1-11ea-974e-cb55ec84ce2d.png)
