### PR TITLE
2731 search bar improvements

### DIFF
--- a/src/shared/components/SearchBar/Hit.less
+++ b/src/shared/components/SearchBar/Hit.less
@@ -23,4 +23,8 @@
   &__body {
     flex-grow: 1;
   }
+
+  &__arrow {
+    transform: scaleX(-1);
+  }
 }

--- a/src/shared/components/SearchBar/Hit.tsx
+++ b/src/shared/components/SearchBar/Hit.tsx
@@ -40,7 +40,7 @@ const Hit: React.FC<{
       <div className="hit__body">{children}</div>
       <div className="hit__action">
         <span>
-          <EnterOutlined style={{ transform: 'scaleX(-1)' }} /> jump to project{' '}
+          <EnterOutlined style={{ transform: 'scaleX(-1)' }} /> Jump to Project{' '}
           {orgLabel && projectLabel && (
             <AccessControl
               permissions={['resources/read']}

--- a/src/shared/components/SearchBar/Hit.tsx
+++ b/src/shared/components/SearchBar/Hit.tsx
@@ -20,8 +20,8 @@ export const globalSearchOption = (value: string | undefined) => {
         <span>{value}</span>
       </div>
       <div className="hit__action">
-        <span className="enter">
-          <EnterOutlined style={{ transform: 'scaleX(-1)' }} /> Search Nexus{' '}
+        <span>
+          <EnterOutlined className="hit__arrow" /> Search Nexus{' '}
         </span>
       </div>
     </div>
@@ -40,7 +40,7 @@ const Hit: React.FC<{
       <div className="hit__body">{children}</div>
       <div className="hit__action">
         <span>
-          <EnterOutlined style={{ transform: 'scaleX(-1)' }} /> Jump to Project{' '}
+          <EnterOutlined className="hit__arrow" /> Jump to Project{' '}
           {orgLabel && projectLabel && (
             <AccessControl
               permissions={['resources/read']}

--- a/src/shared/components/SearchBar/index.tsx
+++ b/src/shared/components/SearchBar/index.tsx
@@ -112,7 +112,7 @@ const SearchBar: React.FC<{
   return (
     <AutoComplete
       defaultActiveFirstOption
-      className={`search-bar ${!!focused && 'search-bar__focused'}`}
+      className="search-bar"
       onFocus={handleSetFocused(true)}
       onBlur={handleSetFocused(false)}
       options={generateOptions()}

--- a/src/shared/components/SearchBar/index.tsx
+++ b/src/shared/components/SearchBar/index.tsx
@@ -99,12 +99,13 @@ const SearchBar: React.FC<{
     }
     options = [
       {
-        value,
         key: 'global-search',
         label: globalSearchOption(value),
+        value,
       },
       ...options,
     ];
+
     return options;
   };
 
@@ -121,6 +122,7 @@ const SearchBar: React.FC<{
       dropdownClassName="search-bar__drop"
       value={value}
       dropdownMatchSelectWidth={false}
+      defaultActiveFirstOption
     >
       <Input
         allowClear

--- a/src/shared/components/SearchBar/index.tsx
+++ b/src/shared/components/SearchBar/index.tsx
@@ -127,7 +127,7 @@ const SearchBar: React.FC<{
         onPressEnter={inputOnPressEnter}
         ref={inputRef}
         className="search-bar__input"
-        placeholder="Visit Project"
+        placeholder="Search or jump to..."
         suffix={<div className="search-bar__icon">/</div>}
       />
     </AutoComplete>

--- a/src/shared/components/SearchBar/index.tsx
+++ b/src/shared/components/SearchBar/index.tsx
@@ -99,9 +99,9 @@ const SearchBar: React.FC<{
     }
     options = [
       {
+        value,
         key: 'global-search',
         label: globalSearchOption(value),
-        value,
       },
       ...options,
     ];

--- a/src/shared/components/SearchBar/index.tsx
+++ b/src/shared/components/SearchBar/index.tsx
@@ -111,6 +111,7 @@ const SearchBar: React.FC<{
 
   return (
     <AutoComplete
+      defaultActiveFirstOption
       className={`search-bar ${!!focused && 'search-bar__focused'}`}
       onFocus={handleSetFocused(true)}
       onBlur={handleSetFocused(false)}
@@ -122,7 +123,6 @@ const SearchBar: React.FC<{
       dropdownClassName="search-bar__drop"
       value={value}
       dropdownMatchSelectWidth={false}
-      defaultActiveFirstOption
     >
       <Input
         allowClear

--- a/src/shared/containers/SearchBarContainer.tsx
+++ b/src/shared/containers/SearchBarContainer.tsx
@@ -9,7 +9,7 @@ import { sortStringsBySimilarity } from '../utils/stringSimilarity';
 
 const PROJECT_RESULTS_DEFAULT_SIZE = 300;
 const SHOULD_INCLUDE_DEPRECATED = false;
-const STORAGE_ITEM = 'last_seacrh';
+const STORAGE_ITEM = 'last_search';
 const SHOW_PROJECTS_NUMBER = 5;
 
 const SearchBarContainer: React.FC = () => {

--- a/src/shared/containers/SearchBarContainer.tsx
+++ b/src/shared/containers/SearchBarContainer.tsx
@@ -9,7 +9,7 @@ import { sortStringsBySimilarity } from '../utils/stringSimilarity';
 
 const PROJECT_RESULTS_DEFAULT_SIZE = 300;
 const SHOULD_INCLUDE_DEPRECATED = false;
-const STORAGE_ITEM = 'last_visited_project';
+const STORAGE_ITEM = 'last_seacrh';
 const SHOW_PROJECTS_NUMBER = 5;
 
 const SearchBarContainer: React.FC = () => {
@@ -46,12 +46,12 @@ const SearchBarContainer: React.FC = () => {
   };
 
   const handleSubmit = (value: string, option: any) => {
+    localStorage.setItem(STORAGE_ITEM, value);
+
     if (option && option.key === 'global-search') {
       history.push(`/search/?query=${value}`);
     } else {
       const orgAndProject = value;
-
-      localStorage.setItem(STORAGE_ITEM, value);
       const [orgLabel, projectLabel] = orgAndProject.split('/');
 
       return goToProject(orgLabel, projectLabel);

--- a/src/shared/utils/keyboardShortcuts.ts
+++ b/src/shared/utils/keyboardShortcuts.ts
@@ -12,7 +12,13 @@ export const focusOnSlash = (focused: boolean, inputRef: any) => {
     }
 
     if (e.key === '/' && !focused) {
-      inputRef.current && inputRef.current.focus();
+      // https://github.com/BlueBrain/nexus/issues/2609#issuecomment-906995492
+      // the content of the Search bar is not selected properly, bacause <Input /> is wrapped in <Autocmplete />
+      // and doesn't have its own value or defaultValue to select
+      inputRef.current &&
+        inputRef.current.focus({
+          cursor: 'all',
+        });
       inputRef.current && inputRef.current.input.select();
       e.preventDefault();
     }


### PR DESCRIPTION
Part of BlueBrain/nexus#2731

 - The search bar displays the following text: "Search or jump to..."
 - The search bar content should match the query from Search (if any)
 - The dropdown items to jump to project should be labeled "Jump to Project", i.e. capitalize Jump and Project to match the style of "Search Nexus"
- After typing a query in the search bar, if you hit enter, it should search immediately (it should pick the first option in the dropdown).