### PR TITLE
Keep resources pane open by default

### DIFF
--- a/src/subapps/projects/components/ResourcesList.less
+++ b/src/subapps/projects/components/ResourcesList.less
@@ -4,9 +4,9 @@
   height: 420px;
   overflow-y: scroll;
   width: 67%;
+  border-left: 1px solid @border-color-base;
 
   &__resources {
-    border-left: 1px solid @border-color-base;
     padding-left: 20px;
   }
 }

--- a/src/subapps/projects/components/ResourcesPane.tsx
+++ b/src/subapps/projects/components/ResourcesPane.tsx
@@ -56,7 +56,7 @@ const ResourcesPane: React.FC<{ linkCode(data: CodeResourceData): void }> = ({
         className="resources-pane"
         style={{ width: `${paneWidth}px` }}
       >
-        <Collapse>
+        <Collapse defaultActiveKey={['1']}>
           <Panel
             header={
               <div className="resources-pane__header">


### PR DESCRIPTION
Fixes BlueBrain/nexus#1763