### PR TITLE
Show Plugins in sorted order

### DIFF
--- a/src/shared/containers/ResourcePlugins.tsx
+++ b/src/shared/containers/ResourcePlugins.tsx
@@ -26,6 +26,25 @@ const ResourcePlugins: React.FunctionComponent<{
     pluginManifest &&
     matchPlugins(pluginsMap(pluginManifest), availablePlugins, resource);
 
+  const pluginDataMap = filteredPlugins
+    ? filteredPlugins
+        .map(pluginName => {
+          if (pluginManifest) {
+            return pluginManifest[pluginName];
+          }
+          return null;
+        })
+        .sort((p1, p2) => {
+          if (p1?.displayPriority && p2?.displayPriority) {
+            return (
+              parseInt(p1.displayPriority, 10) -
+              parseInt(p2.displayPriority, 10)
+            );
+          }
+          return 0;
+        })
+    : [];
+
   return filteredPlugins && filteredPlugins.length > 0 ? (
     <Collapse
       defaultActiveKey={[...Array(filteredPlugins.length).keys()].map(i =>
@@ -33,19 +52,18 @@ const ResourcePlugins: React.FunctionComponent<{
       )}
       onChange={() => {}}
     >
-      {filteredPlugins.map((pluginName, index) => {
-        const pluginData = pluginManifest && pluginManifest[pluginName];
+      {pluginDataMap.map((pluginData, index) => {
         return pluginData ? (
           <Panel
-            header={pluginManifest && pluginManifest[pluginName].name}
+            header={pluginData.name}
             key={(index + 1).toString()}
             extra={<PluginInfo plugin={pluginData} />}
           >
-            <div className="resource-plugin" key={`plugin-${pluginName}`}>
+            <div className="resource-plugin" key={`plugin-${pluginData.name}`}>
               <NexusPlugin
                 nexusClient={nexus}
                 url={pluginData.absoluteModulePath}
-                pluginName={pluginName}
+                pluginName={pluginData.name}
                 resource={resource}
                 goToResource={goToResource}
               />

--- a/src/shared/hooks/usePlugins.ts
+++ b/src/shared/hooks/usePlugins.ts
@@ -14,6 +14,7 @@ export type RemotePluginManifest = {
     author: string;
     license: string;
     mapping: object;
+    displayPriority?: string;
   };
 };
 


### PR DESCRIPTION
Account for pluginDisplayPriority attribute and display plugins in
sorted order.

Fixes  BlueBrain/nexus/issues/1134