### PR TITLE
Fix row hight when hovered over:

### DIFF
--- a/src/shared/styles/search-tables.less
+++ b/src/shared/styles/search-tables.less
@@ -115,19 +115,27 @@ html {
 
           .row-index {
             display: block;
+            padding-top: 2px;
           }
 
           &:hover {
             background: @thead-bg !important;
             .row-select {
               display: block;
+              padding-left: 2px;
             }
             .row-index {
               display: none;
             }
           }
+
+          .row-selection-checkbox {
+            height: 20px;
+          }
+
           padding: 7px 15px;
           width: 200px;
+
           pre {
             margin: unset;
           }

--- a/src/subapps/search/containers/SearchContainer.tsx
+++ b/src/subapps/search/containers/SearchContainer.tsx
@@ -193,6 +193,7 @@ const SearchContainer: React.FC = () => {
     renderCell: (checked: any, record: any, index: number, originNode: any) => {
       return (
         <div
+          className="row-selection-checkbox"
           onClick={e => {
             e.preventDefault();
             e.stopPropagation();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes BlueBrain/nexus#2823

## Description

- Fixes on-hover row height

<img width="1304" alt="Screenshot 2021-10-05 at 14 15 41" src="https://user-images.githubusercontent.com/23080476/136022698-d178ee5f-bf3a-46b8-8aa3-b30a4b2e3e80.png">

## How has this been tested?

Tested in Firefox 92.0.1, MacOS BigSur

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change doesn't require a change to the documentation.
- [x] I have added screenshots (if applicable), in the comment section.
