### PR TITLE
DataTable layout changes

### DIFF
--- a/src/shared/containers/DataTableContainer.tsx
+++ b/src/shared/containers/DataTableContainer.tsx
@@ -69,7 +69,10 @@ const DataTableContainer: React.FC<DataTableProps> = ({
   tableResourceId,
 }) => {
   const [showEditForm, setShowEditForm] = React.useState<boolean>(false);
-  const [showOptions, setShowOptions] = React.useState<boolean>(false);
+  const [searchboxValue, setSearchboxValue] = React.useState<string>('');
+  const [searchboxFocused, setSearchboxFocused] = React.useState<boolean>(
+    false
+  );
   const nexus = useNexusContext();
   const history = useHistory();
   const location = useLocation();
@@ -254,28 +257,41 @@ const DataTableContainer: React.FC<DataTableProps> = ({
     );
     const search = (
       <Input.Search
-        placeholder="input search text"
+        placeholder="Search"
         allowClear
+        value={searchboxValue}
+        onChange={e => setSearchboxValue(e.target.value)}
         onSearch={value => {
           tableData.setSearchValue(value);
         }}
-        style={{ width: '100%' }}
+        onFocus={() => setSearchboxFocused(true)}
+        onBlur={() => setSearchboxFocused(false)}
+        style={{
+          width: searchboxValue === '' && !searchboxFocused ? '50%' : '100%',
+          transition: 'width 0.5s',
+        }}
       ></Input.Search>
     );
     return (
       <div>
-        <Title level={4} className="tableTitle">
-          {tableResource && tableResource.name ? tableResource.name : null}
-        </Title>
-        <Row gutter={[16, 16]}>
-          <Col flex="none"></Col>
-          <Col flex="auto">
-            {tableResource && tableResource.enableSave
-              ? tableResource.enableSave
-              : null}
+        <Row gutter={[16, 16]} align="middle">
+          <Col span={12}>
+            <Title
+              className="table-title"
+              level={3}
+              title={
+                tableResource && tableResource.name
+                  ? tableResource.name
+                  : undefined
+              }
+            >
+              {tableResource && tableResource.name ? tableResource.name : null}
+            </Title>
+          </Col>
+          <Col span={10} className="table-search">
             {search}
           </Col>
-          <Col flex="none">{options}</Col>
+          <Col span={1}>{options}</Col>
         </Row>
       </div>
     );

--- a/src/shared/styles/data-table.less
+++ b/src/shared/styles/data-table.less
@@ -7,10 +7,14 @@
   max-height: 40px;
 }
 
-.ant-table-title h4.tableTitle {
-  position: absolute;
-  top: -30px;
-  text-transform: capitalize;
+h3.ant-typography.table-title {
+  margin-bottom: 0;
+  line-height: 1em;
+  font-size: 16px;
+}
+
+.ant-col.ant-col-10.table-search {
+  text-align: right;
 }
 
 .wrapper {


### PR DESCRIPTION
Implements BlueBrain/nexus#2556

UI changes to DataTable to improve UX.

* Moved the table title to be inline with the search box
* Reduced size of search box and aligned to the right
* Minimised the search box when not active. Expand (with short transition) the search box when focused or has a value
* Add ellipsis to table name if super long with full name shown on hover using title attribute

![2556-data-table-layout-change](https://user-images.githubusercontent.com/11296166/123132616-36185000-d44f-11eb-96e7-63f402e6fdb4.gif)

### Existing Data Table (for reference)
<img width="1043" alt="2556-data-table-original" src="https://user-images.githubusercontent.com/11296166/123133015-9dce9b00-d44f-11eb-8cb4-02c12f83f5a5.png">