### PR TITLE
1123 No plugins/no access warnings

### DIFF
--- a/src/shared/containers/ResourceEditor.tsx
+++ b/src/shared/containers/ResourceEditor.tsx
@@ -1,11 +1,6 @@
 import * as React from 'react';
 import { useAsyncEffect } from 'use-async-effect';
-import {
-  ExpandedResource,
-  ResourceSource,
-  Resource,
-  NexusClient,
-} from '@bbp/nexus-sdk';
+import { ExpandedResource, ResourceSource, Resource } from '@bbp/nexus-sdk';
 import { useNexusContext } from '@bbp/react-nexus';
 
 import ResourceEditor from '../components/ResourceEditor';

--- a/src/shared/containers/ResourceViewContainer.tsx
+++ b/src/shared/containers/ResourceViewContainer.tsx
@@ -298,7 +298,7 @@ const ResourceViewContainer: React.FunctionComponent<{
               )}
               <AccessControl
                 path={`/${orgLabel}/${projectLabel}`}
-                permissions={['resources/test']}
+                permissions={['resources/write']}
                 noAccessComponent={() => (
                   <div>
                     <p>

--- a/src/shared/containers/ResourceViewContainer.tsx
+++ b/src/shared/containers/ResourceViewContainer.tsx
@@ -22,6 +22,7 @@ import {
   getOrgAndProjectFromProjectId,
   matchPlugins,
   pluginsMap,
+  getUsername,
 } from '../utils';
 import { isDeprecated } from '../utils/nexusMaybe';
 
@@ -297,7 +298,37 @@ const ResourceViewContainer: React.FunctionComponent<{
               )}
               <AccessControl
                 path={`/${orgLabel}/${projectLabel}`}
-                permissions={['resources/write']}
+                permissions={['resources/test']}
+                noAccessComponent={() => (
+                  <div>
+                    <p>
+                      <Alert
+                        message={
+                          !filteredPlugins || filteredPlugins.length === 0
+                            ? `There are no plugin configured for this resource, and you don't have admin access. Please ask the resource creator: ${getUsername(
+                                resource['_createdBy']
+                              )} for more information.`
+                            : `It looks like you don't have admin access. Please ask the resource creator: ${getUsername(
+                                resource['_createdBy']
+                              )} for more information.`
+                        }
+                        type="info"
+                      />
+                    </p>
+                    <ResourceEditorContainer
+                      resourceId={resource['@id']}
+                      orgLabel={orgLabel}
+                      projectLabel={projectLabel}
+                      rev={resource._rev}
+                      defaultExpanded={
+                        !!expandedFromQuery && expandedFromQuery === 'true'
+                      }
+                      defaultEditable={false}
+                      onSubmit={() => {}}
+                      onExpanded={handleExpanded}
+                    />
+                  </div>
+                )}
               >
                 <Collapse
                   defaultActiveKey={


### PR DESCRIPTION
Fixes BlueBrain/nexus#1123

### 2 cases:

- If there are plugins, but no access to admin stuff, then we display "It looks like you don’t have admin access. Please ask the resource creator for more information."

- If there are 0 plugins and no access to admin stuff: "There are no plugin configured for this resource, and you don’t have admin access. Please ask the resource creator for more information."

![Screenshot 2020-04-07 at 11 38 32](https://user-images.githubusercontent.com/23080476/78654766-56e59b80-78c5-11ea-9bf6-6f1813d9c3c1.png)
