### PR TITLE
Functionality to deprecate workflow step

### DIFF
--- a/src/subapps/projects/components/WorkflowSteps/WorkflowStepWithActivityForm.less
+++ b/src/subapps/projects/components/WorkflowSteps/WorkflowStepWithActivityForm.less
@@ -26,6 +26,5 @@
 
   &__buttons {
     width: 100%;
-    text-align: right;
   }
 }

--- a/src/subapps/projects/components/WorkflowSteps/WorkflowStepWithActivityForm.tsx
+++ b/src/subapps/projects/components/WorkflowSteps/WorkflowStepWithActivityForm.tsx
@@ -9,8 +9,9 @@ import {
   Button,
   Spin,
   Select,
+  Modal,
 } from 'antd';
-import { InfoCircleOutlined } from '@ant-design/icons';
+import { DeleteOutlined, InfoCircleOutlined } from '@ant-design/icons';
 import * as moment from 'moment';
 
 import { Status, StepResource, WorkflowStepMetadata } from '../../types';
@@ -21,6 +22,7 @@ import './WorkflowStepWithActivityForm.less';
 const WorkflowStepWithActivityForm: React.FC<{
   onClickCancel(): void;
   onSubmit(data: WorkflowStepMetadata): void;
+  onDeprecate?(): any;
   busy: boolean;
   parentLabel?: string | undefined;
   layout?: 'vertical' | 'horisontal';
@@ -42,6 +44,7 @@ const WorkflowStepWithActivityForm: React.FC<{
 }> = ({
   onClickCancel,
   onSubmit,
+  onDeprecate,
   busy,
   parentLabel,
   layout,
@@ -245,21 +248,58 @@ const WorkflowStepWithActivityForm: React.FC<{
           </Col>
         </Row>
         <Row>
-          <div className="workflow-step-form__buttons">
-            <Button
-              style={{ margin: '10px 10px 10px 0' }}
-              onClick={onClickCancel}
+          <Col span={4}>
+            {workflowStep ? (
+              <Button
+                style={{ margin: '10px 10px 10px 0' }}
+                onClick={() => {
+                  Modal.confirm({
+                    title: 'Deprecate Resource',
+                    content: (
+                      <>
+                        Are you sure you want to deprecate this step? <br />
+                        <br />
+                        <em>
+                          This will result in all substeps and associated tables
+                          also being deprecated.
+                        </em>
+                      </>
+                    ),
+                    onOk: () => {
+                      onDeprecate && onDeprecate();
+                    },
+                  });
+                }}
+                type="default"
+                icon={<DeleteOutlined />}
+                danger={true}
+              >
+                Deprecate
+              </Button>
+            ) : (
+              <></>
+            )}
+          </Col>
+          <Col span={10} offset={10}>
+            <div
+              style={{ textAlign: 'right', width: '100%' }}
+              className="workflow-step-form__buttons"
             >
-              Cancel
-            </Button>
-            <Button
-              style={{ margin: '10px 10px 10px 0' }}
-              onClick={onClickSubmit}
-              type="primary"
-            >
-              Save
-            </Button>
-          </div>
+              <Button
+                style={{ margin: '10px 10px 10px 0' }}
+                onClick={onClickCancel}
+              >
+                Cancel
+              </Button>
+              <Button
+                style={{ margin: '10px 10px 10px 0' }}
+                onClick={onClickSubmit}
+                type="primary"
+              >
+                Save
+              </Button>
+            </div>
+          </Col>
         </Row>
       </Spin>
     </Form>


### PR DESCRIPTION
Fixes BlueBrain/nexus#2426

Deprecating a workflow step can be triggered by the step info modal. Deprecating a workflow step will result in the step, all substeps, and any tables associated with those steps also being deprecated. If the workflow step is the previous step for any steps then it will update those steps to remove that association.

Note: requires a browser refresh currently to refresh workflow page to show updated results.

![workflow_delete_step](https://user-images.githubusercontent.com/11296166/122729357-5ee6ec80-d279-11eb-88e5-9dd53e396c56.gif)