### PR TITLE
Visual indicator that can drag columns

### DIFF
--- a/src/subapps/search/components/ColumnsVisibilityConfig/ColumnsVisibility.less
+++ b/src/subapps/search/components/ColumnsVisibilityConfig/ColumnsVisibility.less
@@ -10,3 +10,7 @@
     overflow: auto;
   }
 }
+
+.drag-icon-spacer {
+  opacity: 0;
+}

--- a/src/subapps/search/components/ColumnsVisibilityConfig/index.tsx
+++ b/src/subapps/search/components/ColumnsVisibilityConfig/index.tsx
@@ -1,4 +1,4 @@
-import { EyeInvisibleOutlined } from '@ant-design/icons';
+import { EyeInvisibleOutlined, MoreOutlined } from '@ant-design/icons';
 import { Button, Form, Modal, Switch } from 'antd';
 import * as React from 'react';
 import { DragDropContext, Draggable, Droppable } from 'react-beautiful-dnd';
@@ -87,6 +87,7 @@ const ColumnsVisibilityConfig: React.FunctionComponent<{
                 >
                   <Form>
                     <Form.Item style={{ marginBottom: 0 }}>
+                      <MoreOutlined className="drag-icon-spacer" />
                       <label>
                         <Switch
                           size="small"
@@ -110,6 +111,7 @@ const ColumnsVisibilityConfig: React.FunctionComponent<{
                             {...provided.dragHandleProps}
                           >
                             <Form.Item key={el.key} style={{ marginBottom: 0 }}>
+                              <MoreOutlined />
                               <label>
                                 <Switch
                                   size="small"


### PR DESCRIPTION
Fixes https://github.com/BlueBrain/nexus/issues/2790

## Description

Within the hidden columns modal display an icon next to each column to indicate that it can be dragged. The mouse cursor changes to a hand on hover of the icon. No drag option or icon on the first "(Show all Columns)" but spaced to align with the other options.

![Screen Shot 2021-10-04 at 10 54 24](https://user-images.githubusercontent.com/11296166/135823562-d4a784ec-41f8-48a0-a696-f819d00c89ef.png)

## How has this been tested?

Tested in Firefox. Tested that style is as expected and that drag behaviour unchanged.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [x] I have added screenshots (if applicable), in the comment section.
