### PR TITLE
Add commit hash to infobox

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "repository": "github:bluebrain/nexus-explorer",
   "url": "https://github.com/BlueBrain/nexus/issues/new?labels=frontend,nexus-web",
   "scripts": {
-    "start": "NODE_ENV=development DEBUG=* webpack --mode development --config-name server && node dist/server.js",
+    "start": "NODE_ENV=development  DEBUG=* webpack --mode development --config-name server && node dist/server.js",
     "build": "NODE_ENV=production webpack --mode production",
     "test": "jest",
     "cy:run": "cypress run",
@@ -35,6 +35,7 @@
     "deep-object-diff": "^1.1.0",
     "express": "^4.16.4",
     "express-prom-bundle": "^5.0.2",
+    "git-revision-webpack-plugin": "^3.0.6",
     "history": "^4.7.2",
     "jwt-decode": "^2.2.0",
     "lodash": "^4.17.15",

--- a/src/shared/components/Header/index.tsx
+++ b/src/shared/components/Header/index.tsx
@@ -19,10 +19,12 @@ const infoIcon = require('../../images/infoIcon.svg');
 const copyIcon = require('../../images/copyIcon.svg');
 
 const documentationURL = 'https://bluebrainnexus.io/docs';
+const repoUrl = 'https://github.com/BlueBrain/nexus-web';
 
 interface InformationContentProps {
   version: string;
   githubIssueURL: string;
+  commitHash?: string;
   consent?: ConsentType;
   onClickRemoveConsent?(): void;
 }
@@ -48,7 +50,9 @@ const InformationContent = (props: InformationContentProps) => {
       <h4>Nexus Services</h4>
       <p>
         Nexus Delta v{props.version} <br />
-        Nexus Fusion v{packageJson.version}
+        <a href={`${repoUrl}/commits/${props.commitHash}`}>
+          Nexus Fusion v{packageJson.version}
+        </a>
       </p>
       <p>
         <a href={documentationURL} target="_blank">
@@ -78,6 +82,7 @@ export interface HeaderProps {
   displayLogin?: boolean;
   children?: React.ReactChild;
   consent?: ConsentType;
+  commitHash?: string;
   onClickRemoveConsent?(): void;
   onClickSideBarToggle(): void;
   performLogin(realmName: string): void;
@@ -93,6 +98,7 @@ const Header: React.FunctionComponent<HeaderProps> = ({
   version,
   githubIssueURL,
   consent,
+  commitHash,
   onClickRemoveConsent,
   onClickSideBarToggle,
   performLogin,
@@ -155,6 +161,7 @@ const Header: React.FunctionComponent<HeaderProps> = ({
               githubIssueURL={githubIssueURL}
               consent={consent}
               onClickRemoveConsent={onClickRemoveConsent}
+              commitHash={commitHash}
             />
           }
           trigger="click"

--- a/src/shared/components/Header/index.tsx
+++ b/src/shared/components/Header/index.tsx
@@ -14,12 +14,15 @@ import { ConsentType } from '../../layouts/FusionMainLayout';
 
 import './Header.less';
 
+declare var Version: string;
+
 const epflLogo = require('../../images/EPFL-logo.svg');
 const infoIcon = require('../../images/infoIcon.svg');
 const copyIcon = require('../../images/copyIcon.svg');
 
 const documentationURL = 'https://bluebrainnexus.io/docs';
 const repoUrl = 'https://github.com/BlueBrain/nexus-web';
+const releaseNoteUrl = 'https://github.com/BlueBrain/nexus-web/releases';
 
 interface InformationContentProps {
   version: string;
@@ -51,7 +54,7 @@ const InformationContent = (props: InformationContentProps) => {
       <p>
         Nexus Delta v{props.version} <br />
         <a href={`${repoUrl}/commits/${props.commitHash}`}>
-          Nexus Fusion v{packageJson.version}
+          Nexus Fusion {Version}
         </a>
       </p>
       <p>
@@ -61,6 +64,10 @@ const InformationContent = (props: InformationContentProps) => {
         {' | '}
         <a href={props.githubIssueURL} target="_blank">
           <GithubOutlined /> Report Issue
+        </a>
+        {' | '}
+        <a href={releaseNoteUrl} target="_blank">
+          <GithubOutlined /> Fusion Release Notes
         </a>
       </p>
       {

--- a/src/shared/layouts/FusionMainLayout.tsx
+++ b/src/shared/layouts/FusionMainLayout.tsx
@@ -24,7 +24,7 @@ import './FusionMainLayout.less';
 const { Sider, Content } = Layout;
 
 const logo = require('../images/logoDarkBg.svg');
-
+declare var COMMIT_HASH: string;
 export interface FusionMainLayoutProps {
   authenticated: boolean;
   realms: Realm[];
@@ -234,6 +234,7 @@ const FusionMainLayout: React.FC<FusionMainLayoutProps> = ({
             version={deltaVersion}
             githubIssueURL={githubIssueURL}
             consent={consent}
+            commitHash={COMMIT_HASH}
             onClickRemoveConsent={() => setConsent(undefined)}
             onClickSideBarToggle={() => setCollapsed(!collapsed)}
           />

--- a/src/subapps/studioLegacy/views/StudioView.tsx
+++ b/src/subapps/studioLegacy/views/StudioView.tsx
@@ -5,7 +5,6 @@ import StudioContainer from '../containers/StudioContainer';
 import useQueryString from '../../../shared/hooks/useQueryString';
 import { useNexusContext } from '@bbp/react-nexus';
 import { Resource } from '@bbp/nexus-sdk';
-import StudioHeader from '../components/StudioHeader';
 
 type StudioContextType = {
   orgLabel: string;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,9 @@ const TerserPlugin = require('terser-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const devMode = process.env.NODE_ENV !== 'production';
 
-const gitRevisionPlugin = new GitRevisionPlugin();
+const gitRevisionPlugin = new GitRevisionPlugin({
+  versionCommand: 'describe --tags',
+});
 
 const config = [
   {
@@ -67,6 +69,7 @@ const config = [
       new webpack.DefinePlugin({
         __isBrowser__: true,
         COMMIT_HASH: JSON.stringify(gitRevisionPlugin.commithash()),
+        Version: JSON.stringify(gitRevisionPlugin.version()),
       }),
       new MiniCssExtractPlugin(),
     ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,10 +1,13 @@
 const path = require('path');
 const webpack = require('webpack');
+const GitRevisionPlugin = require('git-revision-webpack-plugin');
 const nodeExternals = require('webpack-node-externals');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const devMode = process.env.NODE_ENV !== 'production';
+
+const gitRevisionPlugin = new GitRevisionPlugin();
 
 const config = [
   {
@@ -60,8 +63,10 @@ const config = [
       ],
     },
     plugins: [
+      gitRevisionPlugin,
       new webpack.DefinePlugin({
         __isBrowser__: true,
+        COMMIT_HASH: JSON.stringify(gitRevisionPlugin.commithash()),
       }),
       new MiniCssExtractPlugin(),
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -6169,6 +6169,11 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
+git-revision-webpack-plugin@^3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/git-revision-webpack-plugin/-/git-revision-webpack-plugin-3.0.6.tgz#5dd6c6829fae05b405059dea6195b23875d69d4d"
+  integrity sha512-vW/9dBahGbpKPcccy3xKkHgdWoH/cAPPc3lQw+3edl7b4j29JfNGVrja0a1d8ZoRe4nTN8GCPrF9aBErDnzx5Q==
+
 glob-base@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-base/-/glob-base-0.3.0.tgz#dbb164f6221b1c0b1ccf82aea328b497df0ea3c4"


### PR DESCRIPTION
Get commit hash as a webpack plugin and link it to to the version test
in info-box.

MacOS Mojave 10.14.6
- [x] Chrome 86.0.4240.183 (Official Build)
- [x] Safari 14.0 (14610.1.28.1.10)
- [x] Edge 86.0.622.63 (Official build)
- [x] Firefox 81.0 (64 bit)

Fixes BlueBrain/nexus/issues/1757 