### PR TITLE
Stop position update on title click

### DIFF
--- a/src/subapps/projects/components/WorkflowSteps/StepCard.tsx
+++ b/src/subapps/projects/components/WorkflowSteps/StepCard.tsx
@@ -213,6 +213,7 @@ const StepCard: React.FC<{
     <>
       <Draggable
         bounds="parent"
+        cancel=".step-card__title"
         onDrag={handleDrag}
         onStop={handleStop}
         defaultPosition={

--- a/src/subapps/projects/views/ProjectsListView.tsx
+++ b/src/subapps/projects/views/ProjectsListView.tsx
@@ -54,7 +54,6 @@ const ProjectsListView: React.FC<{}> = () => {
       size: MAX_PROJECTS,
       deprecated: false,
     }).then(value => {
-      console.log(value._results.length);
       const shared = value._results.filter((v: ProjectResponseCommon) => {
         return v._organizationLabel !== personalOrg;
       });


### PR DESCRIPTION
It prevents an unwanted event: stops a card from sending a request to update its position, when a user clicks on a title to open a card.