### PR TITLE
Consolidated notifications

### DIFF
--- a/src/shared/App.tsx
+++ b/src/shared/App.tsx
@@ -8,24 +8,32 @@ import useSubApps from './hooks/useSubApps';
 import useDataCart, { CartContext, CartType } from './hooks/useDataCart';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import './App.less';
+import {
+  getNotificationContextValue,
+  NotificationContext,
+  NotificationContextType,
+} from './hooks/useNotification';
 
 const App: React.FC = () => {
   // TODO log the error in to sentry.
   const { subAppProps, subAppRoutes, subAppError } = useSubApps();
   const cartData: CartType = useDataCart();
   const queryClient = new QueryClient();
+  const notificationData: NotificationContextType = getNotificationContextValue();
 
   // Apply Subapp routes
   const routesWithSubApps = [...routes, ...subAppRoutes];
 
   return (
     <CartContext.Provider value={cartData}>
-      <QueryClientProvider client={queryClient}>
-        <FusionMainLayout subApps={subAppProps}>
-          <SubAppsView routesWithSubApps={routesWithSubApps} />
-          <GalleryView />
-        </FusionMainLayout>
-      </QueryClientProvider>
+      <NotificationContext.Provider value={notificationData}>
+        <QueryClientProvider client={queryClient}>
+          <FusionMainLayout subApps={subAppProps}>
+            <SubAppsView routesWithSubApps={routesWithSubApps} />
+            <GalleryView />
+          </FusionMainLayout>
+        </QueryClientProvider>
+      </NotificationContext.Provider>
     </CartContext.Provider>
   );
 };

--- a/src/shared/hooks/useNotification.ts
+++ b/src/shared/hooks/useNotification.ts
@@ -1,0 +1,132 @@
+import * as React from 'react';
+import { notification as antdNotification } from 'antd';
+import _ from 'lodash';
+
+export type NotificationContextType = {
+  error: (args: { message: string; description?: string }) => void;
+  success: (args: { message: string; description?: string }) => void;
+  info: (args: { message: string; description?: string }) => void;
+  warning: (args: { message: string; description?: string }) => void;
+};
+
+export const NotificationContext = React.createContext<NotificationContextType>(
+  {} as NotificationContextType
+);
+
+/**
+ * Custom hook providing convenient access to our context value
+ * that keeps track of open notifications. Uses antd notification
+ * api.
+ *
+ * Usage:
+ *
+ * import useNotification from '../../shared/hooks/useNotification';
+ * const notification = useNotification();
+ *
+ * notification.info({message: 'Welcome!', description: 'What up you legend'});
+ * notification.error({message: 'Darn, that didn''t work', description: 'Try again later maybe'});
+ * notification.warning({message: 'Careful', description: 'Do you really want to do that?'});
+ * notification.success({message: 'Congrats','You''ve only gone and done it!'});
+ *
+ */
+export default function useNotification() {
+  return React.useContext(NotificationContext);
+}
+
+declare type MessageType = 'success' | 'info' | 'error' | 'warning';
+const errorDuration = 5;
+const infoDuration = 3;
+const warningDuration = 3;
+const successDuration = 3;
+const distanceFromTopToDisplay = 110;
+
+const messageDuration = (type: MessageType) => {
+  switch (type) {
+    case 'error':
+      return errorDuration;
+    case 'info':
+      return infoDuration;
+    case 'warning':
+      return warningDuration;
+    case 'success':
+      return successDuration;
+  }
+};
+
+interface NotificationDict {
+  [key: string]: {
+    type: MessageType;
+    description?: string;
+    number: number;
+  };
+}
+
+export const getNotificationContextValue = () => {
+  const [notifications, setNotifications] = React.useState<NotificationDict>(
+    {}
+  );
+
+  React.useEffect(() => {
+    Object.keys(notifications).forEach(message => {
+      const notificationMessage = notifications[message];
+      if (notificationMessage.number > 0) {
+        /* Close any existing notifications. If already closed
+         it won't have any effect */
+        for (let i = 0; i < notificationMessage.number; i += 1) {
+          antdNotification.close(`${message}_${i}`);
+        }
+      }
+      /* Open new notifications. Will have no effect if already open */
+      antdNotification[notificationMessage.type]({
+        message,
+        key: `${message}_${notificationMessage.number}`,
+        description: notificationMessage.description,
+        duration: messageDuration(notificationMessage.type),
+        onClose: () => {
+          setNotifications(notification => {
+            const { [message]: _, ...withoutMessageState } = notifications;
+            return withoutMessageState;
+          });
+        },
+        top: distanceFromTopToDisplay,
+      });
+    });
+  }, [notifications]);
+
+  const notify = (type: MessageType, message: string, description?: string) => {
+    setNotifications(notifications => {
+      const { ...notificationsToUpdate } = notifications;
+      if (message in notifications) {
+        notificationsToUpdate[message].number += 1;
+      } else {
+        notificationsToUpdate[message] = {
+          type,
+          description,
+          number: 0,
+        };
+      }
+
+      return notificationsToUpdate;
+    });
+  };
+
+  const error = (args: { message: string; description?: string }) => {
+    notify('error', args.message, args.description);
+  };
+  const success = (args: { message: string; description?: string }) => {
+    notify('success', args.message, args.description);
+  };
+  const info = (args: { message: string; description?: string }) => {
+    notify('info', args.message, args.description);
+  };
+  const warning = (args: { message: string; description?: string }) => {
+    notify('warning', args.message, args.description);
+  };
+
+  return {
+    error,
+    success,
+    warning,
+    info,
+  };
+};

--- a/src/shared/hooks/useNotification.ts
+++ b/src/shared/hooks/useNotification.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { notification as antdNotification } from 'antd';
-import _ from 'lodash';
 
 export type NotificationContextType = {
   error: (args: { message: string; description?: string }) => void;

--- a/src/subapps/admin/views/ProjectView.tsx
+++ b/src/subapps/admin/views/ProjectView.tsx
@@ -5,15 +5,17 @@ import {
   DEFAULT_ELASTIC_SEARCH_VIEW_ID,
 } from '@bbp/nexus-sdk';
 import { useNexusContext } from '@bbp/react-nexus';
-import { notification, Popover, Button } from 'antd';
+import { Popover, Button } from 'antd';
 import { Link } from 'react-router-dom';
 
 import ViewStatisticsContainer from '../components/Views/ViewStatisticsProgress';
 import ResourceListBoardContainer from '../../../shared/containers/ResourceListBoardContainer';
 import ProjectTools from '../components/Projects/ProjectTools';
 import { useAdminSubappContext } from '..';
+import useNotification from '../../../shared/hooks/useNotification';
 
 const ProjectView: React.FunctionComponent = () => {
+  const notification = useNotification();
   const nexus = useNexusContext();
   const subapp = useAdminSubappContext();
   const match = useRouteMatch<{ orgLabel: string; projectLabel: string }>(

--- a/src/subapps/admin/views/ProjectsView.tsx
+++ b/src/subapps/admin/views/ProjectsView.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Drawer, notification, Modal, Button, Empty } from 'antd';
+import { Drawer, Modal, Button, Empty } from 'antd';
 import { PlusSquareOutlined } from '@ant-design/icons';
 import { useHistory, useRouteMatch } from 'react-router';
 import { AccessControl, useNexusContext } from '@bbp/react-nexus';
@@ -11,8 +11,10 @@ import ProjectForm from '../components/Projects/ProjectForm';
 import ListItem from '../../../shared/components/List/Item';
 import ProjectItem from '../components/Projects/ProjectItem';
 import { useAdminSubappContext } from '..';
+import useNotification from '../../../shared/hooks/useNotification';
 
 const ProjectsView: React.FunctionComponent = () => {
+  const notification = useNotification();
   const [formBusy, setFormBusy] = React.useState<boolean>(false);
   const [orgLoadingBusy, setOrgLoadingBusy] = React.useState<boolean>(false);
   const [modalVisible, setModalVisible] = React.useState<boolean>(false);
@@ -56,7 +58,6 @@ const ProjectsView: React.FunctionComponent = () => {
           notification.error({
             message: `An error occured whilst fetching Organization ${match.params.orgLabel}`,
             description: error.message,
-            duration: 0,
           });
         });
     }
@@ -76,7 +77,6 @@ const ProjectsView: React.FunctionComponent = () => {
       .then(() => {
         notification.success({
           message: 'Project created',
-          duration: 2,
         });
         setFormBusy(false);
         goTo(activeOrg._label, newProject._label);
@@ -86,7 +86,6 @@ const ProjectsView: React.FunctionComponent = () => {
         notification.error({
           message: 'An error occurred',
           description: error.message || error.reason,
-          duration: 0,
         });
       });
   };
@@ -113,7 +112,6 @@ const ProjectsView: React.FunctionComponent = () => {
       .then(() => {
         notification.success({
           message: 'Project saved',
-          duration: 2,
         });
         setFormBusy(false);
         setModalVisible(false);
@@ -125,7 +123,6 @@ const ProjectsView: React.FunctionComponent = () => {
         notification.error({
           message: 'An unknown error occurred',
           description: error.message,
-          duration: 0,
         });
       });
   };
@@ -141,7 +138,6 @@ const ProjectsView: React.FunctionComponent = () => {
         () => {
           notification.success({
             message: 'Project successfully deprecated',
-            duration: 2,
           });
           setFormBusy(false);
           setModalVisible(false);
@@ -151,7 +147,6 @@ const ProjectsView: React.FunctionComponent = () => {
           notification.warning({
             message: 'Project NOT deprecated',
             description: action?.error?.message,
-            duration: 2,
           });
           setFormBusy(false);
         }
@@ -160,7 +155,6 @@ const ProjectsView: React.FunctionComponent = () => {
         notification.error({
           message: 'An unknown error occurred',
           description: error.message,
-          duration: 0,
         });
       });
   };


### PR DESCRIPTION
Fixes BlueBrain/nexus#504

If the same notification (notification with same message) is triggered whilst the existing one is still being displayed, the new notification will replace the existing one. Client code should use this notification implementation rather than antd's notification.

PR includes the enhanced notification functionality and replaces calls to antd's notification api in a couple of places but needs to be replaced globally, have opened issue BlueBrain/nexus#2550 to do this once this is approved.

Demo of behaviour using some buttons to test functionality (buttons not in this PR): 
![EnhancedNotifications](https://user-images.githubusercontent.com/11296166/121906419-65321180-cd2b-11eb-8556-bc7579150478.gif)

