### PR TITLE
Fix infinite scroll on ResourceList

### DIFF
--- a/src/shared/components/List/InfiniteSearch.tsx
+++ b/src/shared/components/List/InfiniteSearch.tsx
@@ -11,6 +11,7 @@ export type InfiniteSearchProps = {
   hasSearch?: boolean;
   height?: number;
   dataLength: number;
+  scrollParent?: HTMLElement | string | null;
 };
 const InfiniteSearch: React.FunctionComponent<InfiniteSearchProps> = props => {
   const {
@@ -50,6 +51,7 @@ const InfiniteSearch: React.FunctionComponent<InfiniteSearchProps> = props => {
         loader={<h4>Loading...</h4>}
         height={props.height}
         scrollThreshold={'100px'}
+        scrollableTarget={props.scrollParent}
       >
         {props.children}
       </InfiniteScroll>

--- a/src/shared/components/ResourceLinks/ResourceLinkItem.less
+++ b/src/shared/components/ResourceLinks/ResourceLinkItem.less
@@ -17,3 +17,8 @@
     margin-top: 5px;
   }
 }
+
+.resource-links {
+  height: 95%;
+  overflow: scroll;
+}

--- a/src/shared/components/ResourceLinks/index.tsx
+++ b/src/shared/components/ResourceLinks/index.tsx
@@ -20,7 +20,7 @@ const ResourceLinks: React.FunctionComponent<{
   const firstLoad = busy && links.length === 0;
 
   return (
-    <div className="resource-links" ref={scrollParent} id="yo">
+    <div className="resource-links" ref={scrollParent}>
       {firstLoad ? (
         <Skeleton active />
       ) : (

--- a/src/shared/components/ResourceLinks/index.tsx
+++ b/src/shared/components/ResourceLinks/index.tsx
@@ -20,7 +20,7 @@ const ResourceLinks: React.FunctionComponent<{
   const firstLoad = busy && links.length === 0;
 
   return (
-    <div className="resource-links" ref={scrollParent}>
+    <div className="resource-links" ref={scrollParent} id="yo">
       {firstLoad ? (
         <Skeleton active />
       ) : (
@@ -32,6 +32,7 @@ const ResourceLinks: React.FunctionComponent<{
               onLoadMore={onLoadMore}
               hasMore={hasMore}
               hasSearch={false}
+              scrollParent={scrollParent.current}
             >
               {links.map(link => (
                 <ListItem key={link['@id']}>


### PR DESCRIPTION
Add scrollable target to infinite scroll so that, when it is rendered
inside a modal, it can still find a parent with  scroll.

Fixes BlueBrain/nexus/issues/1591