### PR TITLE
Show more studios in the list

### DIFF
--- a/src/shared/components/Studio/StudioList.tsx
+++ b/src/shared/components/Studio/StudioList.tsx
@@ -53,6 +53,7 @@ const StudioList: React.FC<{
           onLoadMore={onLoadMore}
           hasMore={hasMore}
           defaultSearchValue={searchQuery}
+          height={350}
         >
           {studios.map(studio => {
             return (

--- a/src/shared/views/StudioListView.tsx
+++ b/src/shared/views/StudioListView.tsx
@@ -12,6 +12,8 @@ const DEFAULT_STUDIO_TYPE =
   'https://bluebrainnexus.io/studio/vocabulary/Studio';
 
 const ES_QUERY = {
+  from: 0,
+  size: 100,
   query: {
     bool: {
       must: [


### PR DESCRIPTION
Fixes BlueBrain/nexus#1287

The list can display up to 100 studios now.
<img width="769" alt="Screenshot 2020-07-08 at 11 50 10" src="https://user-images.githubusercontent.com/23080476/86904813-82b92d00-c111-11ea-81a8-62e29c28651a.png">
