### PR TITLE
Remove location state from goToProject link

### DIFF
--- a/src/shared/containers/ResourceViewContainer.tsx
+++ b/src/shared/containers/ResourceViewContainer.tsx
@@ -61,7 +61,7 @@ const ResourceViewContainer: React.FunctionComponent<{
   };
 
   const goToProject = (orgLabel: string, projectLabel: string) =>
-    history.push(`/admin/${orgLabel}/${projectLabel}`, location.state);
+    history.push(`/admin/${orgLabel}/${projectLabel}`);
 
   const goToOrg = (orgLabel: string) => history.push(`/admin/${orgLabel}`);
 


### PR DESCRIPTION
resolves https://github.com/BlueBrain/nexus/issues/1939

Basically I've found that you should not push to history with a 2nd argument for the background state if you don't intend the new route to include a modal. 