### PR TITLE
2592 Fix orgs and projects duplication

### DIFF
--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -38,7 +38,6 @@ const history = createBrowserHistory({ basename: base });
 // OR
 // Keep the state, so we can have the same context loaded (will be slower performance)
 history.location.state = {};
-
 // Grab preloaded state (that comes from the server)
 const preloadedState: RootState = (window as any).__PRELOADED_STATE__;
 // let's report all the nasty errors id sentry dsn is present

--- a/src/shared/containers/SearchBarContainer.tsx
+++ b/src/shared/containers/SearchBarContainer.tsx
@@ -1,4 +1,4 @@
-import { useNexus, useNexusContext } from '@bbp/react-nexus';
+import { useNexusContext } from '@bbp/react-nexus';
 import { take } from 'lodash';
 import * as React from 'react';
 import { useHistory, useLocation } from 'react-router';
@@ -11,6 +11,7 @@ import { parseURL } from '../utils/nexusParse';
 
 const DEFAULT_SEARCH_BAR_RESULT_SIZE = 50;
 const PROJECT_RESULTS_DEFAULT_SIZE = 100;
+const SHOULD_INCLUDE_DEPRECATED = false;
 
 const SearchBarContainer: React.FC = () => {
   const { preferedSearchConfig, searchConfigs } = useSearchConfigs();
@@ -25,7 +26,7 @@ const SearchBarContainer: React.FC = () => {
   const projectData = useAsyncCall(
     nexus.Project.list(undefined, {
       size: 100,
-      deprecated: false,
+      deprecated: SHOULD_INCLUDE_DEPRECATED,
     }),
     []
   );

--- a/src/subapps/admin/containers/ProjectList.tsx
+++ b/src/subapps/admin/containers/ProjectList.tsx
@@ -4,6 +4,7 @@ import { useNexusContext } from '@bbp/react-nexus';
 import InfiniteSearch from '../../../shared/components/List/InfiniteSearch';
 
 const DEFAULT_PAGE_SIZE = 20;
+const SHOULD_INCLUDE_DEPRECATED = false;
 
 const ProjectListContainer: React.FunctionComponent<{
   orgLabel: string;
@@ -16,7 +17,6 @@ const ProjectListContainer: React.FunctionComponent<{
     total: 0,
     items: [],
     searchValue: props.defaultSearchValue,
-    includeDeprecated: false,
   });
 
   // initial load
@@ -24,7 +24,7 @@ const ProjectListContainer: React.FunctionComponent<{
     nexus.Project.list(props.orgLabel, {
       size: DEFAULT_PAGE_SIZE,
       label: projects.searchValue,
-      deprecated: projects.includeDeprecated,
+      deprecated: SHOULD_INCLUDE_DEPRECATED,
     }).then(res =>
       setProjects({ ...projects, total: res._total, items: res._results })
     );
@@ -35,11 +35,12 @@ const ProjectListContainer: React.FunctionComponent<{
     // - the entire list back to []
     // - the from index back to 0
     const newFilter: boolean = searchValue !== projects.searchValue;
+
     nexus.Project.list(props.orgLabel, {
       size: DEFAULT_PAGE_SIZE,
       from: newFilter ? 0 : projects.items.length,
       label: searchValue,
-      deprecated: projects.includeDeprecated,
+      deprecated: SHOULD_INCLUDE_DEPRECATED,
     }).then(res => {
       setProjects({
         searchValue,


### PR DESCRIPTION
Fixes BlueBrain/nexus#2592

The issue was happening, because the filter `deprecated=false` is lost when we `loadMore` orgs and projects, so it was messing up the lists of results we get.