### PR TITLE
Correct filter options list for edge case in safari

### DIFF
--- a/src/subapps/search/containers/FilterOptions.tsx
+++ b/src/subapps/search/containers/FilterOptions.tsx
@@ -71,13 +71,13 @@ const FilterOptions: React.FC<{
   const filterKeyWord = createKeyWord(field);
   React.useEffect(() => {
     const allSuggestions = constructQuery(query)
-      .aggregation('terms', filterKeyWord, 'suggestions')
+      .aggregation('terms', filterKeyWord, 'suggestions', { size: 1000 })
       .build();
 
     const allSuggestionsPromise = nexusClient.Search.query(allSuggestions);
 
     const filterSuggestions = withOtherFilters
-      .aggregation('terms', filterKeyWord, 'suggestions')
+      .aggregation('terms', filterKeyWord, 'suggestions', { size: 1000 })
       .aggregation('missing', filterKeyWord, 'missing')
       .build();
 
@@ -206,7 +206,9 @@ const FilterOptions: React.FC<{
           setAggregations(filteredSuggestions);
         }}
       ></Input.Search>
-      <Form.Item style={{ maxHeight: '91px', overflow: 'scroll' }}>
+      <Form.Item
+        style={{ maxHeight: '91px', overflow: 'scroll', width: '105%' }}
+      >
         {filterValues}
       </Form.Item>
       <Form.Item></Form.Item>


### PR DESCRIPTION
When setting the scroll settings in sys preferences in mac os to 'always' safari breaks styling. This has been resolved by increasing width.

Fixes #

## Description

<!--- Describe your changes in detail -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
