### PR TITLE
fix(ElasticSearchResultsTable): Fix certain dataIndexes rendering

### DIFF
--- a/src/shared/components/ElasticSearchResultsTable/index.tsx
+++ b/src/shared/components/ElasticSearchResultsTable/index.tsx
@@ -176,7 +176,12 @@ const ElasticSearchResultsTable: React.FC<ResultsGridProps> = ({
         ...field,
         sorter: !!field.sortable && sorter(field.key),
         render: (text: string, resource: Resource) =>
-          get(resource, field.dataIndex),
+          get(
+            resource,
+            Array.isArray(field.dataIndex)
+              ? field.dataIndex
+              : field.dataIndex.split('.')
+          ),
       }));
   });
 

--- a/src/shared/components/ElasticSearchResultsTable/index.tsx
+++ b/src/shared/components/ElasticSearchResultsTable/index.tsx
@@ -2,8 +2,9 @@ import * as React from 'react';
 import { Table, Tooltip, Button, Input, Select } from 'antd';
 import { Resource } from '@bbp/nexus-sdk';
 import { match } from 'ts-pattern';
-
+import { get, sortBy } from 'lodash';
 import { ColumnsType, TablePaginationConfig } from 'antd/lib/table';
+
 import {
   SortDirection,
   UseSearchProps,
@@ -15,8 +16,8 @@ import { convertMarkdownHandlebarStringWithData } from '../../utils/markdownTemp
 import { parseURL } from '../../utils/nexusParse';
 import { SorterResult, TableRowSelection } from 'antd/lib/table/interface';
 import { ResultTableFields } from '../../types/search';
+
 import './../../styles/result-table.less';
-import { sortBy } from 'lodash';
 
 const { Search } = Input;
 const { Option } = Select;
@@ -174,9 +175,8 @@ const ElasticSearchResultsTable: React.FC<ResultsGridProps> = ({
       .otherwise(() => ({
         ...field,
         sorter: !!field.sortable && sorter(field.key),
-        render: (text: string, resource: Resource) => {
-          return text;
-        },
+        render: (text: string, resource: Resource) =>
+          get(resource, field.dataIndex),
       }));
   });
 

--- a/src/shared/types/search.ts
+++ b/src/shared/types/search.ts
@@ -26,7 +26,7 @@ export interface SearchResponse<T> {
 
 export type ResultTableFields = {
   title: string;
-  dataIndex: string | string[];
+  dataIndex: string;
   sortable?: boolean;
   key: string;
   displayIndex: number;


### PR DESCRIPTION
some columns wouldn't be displayed, depending on their `dataIndex` value and type from the config.