### PR TITLE
Use all vertical space for resource list

### DIFF
--- a/src/shared/components/ResourceList/ResourceList.less
+++ b/src/shared/components/ResourceList/ResourceList.less
@@ -12,6 +12,7 @@
 
 .resource-list {
   .cardlike();
+  height: 100%;
   background-color: @primary-card;
   width: @default-card-width;
   min-width: @default-card-width;
@@ -101,19 +102,23 @@
       background-color: fade(black, 50%);
     }
   }
-}
+  /* keep paginator at bottom */
+  & .ant-list-pagination {
+    bottom: 0;
+    position: absolute;
+    left: 0;
+    right: 0;
+    background-color: #f5f6f7;
+    padding: 10px;
+  }
 
-/* keep paginator at bottom */
-.ant-list-pagination {
-  bottom: 0;
-  position: absolute;
-  left: 0;
-  right: 0;
-  background-color: #f5f6f7;
-  padding: 10px;
-}
+  /* ensure consistent height of resource items */
+  & .resource-type-list {
+    height: 18px;
+  }
 
-/* ensure consistent height of resource items */
-.resource-type-list {
-  height: 18px;
+  & .dummy-height-test-list-item,
+  .list-item {
+    height: 100%;
+  }
 }

--- a/src/shared/components/ResourceList/ResourceList.less
+++ b/src/shared/components/ResourceList/ResourceList.less
@@ -109,5 +109,11 @@
   position: absolute;
   left: 0;
   right: 0;
-  margin: auto;
+  background-color: #f5f6f7;
+  padding: 10px;
+}
+
+/* ensure consistent height of resource items */
+.resource-type-list {
+  height: 18px;
 }

--- a/src/shared/components/ResourceList/index.tsx
+++ b/src/shared/components/ResourceList/index.tsx
@@ -172,18 +172,19 @@ const ResourceListComponent: React.FunctionComponent<{
     // use to calculate dimensions of list item
     <div
       ref={hiddenHeightTestListItemRef}
-      style={{ display: 'none', height: '100%' }}
+      className="dummy-height-test-list-item"
+      style={{ display: 'none' }}
     >
       <List
         pagination={{ position: 'bottom', showSizeChanger: false }}
-        style={{ height: '100%' }}
+        className="list-item"
       >
         <a
           id="testListItem"
-          key={'testListItemLink'}
-          className="testListItemLink"
+          key="testListItemLink"
+          className="test-list-item-link"
         >
-          <ListItem key={'testListItem'}>
+          <ListItem key="testListItem">
             Test Dimension
             <div className="resource-type-list">
               <TypesIconList type={['Testing']} />
@@ -208,12 +209,12 @@ const ResourceListComponent: React.FunctionComponent<{
       paginationTopPosition - listItemTopPosition;
 
     const listItemHeight = listItemDiv
-      .getElementsByClassName('testListItemLink')[0]
+      .getElementsByClassName('test-list-item-link')[0]
       .getBoundingClientRect().height;
     const listItemMarginTop = parseInt(
       window.getComputedStyle(
         listItemDiv
-          .getElementsByClassName('testListItemLink')[0]
+          .getElementsByClassName('test-list-item-link')[0]
           .getElementsByClassName('ListItem')[0] as HTMLElement
       ).marginTop,
       10
@@ -247,7 +248,7 @@ const ResourceListComponent: React.FunctionComponent<{
 
   return (
     <div className="resource-list-height-tester" ref={wrapperHeightRef}>
-      <div className="resource-list" style={{ height: '100%' }}>
+      <div className="resource-list">
         <h3 className={`header ${busy ? '-fetching' : ''}`}>
           <RenameableItem
             defaultValue={name || 'Unnamed List'}

--- a/src/shared/containers/ResourceListContainer.tsx
+++ b/src/shared/containers/ResourceListContainer.tsx
@@ -56,23 +56,28 @@ const ResourceListContainer: React.FunctionComponent<{
     total: 0,
   });
 
-  const DEFAULT_PAGE_SIZE = 6;
   const [paginationState, setPaginationState] = React.useState<{
     currentPage: number;
-    pageSize: number;
+    pageSize?: number;
   }>({
     currentPage: 1,
-    pageSize: DEFAULT_PAGE_SIZE,
   });
 
   const handlePaginationChange = (
     searchValue: string,
     page: number,
-    pageSize?: number
+    pageSize: number
   ) => {
+    setPaginationState({
+      pageSize,
+      currentPage: page,
+    });
+
     const query = {
       ...list.query,
       q: searchValue,
+      from: (page - 1) * pageSize,
+      size: pageSize,
     };
 
     if (searchValue) {
@@ -90,16 +95,9 @@ const ResourceListContainer: React.FunctionComponent<{
       return;
     }
 
-    query.from = (page - 1) * paginationState.pageSize;
-    query.size = pageSize;
     setList({
       ...list,
       query,
-    });
-
-    setPaginationState({
-      currentPage: page,
-      pageSize: pageSize || DEFAULT_PAGE_SIZE,
     });
   };
 
@@ -150,13 +148,11 @@ const ResourceListContainer: React.FunctionComponent<{
         });
       });
   }, [
-    // Reset pagination and reload based on these props
     orgLabel,
     projectLabel,
     JSON.stringify(list.query),
     toggleForceReload,
     refreshList,
-    paginationState,
   ]);
 
   const handleDelete = () => {
@@ -164,6 +160,7 @@ const ResourceListContainer: React.FunctionComponent<{
   };
 
   const handleUpdate = (list: ResourceBoardList) => {
+    setPaginationState({ ...paginationState, currentPage: 1 });
     setList(list);
   };
 
@@ -181,7 +178,12 @@ const ResourceListContainer: React.FunctionComponent<{
       query: {
         ...list.query,
         type: !!value ? value : undefined,
+        from: 0,
       },
+    });
+    setPaginationState({
+      ...paginationState,
+      currentPage: 1,
     });
   };
 
@@ -191,7 +193,12 @@ const ResourceListContainer: React.FunctionComponent<{
       query: {
         ...list.query,
         schema: !!value ? value : undefined,
+        from: 0,
       },
+    });
+    setPaginationState({
+      ...paginationState,
+      currentPage: 1,
     });
   };
 
@@ -210,6 +217,18 @@ const ResourceListContainer: React.FunctionComponent<{
     window.location.href
   }?shareList=${encodeShareableList(list)}`;
 
+  const handlePageSizeChange = (pageSize: number) => {
+    const query = {
+      ...list.query,
+    };
+    query.size = pageSize;
+    setList({
+      ...list,
+      query,
+    });
+    setPaginationState({ ...paginationState, pageSize });
+  };
+
   return (
     <ResourceListComponent
       busy={busy}
@@ -219,6 +238,7 @@ const ResourceListContainer: React.FunctionComponent<{
       pageSize={paginationState.pageSize}
       currentPage={paginationState.currentPage}
       onPaginationChange={handlePaginationChange}
+      onPageSizeChange={handlePageSizeChange}
       hasSearch={true}
       error={error}
       onUpdate={handleUpdate}


### PR DESCRIPTION
Fixes https://github.com/BlueBrain/nexus/issues/2594

Calculate available vertical space for list items and set page size accordingly.

![ResourceListUseVerticalSpace](https://user-images.githubusercontent.com/11296166/129693327-b40990c0-06ed-4eb9-83e7-963f88f33a99.gif)
