### PR TITLE
Empty query update

### DIFF
--- a/src/subapps/search/utils/index.ts
+++ b/src/subapps/search/utils/index.ts
@@ -4,12 +4,14 @@ import { ESMaxResultWindowSize } from '../hooks/useSearchPagination';
 
 export const constructQuery = (searchText: string) => {
   const body = bodybuilder();
-  body.query('multi_match', {
-    query: searchText ? searchText : '*',
-    fuzziness: 5,
-    prefix_length: 0,
-    fields: ['*'],
-  });
+  searchText
+    ? body.query('multi_match', {
+        query: searchText,
+        fuzziness: 5,
+        prefix_length: 0,
+        fields: ['*'],
+      })
+    : body.query('match_all', {});
   return body;
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When search string is empty, use match_all instead of multi match. multi match is not suitable for 'get everything' type queries. 
<!--- Describe your changes in detail -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
