### PR TITLE
Allow sorting via ES query

### DIFF
--- a/src/shared/components/ElasticSearchResultsTable/index.tsx
+++ b/src/shared/components/ElasticSearchResultsTable/index.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { Table, Tooltip, Button, Input, Select } from 'antd';
 import { Resource } from '@bbp/nexus-sdk';
+import { match } from 'ts-pattern';
+
 import { ColumnsType, TablePaginationConfig } from 'antd/lib/table';
-import * as prettyBytes from 'pretty-bytes';
 import {
   SortDirection,
   UseSearchProps,
@@ -12,8 +13,6 @@ import TypesIconList from '../Types/TypesIcon';
 import { getResourceLabel } from '../../utils';
 import { convertMarkdownHandlebarStringWithData } from '../../utils/markdownTemplate';
 import { parseURL } from '../../utils/nexusParse';
-import { FILE_SCHEMA } from '../../types/nexus';
-import { match } from 'ts-pattern';
 import { SorterResult, TableRowSelection } from 'antd/lib/table/interface';
 import { ResultTableFields } from '../../types/search';
 import './../../styles/result-table.less';
@@ -40,24 +39,28 @@ export const DEFAULT_FIELDS = [
     title: 'Label',
     dataIndex: 'label',
     key: 'label',
+    displayIndex: 0,
   },
   {
     title: 'Project',
     dataIndex: '_project',
     sortable: true,
     key: 'project',
+    displayIndex: 1,
   },
   {
     title: 'Schema',
     dataIndex: '_constrainedBy',
     sortable: true,
     key: 'schema',
+    displayIndex: 2,
   },
   {
     title: 'Types',
     dataIndex: '@type',
     sortable: true,
     key: '@type',
+    displayIndex: 3,
   },
 ];
 
@@ -261,7 +264,9 @@ const ElasticSearchResultsTable: React.FC<ResultsGridProps> = ({
         onChange={handleTableChange}
         rowSelection={rowSelection}
         dataSource={filteredItems}
-        columns={isStudio ? selectedColumns : columns}
+        columns={
+          isStudio ? selectedColumns : sortBy(columns, ['displayIndex', 'key'])
+        }
         pagination={pagination}
         bordered
         title={isStudio ? renderTitle : undefined}

--- a/src/shared/components/SparqlResultsTable/index.tsx
+++ b/src/shared/components/SparqlResultsTable/index.tsx
@@ -164,7 +164,6 @@ const SparqlResultsTable: React.FunctionComponent<ResultTableProps> = ({
       ? selectedColumns.map(x => x.dataIndex)
       : [];
     const columnsToOmit = difference(allColumnsTitles, selectedColumnTitles);
-    console.log(columnsToOmit);
     if (tableItems) {
       const itemsToSave = tableItems.map(item =>
         omit(item, 'id', 'key', 'self', ...columnsToOmit)

--- a/src/shared/hooks/useSearchQuery.ts
+++ b/src/shared/hooks/useSearchQuery.ts
@@ -50,10 +50,15 @@ export enum SortDirection {
 
 export type UseSearchProps = {
   query?: string;
-  sort?: {
-    key: string;
-    direction: SortDirection;
-  };
+  sort?:
+    | {
+        key: string;
+        direction: SortDirection;
+      }
+    | {
+        key: string;
+        direction: SortDirection;
+      }[];
   pagination?: {
     from: number;
     size: number;
@@ -83,7 +88,7 @@ export default function useSearchQuery(selfURL?: string | null) {
   });
   const {
     query,
-    sort = DEFAULT_SEARCH_PROPS.sort,
+    sort,
     pagination = DEFAULT_SEARCH_PROPS.pagination,
     facetMap = new Map<
       string,
@@ -111,8 +116,16 @@ export default function useSearchQuery(selfURL?: string | null) {
       // TODO upgrade typescript to enable spread arguments
       // @ts-ignore
       .filter(...matchQuery)
-      .filter('term', '_deprecated', false)
-      .sort(sort.key, sort.direction);
+      .filter('term', '_deprecated', false);
+
+    // Sorting
+    if (Array.isArray(sort)) {
+      sort.forEach(sort => {
+        body.sort(sort.key, sort.direction);
+      });
+    } else {
+      sort && body.sort(sort.key, sort.direction);
+    }
 
     facetMap.forEach(({ propertyKey, type, label, value }) => {
       value.forEach(item => {

--- a/src/shared/types/search.ts
+++ b/src/shared/types/search.ts
@@ -29,4 +29,5 @@ export type ResultTableFields = {
   dataIndex: string | string[];
   sortable?: boolean;
   key: string;
+  displayIndex: number;
 };

--- a/src/shared/types/search.ts
+++ b/src/shared/types/search.ts
@@ -27,5 +27,6 @@ export interface SearchResponse<T> {
 export type ResultTableFields = {
   title: string;
   dataIndex: string | string[];
+  sortable?: boolean;
   key: string;
 };

--- a/src/subapps/hooks/useSearchQuery.ts
+++ b/src/subapps/hooks/useSearchQuery.ts
@@ -21,10 +21,15 @@ export enum SortDirection {
 
 export type UseSearchProps = {
   query?: object;
-  sort?: {
-    key: string;
-    direction: SortDirection;
-  };
+  sort?:
+    | {
+        key: string;
+        direction: SortDirection;
+      }
+    | {
+        key: string;
+        direction: SortDirection;
+      }[];
   pagination?: {
     from: number;
     size: number;
@@ -62,10 +67,18 @@ export default function useSearchQueryFromStudio(
 
     body
       .filter('term', '_deprecated', false)
-      .sort(sort.key, sort.direction)
       .size(pagination.size)
       .from(pagination.from)
       .rawOption('track_total_hits', TOTAL_HITS_TRACKING);
+
+    // Sorting
+    if (Array.isArray(sort)) {
+      sort.forEach(sort => {
+        body.sort(sort.key, sort.direction);
+      });
+    } else {
+      sort && body.sort(sort.key, sort.direction);
+    }
 
     const bodyQuery = body.build();
     const { org, project, id } = parseURL(selfURL);

--- a/src/subapps/search/views/SearchView.tsx
+++ b/src/subapps/search/views/SearchView.tsx
@@ -229,6 +229,13 @@ const SearchView: React.FC = () => {
     setSearchViewType(value ? SEARCH_VIEW_TYPES.GRID : SEARCH_VIEW_TYPES.TABLE);
   };
 
+  const handleSort = (sort: UseSearchProps['sort']) => {
+    setSearchProps({
+      ...searchProps,
+      sort,
+    });
+  };
+
   // Pagination Props
   const total = searchResponse.data?.hits.total.value || 0;
   const size = searchProps.pagination?.size || 0;
@@ -446,6 +453,7 @@ const SearchView: React.FC = () => {
                     fields={fields}
                     searchResponse={searchResponse}
                     onClickItem={handleClickItem}
+                    onSort={handleSort}
                     pagination={
                       shouldShowPagination
                         ? {

--- a/src/subapps/studioLegacy/containers/DashboardResults/DashboardElasticSearchQueryContainer.tsx
+++ b/src/subapps/studioLegacy/containers/DashboardResults/DashboardElasticSearchQueryContainer.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import ElasticSearchResultsTable, {
   DEFAULT_FIELDS,
 } from '../../../../shared/components/ElasticSearchResultsTable';
+import { UseSearchProps } from '../../../../shared/hooks/useSearchQuery';
 import { ResultTableFields } from '../../../../shared/types/search';
 import useSearchQuery from '../../../hooks/useSearchQuery';
 
@@ -32,6 +33,13 @@ const DashboardElasticSearchQueryContainer: React.FC<{
     });
   };
 
+  const handleSort = (sort: UseSearchProps['sort']) => {
+    setSearchProps({
+      ...searchProps,
+      sort,
+    });
+  };
+
   // Pagination Props
   const total = searchResponse.data?.hits.total.value || 0;
   const size = searchProps.pagination?.size || 0;
@@ -46,6 +54,7 @@ const DashboardElasticSearchQueryContainer: React.FC<{
       fields={fields || DEFAULT_FIELDS}
       searchResponse={searchResponse}
       onClickItem={handleClickItem}
+      onSort={handleSort}
       pagination={
         shouldShowPagination
           ? {


### PR DESCRIPTION
- fixes a problem where the fields passed from the parent to the ESResultsTable won't form the columns, but instead the default columns were being used. 
- allows for sorting things using the `useSearchQuery` ES View interface (via backend) instead of client side sorting