### PR TITLE
Add search to history.push

### DIFF
--- a/src/shared/App.tsx
+++ b/src/shared/App.tsx
@@ -120,7 +120,9 @@ const App: React.FC = () => {
             <Modal
               visible={true}
               footer={null}
-              onCancel={() => history.push(background.pathname, {})}
+              onCancel={() =>
+                history.push(`${background.pathname}?${background.search}`, {})
+              }
               className="modal-view"
               width="inherit"
             >


### PR DESCRIPTION
  Currently only  pathname is pushed to history. Adding search will fix
  issues related to studios/dashboard not persisting on close of the
  modal.

Fixes BlueBrain/nexus/issues/1555