### PR TITLE
Redirect Old studio paths

### DIFF
--- a/src/shared/App.tsx
+++ b/src/shared/App.tsx
@@ -6,6 +6,7 @@ import {
   useLocation,
   useHistory,
   RouteProps,
+  Redirect,
 } from 'react-router-dom';
 import { Location } from 'history';
 import { useNexusContext } from '@bbp/react-nexus';

--- a/src/shared/layouts/FusionMainLayout.tsx
+++ b/src/shared/layouts/FusionMainLayout.tsx
@@ -79,15 +79,6 @@ const FusionMainLayout: React.FC<FusionMainLayoutProps> = ({
     'consentToTracking'
   );
 
-  // React.useEffect(() => {
-  //   // only navigate if not in the subApp path already
-  //   if (`/${location.pathname.split('/')[1]}` === selectedItem.route) {
-  //     // already in the subApp, don't change location
-  //     return;
-  //   }
-  //   goTo(selectedItem.route);
-  // }, [selectedItem]);
-
   const goTo = (url: string) => {
     dispatch(push(url, { previousUrl: window.location.href }));
   };

--- a/src/shared/layouts/FusionMainLayout.tsx
+++ b/src/shared/layouts/FusionMainLayout.tsx
@@ -79,14 +79,14 @@ const FusionMainLayout: React.FC<FusionMainLayoutProps> = ({
     'consentToTracking'
   );
 
-  React.useEffect(() => {
-    // only navigate if not in the subApp path already
-    if (`/${location.pathname.split('/')[1]}` === selectedItem.route) {
-      // already in the subApp, don't change location
-      return;
-    }
-    goTo(selectedItem.route);
-  }, [selectedItem]);
+  // React.useEffect(() => {
+  //   // only navigate if not in the subApp path already
+  //   if (`/${location.pathname.split('/')[1]}` === selectedItem.route) {
+  //     // already in the subApp, don't change location
+  //     return;
+  //   }
+  //   goTo(selectedItem.route);
+  // }, [selectedItem]);
 
   const goTo = (url: string) => {
     dispatch(push(url, { previousUrl: window.location.href }));
@@ -111,6 +111,13 @@ const FusionMainLayout: React.FC<FusionMainLayoutProps> = ({
   const onSelectSubAbpp = (data: any) => {
     const item = subApps.find(subApp => subApp.key === data.key);
     setSelectedItem(item as SubAppProps);
+    if (item) {
+      if (`/${location.pathname.split('/')[1]}` === item.route) {
+        // already in the subApp, don't change location
+        return;
+      }
+      goTo(item.route);
+    }
   };
 
   return (

--- a/src/shared/routes.ts
+++ b/src/shared/routes.ts
@@ -2,6 +2,7 @@ import { RouteProps } from 'react-router-dom';
 import Login from './views/Login';
 import ResourceView from './views/ResourceView';
 import UserView from './views/UserView';
+import StudioRedirectView from './views/StudioRedirectView';
 import Home from './views/Home';
 
 const routes: RouteProps[] = [
@@ -21,6 +22,28 @@ const routes: RouteProps[] = [
   {
     path: '/:orgLabel/:projectLabel/resources/:resourceId',
     component: ResourceView,
+  },
+  {
+    path: '/:orgLabel/:projectLabel/studios/:studioId',
+    exact: true,
+    component: StudioRedirectView,
+  },
+  {
+    path: '/:orgLabel/:projectLabel/studios/:studioId/workspaces/:workspaceId',
+    exact: true,
+    component: StudioRedirectView,
+  },
+  {
+    path:
+      '/:orgLabel/:projectLabel/studios/:studioId/workspaces/:workspaceId/dashboards/:dashboardId',
+    exact: true,
+    component: StudioRedirectView,
+  },
+  {
+    path:
+      '/:orgLabel/:projectLabel/studios/:studioId/workspaces/:workspaceId/dashboards/:dashboardId/studioResource/:studioResourceId',
+    exact: true,
+    component: StudioRedirectView,
   },
 ];
 

--- a/src/shared/views/StudioRedirectView.tsx
+++ b/src/shared/views/StudioRedirectView.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { Redirect, useLocation } from 'react-router-dom';
+
+const ResourceView: React.FunctionComponent = props => {
+  const location = useLocation();
+  console.log(location.pathname);
+  return (
+    <Redirect
+      to={{
+        pathname: `/studioLegacy${location.pathname}`,
+        search: location.search,
+      }}
+    />
+  );
+};
+export default ResourceView;


### PR DESCRIPTION
- Redirect old studio paths.
- Remove useEffect from layout, this broke absolute link not related to
sub apps from resolving.

Fixes BlueBrain/nexus/issues/1336