### PR TITLE
Set border width of first column in Search results table to be same as rest

### DIFF
--- a/src/shared/styles/search-tables.less
+++ b/src/shared/styles/search-tables.less
@@ -19,9 +19,6 @@
   &:nth-child(1) {
     border-left: 1px @border-color outset;
   }
-  &:nth-child(2) {
-    border-left: 1px @border-color inset;
-  }
 }
 
 .td-borders() {
@@ -29,9 +26,6 @@
   border-bottom: 1px @border-color solid;
   &:nth-child(1) {
     border-left: 1px @border-color outset;
-  }
-  &:nth-child(2) {
-    border-left: 1px @border-color inset;
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/BlueBrain/nexus/issues/2824

## Description

Set border width between first and second columns to same as between other columns whereas previously it was thicker.

![Screen Shot 2021-10-06 at 09 37 01](https://user-images.githubusercontent.com/11296166/136160978-b3ae411d-6338-4198-aeeb-9f53ecf8f586.png)

## How has this been tested?

Tested in Chrome Version 91.0.4472.77 (Official Build) (x86_64) and Firefox 91.0 (64-bit) on MacOS 11.6. Confirmed border width is now as expected, the same as the rest.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [x] I have added screenshots (if applicable), in the comment section.
