### PR TITLE
Prioritize labels by @mfsy suggestion

### DIFF
--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -223,7 +223,12 @@ export function getResourceLabel(
     [key: string]: any;
   }
 ) {
-  return resource.name || resource.label || labelOf(resource['@id']);
+  return (
+    resource.prefLabel ||
+    resource.label ||
+    resource.name ||
+    labelOf(resource['@id'])
+  );
 }
 
 /**


### PR DESCRIPTION
Re-prioritize label displays according to a @MFSY 's suggestion from the nexus-search-webapp experiment. 

<img width="411" alt="Screenshot 2020-08-03 at 13 54 24" src="https://user-images.githubusercontent.com/5485824/89180095-53bb9d00-d591-11ea-9be0-ab3212743449.png">
