### PR TITLE
1189 global studio list bugfixes

### DIFF
--- a/src/shared/components/Header/__tests__/Header.test.tsx
+++ b/src/shared/components/Header/__tests__/Header.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { shallow, mount } from 'enzyme';
 import Header, { ServiceVersions } from '..';
+import { MemoryRouter } from 'react-router-dom';
 
 const versions: ServiceVersions = {
   nexus: '1.0',
@@ -36,14 +37,17 @@ const shallowHeader = shallow(
     serviceVersions={versions}
   />
 );
+
 const wrapper = mount(
-  <Header
-    name="Mark Hamill"
-    links={links}
-    githubIssueURL=""
-    version=""
-    serviceVersions={versions}
-  />
+  <MemoryRouter>
+    <Header
+      name="Mark Hamill"
+      links={links}
+      githubIssueURL=""
+      version=""
+      serviceVersions={versions}
+    />
+  </MemoryRouter>
 );
 
 describe('Header component', () => {
@@ -69,13 +73,36 @@ describe('Header component', () => {
     });
 
     it('Should display login link', () => {
-      wrapper.setProps({ name: '' });
-      expect(wrapper.find('.menu-dropdown').text()).toEqual('login ');
+      const wrapperNoName = mount(
+        <MemoryRouter>
+          <Header
+            name=""
+            links={links}
+            githubIssueURL=""
+            version=""
+            serviceVersions={versions}
+          />
+        </MemoryRouter>
+      );
+
+      expect(wrapperNoName.find('.menu-dropdown').text()).toEqual('login ');
     });
 
     it('Should NOT display login link', () => {
-      wrapper.setProps({ displayLogin: false });
-      expect(wrapper.find('.menu-dropdown').children()).toHaveLength(0);
+      const wrapperNoLogin = mount(
+        <MemoryRouter>
+          <Header
+            name=""
+            links={links}
+            githubIssueURL=""
+            version=""
+            serviceVersions={versions}
+            displayLogin={false}
+          />
+        </MemoryRouter>
+      );
+
+      expect(wrapperNoLogin.find('.menu-dropdown').children()).toHaveLength(0);
     });
   });
 });

--- a/src/shared/components/Header/__tests__/__snapshots__/Header.test.tsx.snap
+++ b/src/shared/components/Header/__tests__/__snapshots__/Header.test.tsx.snap
@@ -41,13 +41,13 @@ exports[`Header component Should render correctly 1`] = `
     >
       Admin
     </a>
-    <a
+    <Link
       className="nav-item"
-      href="nexus/studio"
       key="studio-link"
+      to="/studio"
     >
       Studio
-    </a>
+    </Link>
     <Popover
       content={
         <InformationContent

--- a/src/shared/components/Header/index.tsx
+++ b/src/shared/components/Header/index.tsx
@@ -165,9 +165,6 @@ const Header: React.FunctionComponent<HeaderProps> = ({
       </div>
       <div className="menu-block">
         {studioView !== '' && [
-          //   <Link to={`/${orgLabel}/${projectLabel}/nxv:defaultSparqlIndex/sparql`}>
-          //   Admin
-          // </Link>
           <a
             className="nav-item"
             href=""
@@ -181,7 +178,7 @@ const Header: React.FunctionComponent<HeaderProps> = ({
           >
             Admin
           </a>,
-          <Link className="nav-item" to="/studio">
+          <Link className="nav-item" to="/studio" key="studio-link">
             Studio
           </Link>,
         ]}

--- a/src/shared/components/Header/index.tsx
+++ b/src/shared/components/Header/index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Menu, Dropdown, Icon, Button, Popover } from 'antd';
 import { useSelector } from 'react-redux';
+import { Link } from 'react-router-dom';
 
 import Copy from '../Copy';
 import ConsentPreferences from '../ConsentPreferences';
@@ -164,6 +165,9 @@ const Header: React.FunctionComponent<HeaderProps> = ({
       </div>
       <div className="menu-block">
         {studioView !== '' && [
+          //   <Link to={`/${orgLabel}/${projectLabel}/nxv:defaultSparqlIndex/sparql`}>
+          //   Admin
+          // </Link>
           <a
             className="nav-item"
             href=""
@@ -177,9 +181,9 @@ const Header: React.FunctionComponent<HeaderProps> = ({
           >
             Admin
           </a>,
-          <a className="nav-item" href="nexus/studio" key="studio-link">
+          <Link className="nav-item" to="/studio">
             Studio
-          </a>,
+          </Link>,
         ]}
         {token && (
           <Copy

--- a/src/shared/components/Studio/ExpandableStudioList.tsx
+++ b/src/shared/components/Studio/ExpandableStudioList.tsx
@@ -45,7 +45,7 @@ const ExpandableStudioList: React.FC<{
     );
   }
 
-  if (studios && studios.length === 0) {
+  if (!studios || (studios && studios.length === 0)) {
     return (
       <div className="expandable-studio-list">
         <Empty />

--- a/src/shared/routes.ts
+++ b/src/shared/routes.ts
@@ -27,7 +27,8 @@ const routes: RouteProps[] = [
     component: UserView,
   },
   {
-    path: '/nexus/studio',
+    path: '/studio',
+    exact: true,
     component: StudioListView,
   },
   {


### PR DESCRIPTION
Fixes BlueBrain/nexus#1189

- updates url path from 'nexus/studio' to '/studio'
- uses `<Link>` instead of `<a>` as a Studio button, fixes failing corresponding tests
- handles the case when the studio list is null/undefined - stops the app from crashing