### PR TITLE
Fix activity update

### DIFF
--- a/src/subapps/projects/containers/ActivityInfoContainer.tsx
+++ b/src/subapps/projects/containers/ActivityInfoContainer.tsx
@@ -60,23 +60,13 @@ const ActivityInfoContainer: React.FC<{
   }, []);
 
   const updateActivity = (data: any) => {
-    const parent = originalPayload && originalPayload.hasParent;
-    const informedBy = originalPayload && originalPayload.wasInformedBy;
-
-    if (parent && parent['@id']) {
-      data.hasParent = parent;
-    }
-
-    if (informedBy && informedBy['@id']) {
-      data.wasInformedBy = informedBy;
-    }
-
     nexus.Resource.update(
       orgLabel,
       projectLabel,
       activity['@id'],
       activity._rev,
       {
+        ...originalPayload,
         ...data,
         '@type': fusionConfig.activityType,
       }

--- a/src/subapps/projects/views/ActivityView.tsx
+++ b/src/subapps/projects/views/ActivityView.tsx
@@ -29,6 +29,12 @@ export type ActivityResource = Resource<{
   wasInformedBy?: {
     '@id': string;
   };
+  used?: {
+    '@id': string;
+  };
+  wasAssociatedWith?: {
+    '@id': string;
+  };
 }>;
 
 type BreadcrumbItem = {


### PR DESCRIPTION
🚧 This is to make sure we put everything back in a payload when we update an activity, like `used`, `hasParent`, `wasAssosiatedWith`, etc. 🚧