### PR TITLE
Configurable Search Facets

### DIFF
--- a/src/shared/components/ElasticSearchResultsTable/index.tsx
+++ b/src/shared/components/ElasticSearchResultsTable/index.tsx
@@ -78,8 +78,14 @@ const ElasticSearchResultsTable: React.FC<ResultsGridProps> = ({
   const results = (searchResponse.data?.hits.hits || []).map(({ _source }) => {
     const { _original_source, ...everythingElse } = _source;
 
+    let parsedSource = {};
+    try {
+      parsedSource = JSON.parse(_original_source);
+    } catch (error) {
+      console.warn(_original_source);
+    }
     const resource = {
-      ...JSON.parse(_original_source),
+      ...parsedSource,
       ...everythingElse,
     };
 

--- a/src/shared/containers/SearchBarContainer.tsx
+++ b/src/shared/containers/SearchBarContainer.tsx
@@ -11,9 +11,9 @@ const DEFAULT_SEARCH_BAR_RESULT_SIZE = 10;
 const SearchBarContainer: React.FC = () => {
   const { preferedSearchConfig, searchConfigs } = useSearchConfigs();
 
-  const [searchResponse, { searchProps, setSearchProps }] = useSearchQuery(
-    preferedSearchConfig?.view
-  );
+  const [searchResponse, { searchProps, setSearchProps }] = useSearchQuery({
+    selfURL: preferedSearchConfig?.view,
+  });
   const history = useHistory();
   const location = useLocation();
   const [queryParams, setQueryString] = useQueryString();

--- a/src/shared/hooks/useSearchQuery.ts
+++ b/src/shared/hooks/useSearchQuery.ts
@@ -150,10 +150,13 @@ export default function useSearchQuery(selfURL?: string | null) {
     }
     const { org, project, id } = parseURL(selfURL);
 
+    const encodedID = encodeURIComponent(id);
+    const usefulId = encodedID === id ? id : encodedID;
+
     return await nexus.View.elasticSearchQuery<SearchResponse<Resource>>(
       org,
       project,
-      encodeURIComponent(id),
+      usefulId,
       body
     );
   };

--- a/src/shared/hooks/useSearchQuery.ts
+++ b/src/shared/hooks/useSearchQuery.ts
@@ -77,25 +77,12 @@ export const DEFAULT_SEARCH_PROPS = {
 
 export interface UseSearchQueryProps {
   selfURL?: string | null;
-  // defaultFacetMap?: Map<string, FacetConfig & { value: Set<string> }>;
 }
 
 export default function useSearchQuery(props: UseSearchQueryProps) {
-  const {
-    selfURL,
-    // defaultFacetMap = new Map<
-    //   string,
-    //   {
-    //     propertyKey: string;
-    //     label: string;
-    //     type: 'terms';
-    //     value: Set<string>;
-    //   }
-    // >(),
-  } = props;
+  const { selfURL } = props;
   const [searchProps, setSearchProps] = React.useState<UseSearchProps>({
     ...DEFAULT_SEARCH_PROPS,
-    // facetMap: defaultFacetMap,
   });
   const {
     query,
@@ -109,6 +96,8 @@ export default function useSearchQuery(props: UseSearchQueryProps) {
   const makeBodyQuery = () => {
     // TODO fix query to match @id's as well
     // might need backend support
+    // TODO allow configurable query target
+    // not all ES View mappings will have this property.
     const matchQuery = query
       ? ['wildcard', '_original_source', `${query}*`]
       : ['match_all', {}];

--- a/src/shared/store/actions/search.ts
+++ b/src/shared/store/actions/search.ts
@@ -3,7 +3,11 @@ import { ActionCreator, AnyAction, Dispatch } from 'redux';
 import { ThunkAction } from '..';
 import { ResultTableFields } from '../../types/search';
 import { RootState } from '../reducers';
-import { SearchConfig, SearchConfigType } from '../reducers/search';
+import {
+  FacetConfig,
+  SearchConfig,
+  SearchConfigType,
+} from '../reducers/search';
 import { FetchAction, FetchFailedAction, FetchFulfilledAction } from './utils';
 
 export const enum SearchActionTypes {
@@ -109,6 +113,7 @@ export const fetchSearchConfigs: ActionCreator<ThunkAction> = () => {
               view: string;
               description?: string;
               fields?: ResultTableFields[];
+              facets?: FacetConfig[];
             }>
           >[]
         );
@@ -118,9 +123,16 @@ export const fetchSearchConfigs: ActionCreator<ThunkAction> = () => {
           label: resource.label,
           view: resource.view,
           description: resource.description,
-          fields: Array.isArray(resource.fields)
-            ? resource.fields
-            : [resource.fields],
+          fields: resource.fields
+            ? Array.isArray(resource.fields)
+              ? resource.fields
+              : [resource.fields]
+            : [],
+          facets: resource.facets
+            ? Array.isArray(resource.facets)
+              ? resource.facets
+              : [resource.facets]
+            : [],
         }));
       };
 

--- a/src/shared/store/reducers/search.ts
+++ b/src/shared/store/reducers/search.ts
@@ -10,12 +10,24 @@ import { ResultTableFields } from '../../types/search';
 
 export const SearchConfigType = 'nxv:SearchConfig';
 
+export enum FacetType {
+  TERMS = 'terms',
+}
+
+export type FacetConfig = {
+  propertyKey: string;
+  key: string;
+  label: string;
+  type: FacetType;
+};
+
 export type SearchConfig = {
   id: string;
   label: string;
   view: string;
   description?: string;
   fields?: ResultTableFields[];
+  facets?: FacetConfig[];
 };
 
 export const DEFAULT_SEARCH_STATE = {

--- a/src/subapps/search/views/SearchView.tsx
+++ b/src/subapps/search/views/SearchView.tsx
@@ -83,9 +83,6 @@ const SearchView: React.FC = () => {
     { searchProps, setSearchProps, query },
   ] = useSearchQuery({
     selfURL: preferedSearchConfig?.view,
-    // defaultFacetMap: generateDefaultSearchFilterMap(
-    //   preferedSearchConfig?.facets || []
-    // ),
   });
   const [queryParams, setQueryString] = useQueryString();
 

--- a/src/subapps/search/views/SearchView.tsx
+++ b/src/subapps/search/views/SearchView.tsx
@@ -68,6 +68,7 @@ const SearchView: React.FC = () => {
     preferedSearchConfig,
     searchConfigs,
     searchConfigProject,
+    setSearchPreference,
   } = useSearchConfigs();
 
   const [
@@ -236,6 +237,10 @@ const SearchView: React.FC = () => {
     });
   };
 
+  const handlePreferredSearchConfigChange = (value: string) => {
+    setSearchPreference(value);
+  };
+
   // Pagination Props
   const total = searchResponse.data?.hits.total.value || 0;
   const size = searchProps.pagination?.size || 0;
@@ -354,6 +359,17 @@ const SearchView: React.FC = () => {
                   })),
                 }}
               />
+              {/* Select Search Config */}
+              <Select
+                value={preferedSearchConfig?.id}
+                loading={searchConfigs.isFetching}
+                onChange={handlePreferredSearchConfigChange}
+                style={{ marginLeft: '2px' }}
+              >
+                {searchConfigs.data?.map(searchConfig => (
+                  <Option value={searchConfig.id}>{searchConfig.label}</Option>
+                ))}
+              </Select>
             </ActiveFilters>
           </Row>
           <Row>

--- a/src/subapps/search/views/SearchView.tsx
+++ b/src/subapps/search/views/SearchView.tsx
@@ -345,10 +345,18 @@ const SearchView: React.FC = () => {
                 dataset={{ ids: selectedRowKeys.map(key => key.toString()) }}
                 csv={{
                   data: (searchResponse.data?.hits.hits || []).map(
-                    ({ _source }) => ({
-                      ..._source,
-                      ...JSON.parse(_source._original_source),
-                    })
+                    ({ _source }) => {
+                      let parsedSource = {};
+                      try {
+                        parsedSource = JSON.parse(_source._original_source);
+                      } catch (error) {
+                        console.warn(_source._original_source);
+                      }
+                      return {
+                        ..._source,
+                        ...parsedSource,
+                      };
+                    }
                   ),
                   fields: fields.map(field => ({
                     label: field.title,


### PR DESCRIPTION
- allows for users to select which `SearchConfig` to use (locally)
- allows for admins to configure facets in their `SearchConfig`

Known Issue:
- the global search bar won't work without `__original_source` property added in an ES mapping. We might require some design to address this.