### PR TITLE
Update activity card

### DIFF
--- a/src/subapps/projects/components/Activities/ActivityCard.less
+++ b/src/subapps/projects/components/Activities/ActivityCard.less
@@ -5,7 +5,7 @@
   background-color: rgb(247, 245, 245);
   width: 270px;
   border-radius: 10px;
-  padding: 0.5em 1em;
+  padding: 0.5em;
   box-shadow: @box-shadow-base;
 
   &--blocked {
@@ -66,5 +66,18 @@
   &__list-container {
     max-height: 107px;
     overflow-y: scroll;
+  }
+
+  &__list-container::-webkit-scrollbar-track {
+    background-color: transparent;
+  }
+
+  &__list-container::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  &__list-container::-webkit-scrollbar-thumb {
+    background-color: @not-started-color;
+    border-radius: 10px;
   }
 }

--- a/src/subapps/projects/components/Activities/ActivityCard.less
+++ b/src/subapps/projects/components/Activities/ActivityCard.less
@@ -3,7 +3,7 @@
 .activity-card {
   margin: 1em;
   background-color: rgb(247, 245, 245);
-  width: 250px;
+  width: 270px;
   border-radius: 10px;
   padding: 0.5em 1em;
   box-shadow: @box-shadow-base;
@@ -31,6 +31,7 @@
 
   &__name {
     margin: 0 10px;
+    line-height: 18px;
   }
 
   &__info-line,
@@ -45,6 +46,7 @@
   &__title {
     display: flex;
     align-items: center;
+    height: 36px;
   }
 
   &__info {

--- a/src/subapps/projects/components/Activities/ActivityCard.less
+++ b/src/subapps/projects/components/Activities/ActivityCard.less
@@ -24,9 +24,12 @@
     border-top: 10px solid @not-started-color;
   }
 
-  &__main,
-  &__subactivities-total {
+  &__main {
     padding: 0 8px;
+  }
+
+  &__subactivities-total {
+    padding: 0 8px 5px 8px;
   }
 
   &__name {
@@ -58,5 +61,10 @@
 
   &__info-icon {
     margin-right: 10px;
+  }
+
+  &__list-container {
+    max-height: 107px;
+    overflow-y: scroll;
   }
 }

--- a/src/subapps/projects/components/Activities/ActivityCard.tsx
+++ b/src/subapps/projects/components/Activities/ActivityCard.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
+import { Tooltip } from 'antd';
 
 import StatusIcon from '../../components/StatusIcon';
 import SubActivityItem from './SubActivityItem';
@@ -22,13 +23,23 @@ const ActivityCard: React.FC<{
   const { name, description, status } = activity;
   const activityId = activity['@id'];
 
+  // TODO: add a tooltip
+
   return (
     <div className={`activity-card activity-card--${status.replace(' ', '-')}`}>
       <div className="activity-card__main">
         <div className="activity-card__title">
           <StatusIcon status={status} mini={true} />
           <Link to={`/projects/${orgLabel}/${projectLabel}/${activityId}`}>
-            <h3 className="activity-card__name">{name}</h3>
+            {name.length > 40 ? (
+              <Tooltip placement="topRight" title={name}>
+                <h3 className="activity-card__name">
+                  {name.slice(0, 40) + '...'}
+                </h3>
+              </Tooltip>
+            ) : (
+              <h3 className="activity-card__name">{name}</h3>
+            )}
           </Link>
           <img src={editIcon} />
         </div>

--- a/src/subapps/projects/components/Activities/ActivityCard.tsx
+++ b/src/subapps/projects/components/Activities/ActivityCard.tsx
@@ -34,7 +34,7 @@ const ActivityCard: React.FC<{
             {name.length > 40 ? (
               <Tooltip placement="topRight" title={name}>
                 <h3 className="activity-card__name">
-                  {name.slice(0, 40) + '...'}
+                  {`${name.slice(0, 40)}...`}
                 </h3>
               </Tooltip>
             ) : (

--- a/src/subapps/projects/components/Activities/ActivityCard.tsx
+++ b/src/subapps/projects/components/Activities/ActivityCard.tsx
@@ -29,10 +29,10 @@ const ActivityCard: React.FC<{
         <div className="activity-card__title">
           <StatusIcon status={status} mini={true} />
           <Link to={`/projects/${orgLabel}/${projectLabel}/${activityId}`}>
-            {name.length > 40 ? (
+            {name.length > 45 ? (
               <Tooltip placement="topRight" title={name}>
                 <h3 className="activity-card__name">
-                  {`${name.slice(0, 40)}...`}
+                  {`${name.slice(0, 45)}...`}
                 </h3>
               </Tooltip>
             ) : (

--- a/src/subapps/projects/components/Activities/ActivityCard.tsx
+++ b/src/subapps/projects/components/Activities/ActivityCard.tsx
@@ -23,8 +23,6 @@ const ActivityCard: React.FC<{
   const { name, description, status } = activity;
   const activityId = activity['@id'];
 
-  // TODO: add a tooltip
-
   return (
     <div className={`activity-card activity-card--${status.replace(' ', '-')}`}>
       <div className="activity-card__main">
@@ -65,15 +63,17 @@ const ActivityCard: React.FC<{
             Activities: {(subactivities && subactivities.length) || 0}
           </span>
         </div>
-        {subactivities &&
-          subactivities.length > 0 &&
-          subactivities.map(subactivitiy => (
-            <SubActivityItem
-              key={subactivitiy['@id']}
-              status={subactivitiy.status}
-              title={subactivitiy.name}
-            />
-          ))}
+        <div className="activity-card__list-container">
+          {subactivities &&
+            subactivities.length > 0 &&
+            subactivities.map(subactivitiy => (
+              <SubActivityItem
+                key={subactivitiy['@id']}
+                status={subactivitiy.status}
+                title={subactivitiy.name}
+              />
+            ))}
+        </div>
       </div>
     </div>
   );

--- a/src/subapps/projects/components/Activities/SubActivityItem.less
+++ b/src/subapps/projects/components/Activities/SubActivityItem.less
@@ -2,9 +2,9 @@
   display: flex;
   align-items: center;
   background-color: #fff;
-  padding: 7px;
+  padding: 5px 7px;
   border-radius: 6px;
-  margin: 7px 0;
+  margin: 4px 0;
 
   &__content {
     margin: 0 10px;
@@ -12,7 +12,7 @@
 
   &__title {
     margin: 0;
-    font-size: 15px;
+    font-size: 14px;
   }
 
   &__total {

--- a/src/subapps/projects/components/Activities/SubActivityItem.less
+++ b/src/subapps/projects/components/Activities/SubActivityItem.less
@@ -4,7 +4,7 @@
   background-color: #fff;
   padding: 5px 7px;
   border-radius: 6px;
-  margin: 4px 0;
+  margin: 0 4px 4px 0;
 
   &__content {
     margin: 0 10px;
@@ -17,5 +17,9 @@
 
   &__total {
     margin: 0;
+  }
+
+  &:last-child {
+    margin-bottom: 0;
   }
 }

--- a/src/subapps/projects/components/Activities/SubActivityItem.less
+++ b/src/subapps/projects/components/Activities/SubActivityItem.less
@@ -12,6 +12,7 @@
 
   &__title {
     margin: 0;
+    font-size: 15px;
   }
 
   &__total {

--- a/src/subapps/projects/components/Activities/SubActivityItem.tsx
+++ b/src/subapps/projects/components/Activities/SubActivityItem.tsx
@@ -17,7 +17,7 @@ const SubActivityItem: React.FC<{
         {title.length > 25 ? (
           <Tooltip placement="topRight" title={title}>
             <h3 className="sub-activity__title">
-              {title.slice(0, 25) + '...'}
+              {`${title.slice(0, 25)}...`}
             </h3>
           </Tooltip>
         ) : (

--- a/src/subapps/projects/components/Activities/SubActivityItem.tsx
+++ b/src/subapps/projects/components/Activities/SubActivityItem.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Tooltip } from 'antd';
 
 import StatusIcon, { Status } from '../StatusIcon';
 
@@ -13,11 +14,15 @@ const SubActivityItem: React.FC<{
     <div className="sub-activity">
       <StatusIcon status={status} mini={true} />
       <div className="sub-activity__content">
-        <h3 className="sub-activity__title">{title}</h3>
-        {/* TODO: add number of subactivities */}
-        {/* <p className="sub-activity__total">
-          {activitiesNumber || 0} activities
-        </p> */}
+        {title.length > 25 ? (
+          <Tooltip placement="topRight" title={title}>
+            <h3 className="sub-activity__title">
+              {title.slice(0, 25) + '...'}
+            </h3>
+          </Tooltip>
+        ) : (
+          <h3 className="sub-activity__title">{title}</h3>
+        )}
       </div>
     </div>
   );

--- a/src/subapps/projects/components/Breadcrumbs.less
+++ b/src/subapps/projects/components/Breadcrumbs.less
@@ -5,7 +5,8 @@
 
   &__label,
   .ant-breadcrumb-separator {
-    font-size: 20px;
+    font-size: 18px;
+    line-height: 22px;
   }
 
   &__label:hover {

--- a/src/subapps/projects/components/Breadcrumbs.tsx
+++ b/src/subapps/projects/components/Breadcrumbs.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Breadcrumb } from 'antd';
+import { Breadcrumb, Tooltip } from 'antd';
 import { Link } from 'react-router-dom';
 
 import './Breadcrumbs.less';
@@ -16,7 +16,15 @@ const Breadcrumbs: React.FC<{ crumbs: BreadcrumbItem[] }> = ({ crumbs }) => {
         {crumbs.map(item => (
           <Breadcrumb.Item key={item.label}>
             <Link to={item.url}>
-              <span className="breadcrumbs__label">{item.label}</span>
+              {item.label.length > 35 ? (
+                <Tooltip placement="top" title={item.label}>
+                  <span className="breadcrumbs__label">
+                    {`${item.label.slice(0, 35)}...`}
+                  </span>
+                </Tooltip>
+              ) : (
+                <span className="breadcrumbs__label">{item.label}</span>
+              )}
             </Link>
           </Breadcrumb.Item>
         ))}

--- a/src/subapps/projects/containers/ActivityInfoContainer.tsx
+++ b/src/subapps/projects/containers/ActivityInfoContainer.tsx
@@ -18,8 +18,18 @@ const ActivityInfoContainer: React.FC<{
   const [showForm, setShowForm] = React.useState<boolean>(false);
   const [busy, setBusy] = React.useState<boolean>(false);
   const [parentLabel, setParentLabel] = React.useState<string>();
+  const [originalPayload, setOriginalPayload] = React.useState<
+    ActivityResource
+  >();
 
   React.useEffect(() => {
+    nexus.Resource.getSource(
+      orgLabel,
+      projectLabel,
+      encodeURIComponent(activity['@id'])
+    )
+      .then(response => setOriginalPayload(response as ActivityResource))
+      .catch(error => displayError(error, 'Failed to load original payload'));
     if (activity.hasParent) {
       nexus.Resource.get(
         orgLabel,
@@ -35,6 +45,12 @@ const ActivityInfoContainer: React.FC<{
   }, []);
 
   const updateActivity = (data: any) => {
+    const parent = originalPayload && originalPayload.hasParent;
+
+    if (parent && parent['@id']) {
+      data.hasParent = parent;
+    }
+
     nexus.Resource.update(
       orgLabel,
       projectLabel,
@@ -42,7 +58,6 @@ const ActivityInfoContainer: React.FC<{
       activity._rev,
       {
         ...data,
-        hasParent: activity.hasParent,
         '@type': fusionConfig.activityType,
       }
     )

--- a/src/subapps/projects/views/ActivityView.less
+++ b/src/subapps/projects/views/ActivityView.less
@@ -5,6 +5,7 @@
   background-color: #fff;
   background-image: url('../../../shared/images/projectGrid.png');
   position: relative;
+  margin-bottom: 52px;
 
   &__panel {
     display: flex;


### PR DESCRIPTION
Fixes BlueBrain/nexus#1666
Fixes BlueBrain/nexus#1665

- Chops long activity names, adds a tooltip to display them
- Chops long breadcrumbs

<img width="1238" alt="Screenshot 2020-10-08 at 15 03 28" src="https://user-images.githubusercontent.com/23080476/95462486-db4dcf80-0977-11eb-8e2f-af7aeae5fd59.png">

- Moves subactivities into a scrollable list (max 3 items shown)

![Screenshot 2020-10-08 at 14 53 31](https://user-images.githubusercontent.com/23080476/95462529-e99beb80-0977-11eb-8479-93bfe65bf829.png)




