### PR TITLE
Notification when editing JSON resource added

### DIFF
--- a/src/shared/containers/ResourceViewContainer.tsx
+++ b/src/shared/containers/ResourceViewContainer.tsx
@@ -249,6 +249,8 @@ const ResourceViewContainer: React.FunctionComponent<{
     }
   };
 
+  const nonEditableResourceTypes = ['File', 'View'];
+
   React.useEffect(() => {
     setResources();
   }, [orgLabel, projectLabel, resourceId, rev, tag]);
@@ -347,12 +349,17 @@ const ResourceViewContainer: React.FunctionComponent<{
                     />
                   </p>
                 )}
-                <p>
-                  <Alert
-                    message="Please not for the time being this resource is not editable. For further information please contact the BBP NISE team."
-                    type="info"
-                  />
-                </p>
+                {!!resource &&
+                  !!resource['@type'] &&
+                  typeof resource['@type'] == 'string' &&
+                  nonEditableResourceTypes.includes(resource['@type']) && (
+                    <p>
+                      <Alert
+                        message="Please not for the time being this resource is not editable. For further information please contact the BBP NISE team."
+                        type="info"
+                      />
+                    </p>
+                  )}
                 <AdminPlugin
                   editable={isLatest && !isDeprecated(resource)}
                   orgLabel={orgLabel}

--- a/src/shared/containers/ResourceViewContainer.tsx
+++ b/src/shared/containers/ResourceViewContainer.tsx
@@ -347,6 +347,12 @@ const ResourceViewContainer: React.FunctionComponent<{
                     />
                   </p>
                 )}
+                <p>
+                  <Alert
+                    message="Please not for the time being this resource is not editable. For further information please contact the BBP NISE team."
+                    type="info"
+                  />
+                </p>
                 <AdminPlugin
                   editable={isLatest && !isDeprecated(resource)}
                   orgLabel={orgLabel}

--- a/src/shared/containers/ResourceViewContainer.tsx
+++ b/src/shared/containers/ResourceViewContainer.tsx
@@ -349,8 +349,7 @@ const ResourceViewContainer: React.FunctionComponent<{
                     />
                   </p>
                 )}
-                {!!resource &&
-                  !!resource['@type'] &&
+                {!!resource['@type'] &&
                   typeof resource['@type'] === 'string' &&
                   nonEditableResourceTypes.includes(resource['@type']) && (
                     <p>

--- a/src/shared/containers/ResourceViewContainer.tsx
+++ b/src/shared/containers/ResourceViewContainer.tsx
@@ -351,7 +351,7 @@ const ResourceViewContainer: React.FunctionComponent<{
                 )}
                 {!!resource &&
                   !!resource['@type'] &&
-                  typeof resource['@type'] == 'string' &&
+                  typeof resource['@type'] === 'string' &&
                   nonEditableResourceTypes.includes(resource['@type']) && (
                     <p>
                       <Alert

--- a/src/shared/containers/ResourceViewContainer.tsx
+++ b/src/shared/containers/ResourceViewContainer.tsx
@@ -354,7 +354,7 @@ const ResourceViewContainer: React.FunctionComponent<{
                   nonEditableResourceTypes.includes(resource['@type']) && (
                     <p>
                       <Alert
-                        message="Please not for the time being this resource is not editable. For further information please contact the BBP NISE team."
+                        message="Please not for the time being this resource is not editable. For further information please contact the administrator."
                         type="info"
                       />
                     </p>


### PR DESCRIPTION
Added the notification so that users know the file can't be edited. I also added the option component for the actions button but the code was a duplicate of the workflow datatable so I spent a little time exporting it to another component.

However, I don't want to combine features because once exported to a new component the DataTableContainer file should be edited too. Might be worth splitting to a new ticket. 

The code I wanted to export to a new component can be found in DataTableContainer L:1175 - L:243. That way we can just add this option actions component. 

Anyway, though it's super small and the instructions for how test can be found on the issue:  
https://github.com/BlueBrain/nexus/issues/1407

<img width="1405" alt="CleanShot 2021-06-24 at 08 36 53@2x" src="https://user-images.githubusercontent.com/1838164/123215015-31dc4900-d4c8-11eb-9cd5-5184a7b26bfc.png">
