### PR TITLE
Search fixed header row

### DIFF
--- a/src/subapps/search/containers/SearchContainer.less
+++ b/src/subapps/search/containers/SearchContainer.less
@@ -18,7 +18,13 @@
 }
 
 .search-table {
-  margin-top: 43px;
+  padding-top: 32px;
+
+  thead {
+    position: sticky;
+    top: 32px;
+    z-index: 20;
+  }
 }
 
 .column-header {


### PR DESCRIPTION
Fixes https://github.com/BlueBrain/nexus/issues/2822

## Description

When the user scrolls to view rows beyond the bottom of the page the header row will remain visible and not scroll off the top of the page.

![FixedHeaderRowSearch](https://user-images.githubusercontent.com/11296166/136060581-9b186e60-61c8-468e-b417-85914845a8bf.gif)

## How has this been tested?

Tested in Firefox 91.0 (64-bit) and Chrome Version 91.0.4472.77 (Official Build) (x86_64) on MacOS 11.6.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [x] I have added screenshots (if applicable), in the comment section.
