### PR TITLE
2874 - Search bar matches query param content bug fix

### DIFF
--- a/src/shared/components/SearchBar/index.tsx
+++ b/src/shared/components/SearchBar/index.tsx
@@ -123,9 +123,9 @@ const SearchBar: React.FC<{
       onKeyDown={handleKeyDown}
       dropdownClassName="search-bar__drop"
       dropdownMatchSelectWidth={false}
+      value={value}
     >
       <Input
-        value={value === lastVisited ? '' : value}
         allowClear
         onPressEnter={inputOnPressEnter}
         ref={inputRef}

--- a/src/shared/containers/SearchBarContainer.tsx
+++ b/src/shared/containers/SearchBarContainer.tsx
@@ -6,6 +6,7 @@ import { useQuery } from 'react-query';
 
 import SearchBar from '../components/SearchBar';
 import { sortStringsBySimilarity } from '../utils/stringSimilarity';
+import useQueryString from '../hooks/useQueryString';
 
 const PROJECT_RESULTS_DEFAULT_SIZE = 300;
 const SHOULD_INCLUDE_DEPRECATED = false;
@@ -17,6 +18,17 @@ const SearchBarContainer: React.FC = () => {
   const history = useHistory();
   const [query, setQuery] = React.useState<string>();
   const [lastVisited, setLastVisited] = React.useState<string>();
+
+  const [queryParams] = useQueryString();
+  const { query: searchQueryParam } = queryParams;
+
+  React.useEffect(() => {
+    setQuery(searchQueryParam);
+    if (searchQueryParam) {
+      setLastVisited(searchQueryParam);
+      localStorage.setItem(STORAGE_ITEM, searchQueryParam);
+    }
+  }, [searchQueryParam]);
 
   const { data } = useQuery(
     'projects',
@@ -97,7 +109,7 @@ const SearchBarContainer: React.FC = () => {
       onSubmit={handleSubmit}
       onClear={handleClear}
       onFocus={onFocus}
-      onBlur={() => setQuery('')}
+      onBlur={() => setQuery(searchQueryParam)}
       inputOnPressEnter={inputOnPressEnter}
     />
   );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes https://github.com/BlueBrain/nexus/issues/2874

## Description

Fixes bug where search bar content did not reflect what was in the query url parameter and had been searched for. Also, contents of search bar are cleared when user has navigated away from search page. Upon clicking on the search bar the last searched for text will be displayed.

![SearchBarBugFixed](https://user-images.githubusercontent.com/11296166/137936966-1eb5a46d-e714-4744-ab17-b0079a0a70f5.gif)

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Tested the various different scenarios in Firefox.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [x] I have added screenshots (if applicable), in the comment section.
