### PR TITLE
Fix redirect issue

### DIFF
--- a/src/shared/containers/ResourceViewContainer.tsx
+++ b/src/shared/containers/ResourceViewContainer.tsx
@@ -111,14 +111,6 @@ const ResourceViewContainer: React.FunctionComponent<{
     });
   };
 
-  const [identities, setIdentities] = React.useState<Identity[]>([]);
-
-  React.useEffect(() => {
-    nexus.Identity.list().then(({ identities }) => {
-      setIdentities(identities);
-    });
-  }, []); // Run only once.
-
   const handleExpanded = (expanded: boolean) => {
     goToResource(orgLabel, projectLabel, resourceId, {
       expanded,
@@ -215,18 +207,23 @@ const ResourceViewContainer: React.FunctionComponent<{
       })
       .catch(error => {
         if (error['@type'] === 'AuthorizationFailed') {
-          const user = identities.find(i => i['@type'] === 'User');
-          const message = user
-            ? "You don't have the permissions to view the resource"
-            : 'Please login to view the resource';
-          notification.error({
-            message: 'Authentication error',
-            description: message,
-            duration: 4,
+          nexus.Identity.list().then(({ identities }) => {
+            const user = identities.find(i => i['@type'] === 'User');
+
+            if (!user) {
+              history.push(`/login${getDestinationParam()}`);
+            }
+
+            const message = user
+              ? "You don't have the permissions to view the resource"
+              : 'Please login to view the resource';
+
+            notification.error({
+              message: 'Authentication error',
+              description: message,
+              duration: 4,
+            });
           });
-          if (!user) {
-            history.push(`/login${getDestinationParam()}`);
-          }
         }
 
         const jsError = new Error(error.reason);


### PR DESCRIPTION
- Moves `nexus.Identity.list()` from `useEffect`, because it doesn't load identities on time when we need them inside another useEffect, and User is always undefined :(

Covers:

- User is not logged in -> redirect to /login
- User doesn't have permissions -> notification

![Screenshot 2020-05-18 at 16 23 53](https://user-images.githubusercontent.com/23080476/82226068-4e519d80-9926-11ea-8244-dacefdd34783.png)
