### PR TITLE
1407 updating resources

### DIFF
--- a/src/shared/components/ResourceCard/index.tsx
+++ b/src/shared/components/ResourceCard/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as moment from 'moment';
 import { Card, Button, Tooltip, Divider, Descriptions } from 'antd';
-import { DownOutlined } from '@ant-design/icons';
+import { DownOutlined, CheckOutlined, CopyOutlined } from '@ant-design/icons';
 import { Resource } from '@bbp/nexus-sdk';
 
 import TypesIcon from '../Types/TypesIcon';
@@ -47,7 +47,7 @@ const ResourceCardComponent: React.FunctionComponent<{
               <Tooltip title={copySuccess ? 'Copied!' : `Copy ${id}`}>
                 <Button
                   size="small"
-                  icon={copySuccess ? 'check' : 'copy'}
+                  icon={copySuccess ? <CheckOutlined /> : <CopyOutlined />}
                   onClick={(e: React.MouseEvent) => {
                     e.preventDefault();
                     e.stopPropagation();
@@ -65,7 +65,7 @@ const ResourceCardComponent: React.FunctionComponent<{
               <Tooltip title={copySuccess ? 'Copied!' : `Copy ${self}`}>
                 <Button
                   size="small"
-                  icon={copySuccess ? 'check' : 'copy'}
+                  icon={copySuccess ? <CheckOutlined /> : <CopyOutlined />}
                   onClick={(e: React.MouseEvent) => {
                     e.preventDefault();
                     e.stopPropagation();

--- a/src/shared/components/ResourceEditor/index.tsx
+++ b/src/shared/components/ResourceEditor/index.tsx
@@ -87,9 +87,10 @@ const ResourceEditor: React.FunctionComponent<ResourceEditorProps> = props => {
   }, [rawData]); // only runs when Editor receives new resource to edit
 
   const handleChange = (editor: any, data: any, value: any) => {
-    if (!editable || value === JSON.stringify(rawData, null, 2)) {
+    if (!editable) {
       return;
     }
+
     try {
       const parsedVal = JSON.parse(value);
       setParsedValue(parsedVal);
@@ -97,8 +98,8 @@ const ResourceEditor: React.FunctionComponent<ResourceEditorProps> = props => {
     } catch (error) {
       setValid(false);
     }
-    setEditing(true);
     setStringValue(value);
+    setEditing(value !== JSON.stringify(rawData, null, 2));
   };
 
   const handleSubmit = () => {

--- a/src/shared/containers/ResourceViewContainer.tsx
+++ b/src/shared/containers/ResourceViewContainer.tsx
@@ -268,7 +268,6 @@ const ResourceViewContainer: React.FunctionComponent<{
         busy: false,
       });
     } catch (error) {
-      console.log({ error });
       let errorMessage;
 
       if (error['@type'] === 'AuthorizationFailed') {
@@ -295,7 +294,6 @@ const ResourceViewContainer: React.FunctionComponent<{
       } else {
         errorMessage = error.reason;
       }
-      console.log(errorMessage);
       const jsError = new Error(errorMessage);
 
       setResource({
@@ -315,36 +313,34 @@ const ResourceViewContainer: React.FunctionComponent<{
   return (
     <>
       <div className="resource-details">
-        {
-          <>
-            <Helmet
-              title={`${
-                resource ? getResourceLabel(resource) : resourceId
-              } | ${projectLabel} | ${orgLabel} | Nexus Web`}
-              meta={[
-                {
-                  name: 'description',
-                  content: resource
-                    ? getResourceLabel(resource)
-                    : labelOf(decodeURIComponent(resourceId)),
-                },
-              ]}
-            />
+        <>
+          <Helmet
+            title={`${
+              resource ? getResourceLabel(resource) : resourceId
+            } | ${projectLabel} | ${orgLabel} | Nexus Web`}
+            meta={[
+              {
+                name: 'description',
+                content: resource
+                  ? getResourceLabel(resource)
+                  : labelOf(decodeURIComponent(resourceId)),
+              },
+            ]}
+          />
 
-            <h1 className="name">
-              <span>
-                <a onClick={() => goToOrg(orgLabel)}>{orgLabel}</a> |{' '}
-                <a onClick={() => goToProject(orgLabel, projectLabel)}>
-                  {projectLabel}
-                </a>{' '}
-                |{' '}
-              </span>
-              {resource
-                ? getResourceLabel(resource)
-                : labelOf(decodeURIComponent(resourceId))}
-            </h1>
-          </>
-        }
+          <h1 className="name">
+            <span>
+              <a onClick={() => goToOrg(orgLabel)}>{orgLabel}</a> |{' '}
+              <a onClick={() => goToProject(orgLabel, projectLabel)}>
+                {projectLabel}
+              </a>{' '}
+              |{' '}
+            </span>
+            {resource
+              ? getResourceLabel(resource)
+              : labelOf(decodeURIComponent(resourceId))}
+          </h1>
+        </>
 
         <Spin spinning={busy}>
           {!!error && (
@@ -366,26 +362,24 @@ const ResourceViewContainer: React.FunctionComponent<{
                     {error.rejections && (
                       <Collapse bordered={false} ghost>
                         <Collapse.Panel key={1} header="More detail...">
-                          {
-                            <>
-                              <ul>
-                                {error.rejections.map((el, ix) => (
-                                  <li key={ix}>{el.reason}</li>
-                                ))}
-                              </ul>
+                          <>
+                            <ul>
+                              {error.rejections.map((el, ix) => (
+                                <li key={ix}>{el.reason}</li>
+                              ))}
+                            </ul>
 
-                              <p>
-                                For further information please refer to the API
-                                documentation,{' '}
-                                <a
-                                  target="_blank"
-                                  href="https://bluebrainnexus.io/docs/delta/api/"
-                                >
-                                  https://bluebrainnexus.io/docs/delta/api/
-                                </a>
-                              </p>
-                            </>
-                          }
+                            <p>
+                              For further information please refer to the API
+                              documentation,{' '}
+                              <a
+                                target="_blank"
+                                href="https://bluebrainnexus.io/docs/delta/api/"
+                              >
+                                https://bluebrainnexus.io/docs/delta/api/
+                              </a>
+                            </p>
+                          </>
                         </Collapse.Panel>
                       </Collapse>
                     )}

--- a/src/shared/containers/ResourceViewContainer.tsx
+++ b/src/shared/containers/ResourceViewContainer.tsx
@@ -184,21 +184,22 @@ const ResourceViewContainer: React.FunctionComponent<{
           const expandedResource = expandedResources[0];
 
           setResource({
+            error,
             resource: {
               ...potentiallyUpdatedResource,
               '@id': expandedResource['@id'],
             } as Resource,
-            error,
             busy: false,
           });
 
           setLatestResource(potentiallyUpdatedResource);
-        } else
+        } else {
           setResource({
             resource,
             error,
             busy: false,
           });
+        }
       }
     }
   };
@@ -368,8 +369,8 @@ const ResourceViewContainer: React.FunctionComponent<{
                           {
                             <>
                               <ul>
-                                {error.rejections.map(el => (
-                                  <li>{el.reason}</li>
+                                {error.rejections.map((el, ix) => (
+                                  <li key={ix}>{el.reason}</li>
                                 ))}
                               </ul>
 

--- a/src/shared/containers/ResourceViewContainer.tsx
+++ b/src/shared/containers/ResourceViewContainer.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Helmet from 'react-helmet';
 import { useLocation, useHistory, useParams } from 'react-router';
-import { Spin, Card, Empty, Alert } from 'antd';
+import { Spin, Alert, Collapse, Typography } from 'antd';
 import * as queryString from 'query-string';
 import { useNexusContext, AccessControl } from '@bbp/react-nexus';
 import {
@@ -21,10 +21,12 @@ import {
   matchPlugins,
   pluginsMap,
   getDestinationParam,
+  labelOf,
 } from '../utils';
 import { isDeprecated } from '../utils/nexusMaybe';
 import useNotification from '../hooks/useNotification';
 import Preview from '../components/Preview/Preview';
+import { getUpdateResourceFunction } from '../utils/updateResource';
 
 export type PluginMapping = {
   [pluginKey: string]: object;
@@ -86,7 +88,13 @@ const ResourceViewContainer: React.FunctionComponent<{
   const [{ busy, resource, error }, setResource] = React.useState<{
     busy: boolean;
     resource: Resource | null;
-    error: Error | null;
+    error:
+      | (Error & {
+          action?: 'update' | 'view';
+          rejections?: { reason: string }[];
+          wasUpdated?: boolean;
+        })
+      | null;
   }>({
     busy: false,
     resource: null,
@@ -127,28 +135,70 @@ const ResourceViewContainer: React.FunctionComponent<{
           error: null,
           busy: true,
         });
-        const { _rev } = await nexus.Resource.update(
+        const updateFn = getUpdateResourceFunction(
+          nexus,
+          resource._rev,
+          value,
+          resource,
           orgLabel,
           projectLabel,
-          resourceId,
-          resource._rev,
-          value
+          resourceId
         );
+
+        const { _rev } = await updateFn();
         goToResource(orgLabel, projectLabel, resourceId, { revision: _rev });
         notification.success({
           message: 'Resource saved',
           description: getResourceLabel(resource),
         });
       } catch (error) {
+        const potentiallyUpdatedResource = (await nexus.Resource.get(
+          orgLabel,
+          projectLabel,
+          resourceId
+        )) as Resource;
+        error.wasUpdated = potentiallyUpdatedResource._rev !== resource._rev;
+
+        error.action = 'update';
+        if ('@context' in error) {
+          if ('rejections' in error) {
+            error.message = 'An error occurred whilst updating the resource';
+          } else {
+            error.message = error.reason;
+          }
+        }
+
         notification.error({
-          message: 'An unknown error occurred',
-          description: error.message,
+          message: 'An error occurred whilst updating the resource',
         });
-        setResource({
-          error,
-          resource: null,
-          busy: false,
-        });
+        if (error.wasUpdated) {
+          const expandedResources = (await nexus.Resource.get(
+            orgLabel,
+            projectLabel,
+            resourceId,
+            {
+              format: 'expanded',
+            }
+          )) as ExpandedResource[];
+
+          const expandedResource = expandedResources[0];
+
+          setResource({
+            resource: {
+              ...potentiallyUpdatedResource,
+              '@id': expandedResource['@id'],
+            } as Resource,
+            error,
+            busy: false,
+          });
+
+          setLatestResource(potentiallyUpdatedResource);
+        } else
+          setResource({
+            resource,
+            error,
+            busy: false,
+          });
       }
     }
   };
@@ -217,6 +267,7 @@ const ResourceViewContainer: React.FunctionComponent<{
         busy: false,
       });
     } catch (error) {
+      console.log({ error });
       let errorMessage;
 
       if (error['@type'] === 'AuthorizationFailed') {
@@ -238,10 +289,12 @@ const ResourceViewContainer: React.FunctionComponent<{
         });
 
         errorMessage = `You don't have the access rights for this resource located in ${orgLabel} / ${projectLabel}.`;
+      } else if (error['@type'] === 'ResourceNotFound') {
+        errorMessage = `Resource '${resourceId}' not found`;
       } else {
         errorMessage = error.reason;
       }
-
+      console.log(errorMessage);
       const jsError = new Error(errorMessage);
 
       setResource({
@@ -252,7 +305,7 @@ const ResourceViewContainer: React.FunctionComponent<{
     }
   };
 
-  const nonEditableResourceTypes = ['File', 'View'];
+  const nonEditableResourceTypes = ['File'];
 
   React.useEffect(() => {
     setResources();
@@ -261,37 +314,88 @@ const ResourceViewContainer: React.FunctionComponent<{
   return (
     <>
       <div className="resource-details">
-        {!!resource && (
-          <Helmet
-            title={`${getResourceLabel(
-              resource
-            )} | ${projectLabel} | ${orgLabel} | Nexus Web`}
-            meta={[
-              {
-                name: 'description',
-                content: getResourceLabel(resource),
-              },
-            ]}
-          />
-        )}
+        {
+          <>
+            <Helmet
+              title={`${
+                resource ? getResourceLabel(resource) : resourceId
+              } | ${projectLabel} | ${orgLabel} | Nexus Web`}
+              meta={[
+                {
+                  name: 'description',
+                  content: resource
+                    ? getResourceLabel(resource)
+                    : labelOf(decodeURIComponent(resourceId)),
+                },
+              ]}
+            />
+
+            <h1 className="name">
+              <span>
+                <a onClick={() => goToOrg(orgLabel)}>{orgLabel}</a> |{' '}
+                <a onClick={() => goToProject(orgLabel, projectLabel)}>
+                  {projectLabel}
+                </a>{' '}
+                |{' '}
+              </span>
+              {resource
+                ? getResourceLabel(resource)
+                : labelOf(decodeURIComponent(resourceId))}
+            </h1>
+          </>
+        }
+
         <Spin spinning={busy}>
           {!!error && (
-            <Card>
-              <Empty description={error.message} />
-            </Card>
-          )}
-          {!!resource && !!latestResource && !error && (
             <>
-              <h1 className="name">
-                <span>
-                  <a onClick={() => goToOrg(orgLabel)}>{orgLabel}</a> |{' '}
-                  <a onClick={() => goToProject(orgLabel, projectLabel)}>
-                    {projectLabel}
-                  </a>{' '}
-                  |{' '}
-                </span>
-                {getResourceLabel(resource)}
-              </h1>
+              <Alert
+                message={
+                  error.wasUpdated ? 'Resource updated with errors' : 'Error'
+                }
+                showIcon
+                closable
+                type="error"
+                description={
+                  <>
+                    <Typography.Paragraph
+                      ellipsis={{ rows: 2, expandable: true }}
+                    >
+                      {error.message}
+                    </Typography.Paragraph>
+                    {error.rejections && (
+                      <Collapse bordered={false} ghost>
+                        <Collapse.Panel key={1} header="More detail...">
+                          {
+                            <>
+                              <ul>
+                                {error.rejections.map(el => (
+                                  <li>{el.reason}</li>
+                                ))}
+                              </ul>
+
+                              <p>
+                                For further information please refer to the API
+                                documentation,{' '}
+                                <a
+                                  target="_blank"
+                                  href="https://bluebrainnexus.io/docs/delta/api/"
+                                >
+                                  https://bluebrainnexus.io/docs/delta/api/
+                                </a>
+                              </p>
+                            </>
+                          }
+                        </Collapse.Panel>
+                      </Collapse>
+                    )}
+                  </>
+                }
+              />
+              <br />
+            </>
+          )}
+          {!!resource && !!latestResource && (
+            <>
               {!isLatest && (
                 <Alert
                   type="warning"
@@ -346,12 +450,6 @@ const ResourceViewContainer: React.FunctionComponent<{
                   </div>
                 )}
               >
-                {(!filteredPlugins || filteredPlugins.length === 0) && (
-                  <Alert
-                    message="This resource does not have plugins configured yet. You can nonetheless edit the resource metadata below."
-                    type="info"
-                  />
-                )}
                 {!!resource['@type'] &&
                   typeof resource['@type'] === 'string' &&
                   nonEditableResourceTypes.includes(resource['@type']) && (

--- a/src/shared/utils/__tests__/updateResource.spec.ts
+++ b/src/shared/utils/__tests__/updateResource.spec.ts
@@ -1,0 +1,285 @@
+import { getUpdateResourceFunction } from '../updateResource';
+import { createNexusClient } from '@bbp/nexus-sdk';
+
+const nexus = createNexusClient({
+  uri: 'https://localhost',
+  fetch: {},
+});
+
+const orgLabel = 'testOrg';
+const projectLabel = 'testProject';
+const resourceId = 'testResourceId';
+
+describe('getUpdateResourceFunction() with generic resource', () => {
+  const resourceNoType = {
+    '@id': 'test',
+  };
+  const fn = getUpdateResourceFunction(
+    nexus,
+    1,
+    resourceNoType,
+    resourceNoType,
+    orgLabel,
+    projectLabel,
+    resourceId
+  );
+  it('resource with no type should match to () => nexus.Resource.update(orgLabel, projectLabel, resourceId, revision, resource)', () => {
+    expect(fn.toString()).toEqual(
+      '() => nexus.Resource.update(orgLabel, projectLabel, resourceId, revision, resource)'
+    );
+  });
+});
+
+describe('getUpdateResourceFunction() with Organization type resource', () => {
+  const organizationTypeResource = {
+    '@id': 'test',
+    '@type': 'Organization',
+  };
+  const fn = getUpdateResourceFunction(
+    nexus,
+    1,
+    organizationTypeResource,
+    organizationTypeResource,
+    orgLabel,
+    projectLabel,
+    resourceId
+  );
+  it('resource with @type including Organization should target Organization endpoint', () => {
+    expect(fn.toString()).toEqual(
+      '() => nexus.Organization.update(orgLabel, revision, resource)'
+    );
+  });
+});
+
+describe('getUpdateResourceFunction() with Project type resource', () => {
+  const projectTypeResource = {
+    '@id': 'test',
+    '@type': 'Project',
+  };
+  const fn = getUpdateResourceFunction(
+    nexus,
+    1,
+    projectTypeResource,
+    projectTypeResource,
+    orgLabel,
+    projectLabel,
+    resourceId
+  );
+  it('resource with @type including Project should target Project endpoint', () => {
+    expect(fn.toString()).toEqual(
+      '() => nexus.Project.update(orgLabel, projectLabel, revision, resource)'
+    );
+  });
+});
+
+describe('getUpdateResourceFunction() with Realm type resource', () => {
+  const realmTypeResource = {
+    '@id': 'test',
+    '@type': 'Realm',
+  };
+  const fn = getUpdateResourceFunction(
+    nexus,
+    1,
+    realmTypeResource,
+    realmTypeResource,
+    orgLabel,
+    projectLabel,
+    resourceId
+  );
+  it('resource with @type including Realm should target Realm endpoint', () => {
+    expect(fn.toString()).toEqual(
+      "() => nexus.Realm.update(originalResource['_label'], revision, resource)"
+    );
+  });
+});
+
+describe('getUpdateResourceFunction() with Resolver type resource', () => {
+  const resolverTypeResource = {
+    '@id': 'test',
+    '@type': 'Resolver',
+  };
+  const fn = getUpdateResourceFunction(
+    nexus,
+    1,
+    resolverTypeResource,
+    resolverTypeResource,
+    orgLabel,
+    projectLabel,
+    resourceId
+  );
+  it('resource with @type including Resolver should target Resolver endpoint', () => {
+    expect(fn.toString()).toEqual(
+      '() => nexus.Resolver.update(orgLabel, projectLabel, resourceId, revision, resource)'
+    );
+  });
+});
+describe('getUpdateResourceFunction() with Schema type resource', () => {
+  const schemaTypeResource = {
+    '@id': 'test',
+    '@type': 'Schema',
+  };
+  const fn = getUpdateResourceFunction(
+    nexus,
+    1,
+    schemaTypeResource,
+    schemaTypeResource,
+    orgLabel,
+    projectLabel,
+    resourceId
+  );
+  it('resource with @type including Schema should target Schema endpoint', () => {
+    expect(fn.toString()).toEqual(
+      '() => nexus.Schema.update(orgLabel, projectLabel, resourceId, revision, resource)'
+    );
+  });
+});
+
+describe('getUpdateResourceFunction() with Storage type resource', () => {
+  const Storage = {
+    '@id': 'test',
+    '@type': 'Storage',
+  };
+  const fn = getUpdateResourceFunction(
+    nexus,
+    1,
+    Storage,
+    Storage,
+    orgLabel,
+    projectLabel,
+    resourceId
+  );
+  it('resource with @type including Storage should target Storage endpoint', () => {
+    expect(fn.toString()).toEqual(
+      '() => nexus.Storage.update(orgLabel, projectLabel, resourceId, revision, resource)'
+    );
+  });
+});
+
+describe('getUpdateResourceFunction() with unexpected types', () => {
+  const resourceWithMultipleTypes = {
+    '@id': 'test',
+    '@type': ['Storage', 'Schema'],
+  };
+
+  it('resource with multiple Nexus reserved types should error', () => {
+    expect(() =>
+      getUpdateResourceFunction(
+        nexus,
+        1,
+        resourceWithMultipleTypes,
+        resourceWithMultipleTypes,
+        orgLabel,
+        projectLabel,
+        resourceId
+      )
+    ).toThrow();
+  });
+
+  const resourceWithFileType = {
+    '@id': 'test',
+    '@type': ['File'],
+  };
+
+  it('resource with type File is not implemented and should error', () => {
+    expect(() =>
+      getUpdateResourceFunction(
+        nexus,
+        1,
+        resourceWithFileType,
+        resourceWithFileType,
+        orgLabel,
+        projectLabel,
+        resourceId
+      )
+    ).toThrow();
+  });
+
+  it('resource with type change should error', () => {
+    expect(() =>
+      getUpdateResourceFunction(
+        nexus,
+        1,
+        {
+          '@type': ['Schema'],
+        },
+        {
+          '@type': ['Storage'],
+        },
+        orgLabel,
+        projectLabel,
+        resourceId
+      )
+    ).toThrow();
+  });
+
+  it('resource with additional type added should error', () => {
+    expect(() =>
+      getUpdateResourceFunction(
+        nexus,
+        1,
+        {
+          '@type': ['Schema'],
+        },
+        {
+          '@type': ['Storage', 'Schema'],
+        },
+        orgLabel,
+        projectLabel,
+        resourceId
+      )
+    ).toThrow();
+  });
+
+  it('resource with addition of reserved type should error', () => {
+    expect(() =>
+      getUpdateResourceFunction(
+        nexus,
+        1,
+        {
+          '@type': ['Schema'],
+        },
+        {
+          '@type': [],
+        },
+        orgLabel,
+        projectLabel,
+        resourceId
+      )
+    ).toThrow();
+  });
+
+  it('resource with removal of reserved type should error', () => {
+    expect(() =>
+      getUpdateResourceFunction(
+        nexus,
+        1,
+        {
+          '@type': [],
+        },
+        {
+          '@type': ['Schema'],
+        },
+        orgLabel,
+        projectLabel,
+        resourceId
+      )
+    ).toThrow();
+  });
+
+  it('resource with removal of type property on a resource with a reserved type should use orginal resource type', () => {
+    const fn = getUpdateResourceFunction(
+      nexus,
+      1,
+      {},
+      {
+        '@type': ['Storage'],
+      },
+      orgLabel,
+      projectLabel,
+      resourceId
+    );
+    expect(fn.toString()).toEqual(
+      '() => nexus.Storage.update(orgLabel, projectLabel, resourceId, revision, resource)'
+    );
+  });
+});

--- a/src/shared/utils/__tests__/updateResource.spec.ts
+++ b/src/shared/utils/__tests__/updateResource.spec.ts
@@ -23,9 +23,9 @@ describe('getUpdateResourceFunction() with generic resource', () => {
     projectLabel,
     resourceId
   );
-  it('resource with no type should match to () => nexus.Resource.update(orgLabel, projectLabel, resourceId, revision, resource)', () => {
-    expect(fn.toString()).toEqual(
-      '() => nexus.Resource.update(orgLabel, projectLabel, resourceId, revision, resource)'
+  it('resource with no type should match to generic Resource endpoint', () => {
+    expect(fn.toString()).toMatch(
+      'nexus.Resource.update(orgLabel, projectLabel, resourceId, revision, resource)'
     );
   });
 });
@@ -45,8 +45,8 @@ describe('getUpdateResourceFunction() with Organization type resource', () => {
     resourceId
   );
   it('resource with @type including Organization should target Organization endpoint', () => {
-    expect(fn.toString()).toEqual(
-      '() => nexus.Organization.update(orgLabel, revision, resource)'
+    expect(fn.toString()).toMatch(
+      'nexus.Organization.update(orgLabel, revision, resource)'
     );
   });
 });
@@ -66,8 +66,8 @@ describe('getUpdateResourceFunction() with Project type resource', () => {
     resourceId
   );
   it('resource with @type including Project should target Project endpoint', () => {
-    expect(fn.toString()).toEqual(
-      '() => nexus.Project.update(orgLabel, projectLabel, revision, resource)'
+    expect(fn.toString()).toMatch(
+      'nexus.Project.update(orgLabel, projectLabel, revision, resource)'
     );
   });
 });
@@ -87,8 +87,8 @@ describe('getUpdateResourceFunction() with Realm type resource', () => {
     resourceId
   );
   it('resource with @type including Realm should target Realm endpoint', () => {
-    expect(fn.toString()).toEqual(
-      "() => nexus.Realm.update(originalResource['_label'], revision, resource)"
+    expect(fn.toString()).toMatch(
+      "nexus.Realm.update(originalResource['_label'], revision, resource)"
     );
   });
 });
@@ -108,8 +108,8 @@ describe('getUpdateResourceFunction() with Resolver type resource', () => {
     resourceId
   );
   it('resource with @type including Resolver should target Resolver endpoint', () => {
-    expect(fn.toString()).toEqual(
-      '() => nexus.Resolver.update(orgLabel, projectLabel, resourceId, revision, resource)'
+    expect(fn.toString()).toMatch(
+      'nexus.Resolver.update(orgLabel, projectLabel, resourceId, revision, resource)'
     );
   });
 });
@@ -128,8 +128,8 @@ describe('getUpdateResourceFunction() with Schema type resource', () => {
     resourceId
   );
   it('resource with @type including Schema should target Schema endpoint', () => {
-    expect(fn.toString()).toEqual(
-      '() => nexus.Schema.update(orgLabel, projectLabel, resourceId, revision, resource)'
+    expect(fn.toString()).toMatch(
+      'nexus.Schema.update(orgLabel, projectLabel, resourceId, revision, resource)'
     );
   });
 });
@@ -149,8 +149,8 @@ describe('getUpdateResourceFunction() with Storage type resource', () => {
     resourceId
   );
   it('resource with @type including Storage should target Storage endpoint', () => {
-    expect(fn.toString()).toEqual(
-      '() => nexus.Storage.update(orgLabel, projectLabel, resourceId, revision, resource)'
+    expect(fn.toString()).toMatch(
+      'nexus.Storage.update(orgLabel, projectLabel, resourceId, revision, resource)'
     );
   });
 });
@@ -278,8 +278,8 @@ describe('getUpdateResourceFunction() with unexpected types', () => {
       projectLabel,
       resourceId
     );
-    expect(fn.toString()).toEqual(
-      '() => nexus.Storage.update(orgLabel, projectLabel, resourceId, revision, resource)'
+    expect(fn.toString()).toMatch(
+      'nexus.Storage.update(orgLabel, projectLabel, resourceId, revision, resource)'
     );
   });
 });

--- a/src/shared/utils/updateResource.ts
+++ b/src/shared/utils/updateResource.ts
@@ -1,0 +1,158 @@
+import { NexusClient } from '@bbp/nexus-sdk/lib/types';
+
+/*
+
+Update a resource using the specific endpoint for that resource.
+
+Organization
+Project
+Realm
+Resolver
+Schema
+Storage
+View
+File - not implemented
+* Resource (default to this if no other type matches)
+
+*/
+export const getUpdateResourceFunction = (
+  nexus: NexusClient,
+  revision: number,
+  resource: any,
+  originalResource: any,
+  orgLabel: string,
+  projectLabel: string,
+  resourceId: string
+) => {
+  const nexusReservedTypes = [
+    'Organization',
+    'Project',
+    'Realm',
+    'Resolver',
+    'Schema',
+    'Storage',
+    'ElasticSearchView',
+    'AggregateElasticSearchView',
+    'SparqlView',
+    'AggregateSparqlView',
+    'CompositeView',
+    'File',
+  ];
+
+  let matchedUpdateFunction;
+
+  let resourceMatchedNexusTypes = [resource['@type']]
+    .flat()
+    .filter(value => nexusReservedTypes.includes(value));
+
+  if (resourceMatchedNexusTypes.length > 1) {
+    throw new Error(
+      'Resource cannot be specified as having multiple Nexus reserved resource types in the @type property.'
+    );
+  }
+
+  const originalResourceMatchedNexusTypes = [originalResource['@type']]
+    .flat()
+    .filter(value => nexusReservedTypes.includes(value));
+
+  if (
+    '@type' in resource &&
+    originalResourceMatchedNexusTypes.length !==
+      resourceMatchedNexusTypes.length
+  ) {
+    throw new Error(
+      'Cannot add/remove a Nexus reserved type from @type on an existing resource'
+    );
+  }
+
+  if (
+    originalResourceMatchedNexusTypes.length === 1 &&
+    resourceMatchedNexusTypes.length === 1 &&
+    originalResourceMatchedNexusTypes[0] !== resourceMatchedNexusTypes[0]
+  ) {
+    throw new Error(
+      'Cannot change a Nexus reserved type from @type on an existing resource'
+    );
+  }
+
+  if ('@type' in originalResource && !('@type' in resource)) {
+    resourceMatchedNexusTypes = originalResourceMatchedNexusTypes;
+  }
+
+  if (resourceMatchedNexusTypes.length === 1) {
+    // Matches one of our resource types - lets use the specific endpoint
+    if (resourceMatchedNexusTypes.includes('Organization')) {
+      matchedUpdateFunction = () =>
+        nexus.Organization.update(orgLabel, revision, resource);
+    } else if (resourceMatchedNexusTypes.includes('Project')) {
+      matchedUpdateFunction = () =>
+        nexus.Project.update(orgLabel, projectLabel, revision, resource);
+    } else if (resourceMatchedNexusTypes.includes('Realm')) {
+      matchedUpdateFunction = () =>
+        nexus.Realm.update(originalResource['_label'], revision, resource);
+    } else if (resourceMatchedNexusTypes.includes('Resolver')) {
+      matchedUpdateFunction = () =>
+        nexus.Resolver.update(
+          orgLabel,
+          projectLabel,
+          resourceId,
+          revision,
+          resource
+        );
+    } else if (resourceMatchedNexusTypes.includes('Schema')) {
+      matchedUpdateFunction = () =>
+        nexus.Schema.update(
+          orgLabel,
+          projectLabel,
+          resourceId,
+          revision,
+          resource
+        );
+    } else if (resourceMatchedNexusTypes.includes('Storage')) {
+      matchedUpdateFunction = () =>
+        nexus.Storage.update(
+          orgLabel,
+          projectLabel,
+          resourceId,
+          revision,
+          resource
+        );
+    } else if (
+      resourceMatchedNexusTypes.some(el =>
+        [
+          'ElasticSearchView',
+          'AggregateElasticSearchView',
+          'SparqlView',
+          'AggregateSparqlView',
+          'CompositeView',
+        ].includes(el)
+      )
+    ) {
+      matchedUpdateFunction = () =>
+        nexus.View.update(
+          orgLabel,
+          projectLabel,
+          resourceId,
+          revision,
+          resource
+        );
+    } else if (resourceMatchedNexusTypes.includes('File')) {
+      throw new Error('Updates to File are not supported via this method.');
+    } else {
+      throw new Error(
+        'Changing the @type of a resource with a reserved Nexus type is not supported.'
+      );
+    }
+  } else {
+    // did not match one of our Nexus specific types - use generic resource endpoint
+    matchedUpdateFunction = () =>
+      nexus.Resource.update(
+        orgLabel,
+        projectLabel,
+        resourceId,
+        revision,
+        resource
+      );
+  }
+  return matchedUpdateFunction;
+};

--- a/src/shared/utils/updateResource.ts
+++ b/src/shared/utils/updateResource.ts
@@ -1,20 +1,19 @@
 import { NexusClient } from '@bbp/nexus-sdk/lib/types';
 
-/*
-
-Update a resource using the specific endpoint for that resource.
-
-Organization
-Project
-Realm
-Resolver
-Schema
-Storage
-View
-File - not implemented
-* Resource (default to this if no other type matches)
-
-*/
+/**
+ * Use specific resource endpoints when we have a "@type"
+ * with a specific Nexus resource type. If no specific
+ * Nexus resource then will default to the resource
+ * endpoint.
+ * @param nexus
+ * @param revision
+ * @param resource
+ * @param originalResource
+ * @param orgLabel
+ * @param projectLabel
+ * @param resourceId
+ * @returns Nexus SDK function to call to perform update to resource
+ */
 export const getUpdateResourceFunction = (
   nexus: NexusClient,
   revision: number,


### PR DESCRIPTION
Fixes https://github.com/BlueBrain/nexus/issues/1407

In Admin, instead of using nexus.Resource.update for everything use the specific endpoint for the resource type when we have a Nexus resource type. This will give us better error messages when there is an error updating a resource which is a Nexus type. Also, some other changes too mainly to improve UX when updating a resource and an error occurs:

* Display error above resource instead of on its own
* Bug fix to editor where parsedValue wasnt always updated if we made a change in the editor and then undid it
* If navigate to resource where doesn't exist, will display the title still and an error message
* Provide link to API documentation when a Nexus error occurs whilst updating resource
* If resource gets updated but there is an error it will reload the resource and display error
* Fix antd warning about using string to specify icon on Resource card

# Example Error
![image](https://user-images.githubusercontent.com/11296166/128391586-8f5d5158-6fb6-4204-93cd-6b731e080359.png)
