### PR TITLE
Fix row click event for ES query

### DIFF
--- a/src/shared/containers/DataTableContainer.tsx
+++ b/src/shared/containers/DataTableContainer.tsx
@@ -155,8 +155,8 @@ const DataTableContainer: React.FC<DataTableProps> = ({
             onRow={data => ({
               onClick: event => {
                 event.preventDefault();
-                console.log(data);
-                goToStudioResource(data.self.value);
+                const self = data._self || data.self.value;
+                goToStudioResource(self);
               },
             })}
             rowSelection={{


### PR DESCRIPTION
- Use "self" correctly on ES query.