### PR TITLE
Include full step path on link activities to workflow step

### DIFF
--- a/src/subapps/projects/components/LinkActivityForm.tsx
+++ b/src/subapps/projects/components/LinkActivityForm.tsx
@@ -20,6 +20,7 @@ const LinkActivityForm: React.FC<{
   stepsList: {
     id: string;
     name: string;
+    parentSteps: { id: string; name: string }[];
   }[];
   onSubmit: (value: string) => void;
   onCancel: () => void;
@@ -30,6 +31,11 @@ const LinkActivityForm: React.FC<{
   const renderOptions = () => {
     return stepsList.map(step => (
       <Option key={step.id} value={step.id}>
+        {step.parentSteps
+          .reverse()
+          .map(parentStep => parentStep.name)
+          .join(' > ')}
+        {step.parentSteps.length > 0 ? ' > ' : ''}
         {step.name}
       </Option>
     ));

--- a/src/subapps/projects/containers/ActivitiesLinkingContainer.tsx
+++ b/src/subapps/projects/containers/ActivitiesLinkingContainer.tsx
@@ -177,10 +177,25 @@ const ActivitiesLinkingContainer: React.FC<{
       });
   };
 
-  const stepsList = steps.map(step => ({
-    id: step['@id'],
-    name: step.name,
-  }));
+  const stepsList = steps.map(step => {
+    const parentSteps: { id: string; name: string }[] = [];
+    let stepTraversal = step;
+    while (stepTraversal.hasParent) {
+      stepTraversal = steps.find(
+        step => step['@id'] === stepTraversal.hasParent['@id']
+      );
+      parentSteps.push({ id: stepTraversal['@id'], name: stepTraversal.name });
+    }
+    return {
+      parentSteps,
+      id: step['@id'],
+      name: step.name,
+    } as {
+      id: string;
+      name: string;
+      parentSteps: { id: string; name: string }[];
+    };
+  });
 
   const defaultActivityType = () => {
     if (selectedActivity) {


### PR DESCRIPTION
Fixes BlueBrain/nexus#2045

In Workflow where there are detached activities we are given the option to link them up to steps. There may be substeps belonging to different parent steps that have the same name. Introduced breadcrumbs to parent steps where they exist to disambiguate.

<img width="1242" alt="Link_Activity_to_Workflow_step" src="https://user-images.githubusercontent.com/11296166/122180612-de934680-ce88-11eb-9783-90ffd019ed00.png">
