### PR TITLE
2807 admin layout tab update

### DIFF
--- a/src/shared/styles/project-banner.less
+++ b/src/shared/styles/project-banner.less
@@ -1,7 +1,6 @@
 @import '../lib.less';
 
 .project-banner {
-  // background-color: fade(@header-background-color, 2.5%);
   padding: 0 @default-pad;
   display: flex;
   justify-content: space-between;

--- a/src/shared/styles/project-banner.less
+++ b/src/shared/styles/project-banner.less
@@ -1,7 +1,7 @@
 @import '../lib.less';
 
 .project-banner {
-  background-color: fade(@header-background-color, 2.5%);
+  // background-color: fade(@header-background-color, 2.5%);
   padding: 0 @default-pad;
   display: flex;
   justify-content: space-between;

--- a/src/subapps/admin/components/ACLs/ACLsForm.tsx
+++ b/src/subapps/admin/components/ACLs/ACLsForm.tsx
@@ -15,7 +15,11 @@ const ACLsForm: React.FunctionComponent<ACLsFormProps> = (
   props: ACLsFormProps
 ) => {
   return (
-    <Tabs defaultActiveKey={`${props.path}-0`} className="ACLs-form">
+    <Tabs
+      defaultActiveKey={`${props.path}-0`}
+      className="ACLs-form"
+      tabPosition="left"
+    >
       {props.acls.map((acl: ACL, index: number) => (
         <Tabs.TabPane
           tab={

--- a/src/subapps/admin/components/Projects/QueryEditor.less
+++ b/src/subapps/admin/components/Projects/QueryEditor.less
@@ -1,0 +1,5 @@
+.query-editor {
+	.ant-tabs-content-holder > div {
+			flex-grow: 1;
+	}
+}

--- a/src/subapps/admin/components/Projects/QueryEditor.less
+++ b/src/subapps/admin/components/Projects/QueryEditor.less
@@ -1,5 +1,5 @@
 .query-editor {
-	.ant-tabs-content-holder > div {
-			flex-grow: 1;
-	}
+  .ant-tabs-content-holder > div {
+    flex-grow: 1;
+  }
 }

--- a/src/subapps/admin/components/Projects/QueryEditor.tsx
+++ b/src/subapps/admin/components/Projects/QueryEditor.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import {
+  DEFAULT_SPARQL_VIEW_ID,
+  DEFAULT_ELASTIC_SEARCH_VIEW_ID,
+} from '@bbp/nexus-sdk';
+
+import { useAdminSubappContext } from '../..';
+
+const QueryEditor: React.FC<{
+  orgLabel: string;
+  projectLabel: string;
+  onUpdate: () => void;
+}> = ({ orgLabel, projectLabel, onUpdate }) => {
+  const subApp = useAdminSubappContext();
+  return (
+    <div className="query-editor">
+      <h3>Project Tools</h3>
+      <p>
+        View resources in your project using pre-defined query-helper lists.
+      </p>
+      <div className="project-menu__controls">
+        <Link
+          to={`/${
+            subApp.namespace
+          }/${orgLabel}/${projectLabel}/${encodeURIComponent(
+            DEFAULT_SPARQL_VIEW_ID
+          )}/sparql`}
+        >
+          Sparql Query Editor
+        </Link>
+        <Link
+          to={`/${
+            subApp.namespace
+          }/${orgLabel}/${projectLabel}/${encodeURIComponent(
+            DEFAULT_ELASTIC_SEARCH_VIEW_ID
+          )}/_search`}
+        >
+          ElasticSearch Query Editor
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default QueryEditor;

--- a/src/subapps/admin/components/Projects/QueryEditor.tsx
+++ b/src/subapps/admin/components/Projects/QueryEditor.tsx
@@ -3,19 +3,11 @@ import SparqlQueryView from '../../views/SparqlQueryView';
 import ElasticSearchQueryView from '../../views/ElasticSearchQueryView';
 import { Tabs } from 'antd';
 
-import {
-  DEFAULT_SPARQL_VIEW_ID,
-  DEFAULT_ELASTIC_SEARCH_VIEW_ID,
-} from '@bbp/nexus-sdk';
-
-import { useAdminSubappContext } from '../..';
-
 const QueryEditor: React.FC<{
   orgLabel: string;
   projectLabel: string;
   onUpdate: () => void;
 }> = ({ orgLabel, projectLabel, onUpdate }) => {
-  const subApp = useAdminSubappContext();
   const { TabPane } = Tabs;
   return (
     <div className="query-editor">

--- a/src/subapps/admin/components/Projects/QueryEditor.tsx
+++ b/src/subapps/admin/components/Projects/QueryEditor.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import SparqlQueryView from '../../views/SparqlQueryView';
 import ElasticSearchQueryView from '../../views/ElasticSearchQueryView';
+import './QueryEditor.less';
 import { Tabs } from 'antd';
 
 const QueryEditor: React.FC<{
@@ -18,12 +19,12 @@ const QueryEditor: React.FC<{
       <div className="project-menu__controls">
         <Tabs defaultActiveKey="browse" tabPosition="left">
           <TabPane tab="SparQL" key="browse">
-            <div style={{ flexGrow: 1 }}>
+            <div>
               <SparqlQueryView />
             </div>
           </TabPane>
           <TabPane tab="ElasticSearch" key="query">
-            <div style={{ flexGrow: 1 }}>
+            <div>
               <ElasticSearchQueryView />
             </div>
           </TabPane>

--- a/src/subapps/admin/components/Projects/QueryEditor.tsx
+++ b/src/subapps/admin/components/Projects/QueryEditor.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react';
-import { Link } from 'react-router-dom';
+import SparqlQueryView from '../../views/SparqlQueryView';
+import ElasticSearchQueryView from '../../views/ElasticSearchQueryView';
+import { Tabs } from 'antd';
+
 import {
   DEFAULT_SPARQL_VIEW_ID,
   DEFAULT_ELASTIC_SEARCH_VIEW_ID,
@@ -13,31 +16,26 @@ const QueryEditor: React.FC<{
   onUpdate: () => void;
 }> = ({ orgLabel, projectLabel, onUpdate }) => {
   const subApp = useAdminSubappContext();
+  const { TabPane } = Tabs;
   return (
     <div className="query-editor">
-      <h3>Project Tools</h3>
+      <h3>Query Browser</h3>
       <p>
         View resources in your project using pre-defined query-helper lists.
       </p>
       <div className="project-menu__controls">
-        <Link
-          to={`/${
-            subApp.namespace
-          }/${orgLabel}/${projectLabel}/${encodeURIComponent(
-            DEFAULT_SPARQL_VIEW_ID
-          )}/sparql`}
-        >
-          Sparql Query Editor
-        </Link>
-        <Link
-          to={`/${
-            subApp.namespace
-          }/${orgLabel}/${projectLabel}/${encodeURIComponent(
-            DEFAULT_ELASTIC_SEARCH_VIEW_ID
-          )}/_search`}
-        >
-          ElasticSearch Query Editor
-        </Link>
+        <Tabs defaultActiveKey="browse" tabPosition="left">
+          <TabPane tab="SparQL" key="browse">
+            <div style={{ flexGrow: 1 }}>
+              <SparqlQueryView />
+            </div>
+          </TabPane>
+          <TabPane tab="ElasticSearch" key="query">
+            <div style={{ flexGrow: 1 }}>
+              <ElasticSearchQueryView />
+            </div>
+          </TabPane>
+        </Tabs>
       </div>
     </div>
   );

--- a/src/subapps/admin/views/ACLsView.tsx
+++ b/src/subapps/admin/views/ACLsView.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { Link, useRouteMatch } from 'react-router-dom';
 import { Empty, Spin, Tooltip } from 'antd';
-import { HomeOutlined } from '@ant-design/icons';
 import { ACL } from '@bbp/nexus-sdk';
 import { useNexusContext } from '@bbp/react-nexus';
 

--- a/src/subapps/admin/views/ACLsView.tsx
+++ b/src/subapps/admin/views/ACLsView.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { Link, useRouteMatch } from 'react-router-dom';
-import { Empty, Spin, Tooltip } from 'antd';
+import { useRouteMatch } from 'react-router-dom';
+import { Empty, Spin } from 'antd';
 import { ACL } from '@bbp/nexus-sdk';
 import { useNexusContext } from '@bbp/react-nexus';
 

--- a/src/subapps/admin/views/ACLsView.tsx
+++ b/src/subapps/admin/views/ACLsView.tsx
@@ -61,41 +61,24 @@ const ACLs: React.FunctionComponent = () => {
   }, [orgLabel, projectLabel]);
 
   return (
-    <div className="acl-view view-container">
-      <div style={{ flexGrow: 1 }}>
-        <h1 className="name">
-          <span>
-            <Link to={`/${namespace}`}>
-              <Tooltip title="Back to all organizations" placement="right">
-                <HomeOutlined />
-              </Tooltip>
-            </Link>
-            {' | '}
-            <Link to={`/${namespace}/${orgLabel}`}>{orgLabel}</Link>
-            {' | '}
-            <Link to={`/${namespace}/${orgLabel}/${projectLabel}`}>
-              {projectLabel}
-            </Link>
-          </span>
-        </h1>
-        {busy && <Spin tip="Loading ACLs..." />}
-        {error && (
+    <div style={{ flexGrow: 1 }}>
+      {busy && <Spin tip="Loading ACLs..." />}
+      {error && (
+        <Empty
+          style={{ marginTop: '22vh' }}
+          description={
+            <span>Error while retrieving ALCs: {error.message}</span>
+          }
+        />
+      )}
+      {!acls ||
+        (acls.length === 0 && (
           <Empty
             style={{ marginTop: '22vh' }}
-            description={
-              <span>Error while retrieving ALCs: {error.message}</span>
-            }
+            description={'No ACLs to display...'}
           />
-        )}
-        {!acls ||
-          (acls.length === 0 && (
-            <Empty
-              style={{ marginTop: '22vh' }}
-              description={'No ACLs to display...'}
-            />
-          ))}
-        {acls && <ACLsForm acls={acls} path={path} />}
-      </div>
+        ))}
+      {acls && <ACLsForm acls={acls} path={path} />}
     </div>
   );
 };

--- a/src/subapps/admin/views/ElasticSearchQueryView.tsx
+++ b/src/subapps/admin/views/ElasticSearchQueryView.tsx
@@ -1,13 +1,10 @@
 import * as React from 'react';
 import { useRouteMatch, useLocation } from 'react-router';
-import { Link } from 'react-router-dom';
 import * as queryString from 'query-string';
-import { Menu } from 'antd';
-import { ViewList, View, DEFAULT_ELASTIC_SEARCH_VIEW_ID } from '@bbp/nexus-sdk';
+import { ViewList, DEFAULT_ELASTIC_SEARCH_VIEW_ID } from '@bbp/nexus-sdk';
 import { useNexusContext } from '@bbp/react-nexus';
 
 import ElasticSearchQueryContainer from '../containers/ElasticSearchQuery';
-import { getResourceLabel } from '../../../shared/utils';
 import { useAdminSubappContext } from '..';
 
 const ElasticSearchQueryView: React.FunctionComponent = (): JSX.Element => {
@@ -27,15 +24,12 @@ const ElasticSearchQueryView: React.FunctionComponent = (): JSX.Element => {
       viewId: '',
     },
   };
-  const [{ _results: views, _total: viewTotal }, setViews] = React.useState<
-    ViewList
-  >({
+  const [, setViews] = React.useState<ViewList>({
     '@context': {},
     _total: 0,
     _results: [],
   });
   const nexus = useNexusContext();
-  const decodedViewId = decodeURIComponent(viewId);
   const query = queryString.parse(location.search).query;
 
   React.useEffect(() => {
@@ -45,32 +39,6 @@ const ElasticSearchQueryView: React.FunctionComponent = (): JSX.Element => {
         // 503 ?
       });
   }, [orgLabel, projectLabel]);
-
-  const menu = (
-    <Menu>
-      {views.map((view: View, index: number) => {
-        const stringifiedViewType = Array.isArray(view['@type'])
-          ? view['@type'].join('')
-          : view['@type'];
-        const pathAppendage = (stringifiedViewType || '')
-          .toLowerCase()
-          .includes('elastic')
-          ? '_search'
-          : 'sparql';
-        return (
-          <Menu.Item key={index}>
-            <Link
-              to={`/${namespace}/${orgLabel}/${projectLabel}/${encodeURIComponent(
-                view['@id']
-              )}/${pathAppendage}`}
-            >
-              {getResourceLabel(view)}
-            </Link>
-          </Menu.Item>
-        );
-      })}
-    </Menu>
-  );
 
   return (
     <>

--- a/src/subapps/admin/views/ElasticSearchQueryView.tsx
+++ b/src/subapps/admin/views/ElasticSearchQueryView.tsx
@@ -14,7 +14,6 @@ const ElasticSearchQueryView: React.FunctionComponent = (): JSX.Element => {
     viewId: string;
   }>();
   const location = useLocation();
-  const { namespace } = useAdminSubappContext();
   const {
     params: { orgLabel, projectLabel, viewId },
   } = match || {

--- a/src/subapps/admin/views/ElasticSearchQueryView.tsx
+++ b/src/subapps/admin/views/ElasticSearchQueryView.tsx
@@ -76,33 +76,6 @@ const ElasticSearchQueryView: React.FunctionComponent = (): JSX.Element => {
 
   return (
     <>
-      <div className="project-banner no-bg" style={{ marginBottom: 20 }}>
-        <div className="label">
-          <h1 className="name">
-            <span>
-              <Link to={`/${namespace}/${orgLabel}`}>{orgLabel}</Link>
-              {' | '}
-              <Link to={`/${namespace}/${orgLabel}/${projectLabel}`}>
-                {projectLabel}
-              </Link>
-              {' | '}
-            </span>
-            <Dropdown overlay={menu}>
-              <span>
-                {labelOf(decodedViewId)}
-                <DownOutlined />
-              </span>
-            </Dropdown>{' '}
-          </h1>
-          <div style={{ marginLeft: 10 }}>
-            <ViewStatisticsProgress
-              orgLabel={orgLabel}
-              projectLabel={projectLabel}
-              resourceId={viewId}
-            />
-          </div>
-        </div>
-      </div>
       <div className="view-view view-container -unconstrained-width">
         <ElasticSearchQueryContainer
           orgLabel={orgLabel}

--- a/src/subapps/admin/views/ElasticSearchQueryView.tsx
+++ b/src/subapps/admin/views/ElasticSearchQueryView.tsx
@@ -5,7 +5,6 @@ import { ViewList, DEFAULT_ELASTIC_SEARCH_VIEW_ID } from '@bbp/nexus-sdk';
 import { useNexusContext } from '@bbp/react-nexus';
 
 import ElasticSearchQueryContainer from '../containers/ElasticSearchQuery';
-import { useAdminSubappContext } from '..';
 
 const ElasticSearchQueryView: React.FunctionComponent = (): JSX.Element => {
   const match = useRouteMatch<{

--- a/src/subapps/admin/views/ElasticSearchQueryView.tsx
+++ b/src/subapps/admin/views/ElasticSearchQueryView.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import * as queryString from 'query-string';
 import { Menu, Dropdown } from 'antd';
 import { DownOutlined } from '@ant-design/icons';
-import { ViewList, View } from '@bbp/nexus-sdk';
+import { ViewList, View, DEFAULT_ELASTIC_SEARCH_VIEW_ID } from '@bbp/nexus-sdk';
 import { useNexusContext } from '@bbp/react-nexus';
 
 import ViewStatisticsProgress from '../components/Views/ViewStatisticsProgress';
@@ -81,7 +81,9 @@ const ElasticSearchQueryView: React.FunctionComponent = (): JSX.Element => {
           orgLabel={orgLabel}
           projectLabel={projectLabel}
           initialQuery={query ? JSON.parse(`${query}`) : null}
-          viewId={viewId}
+          viewId={
+            viewId ? viewId : encodeURIComponent(DEFAULT_ELASTIC_SEARCH_VIEW_ID)
+          }
         />
       </div>
     </>

--- a/src/subapps/admin/views/ElasticSearchQueryView.tsx
+++ b/src/subapps/admin/views/ElasticSearchQueryView.tsx
@@ -2,14 +2,12 @@ import * as React from 'react';
 import { useRouteMatch, useLocation } from 'react-router';
 import { Link } from 'react-router-dom';
 import * as queryString from 'query-string';
-import { Menu, Dropdown } from 'antd';
-import { DownOutlined } from '@ant-design/icons';
+import { Menu } from 'antd';
 import { ViewList, View, DEFAULT_ELASTIC_SEARCH_VIEW_ID } from '@bbp/nexus-sdk';
 import { useNexusContext } from '@bbp/react-nexus';
 
-import ViewStatisticsProgress from '../components/Views/ViewStatisticsProgress';
 import ElasticSearchQueryContainer from '../containers/ElasticSearchQuery';
-import { getResourceLabel, labelOf } from '../../../shared/utils';
+import { getResourceLabel } from '../../../shared/utils';
 import { useAdminSubappContext } from '..';
 
 const ElasticSearchQueryView: React.FunctionComponent = (): JSX.Element => {

--- a/src/subapps/admin/views/ProjectView.less
+++ b/src/subapps/admin/views/ProjectView.less
@@ -4,11 +4,12 @@
   padding: 0 @default-pad;
 
   .tabs-container {
-	  .ant-tabs-top > .ant-tabs-nav {
-		  margin: 0 !important;
-	  }
+    .ant-tabs-top > .ant-tabs-nav {
+      margin: 0 !important;
+    }
     .ant-tabs-content-holder {
       background: #fff;
+	  padding: 0 @default-pad;
     }
     .ant-tabs-nav {
       padding: 0 1rem;

--- a/src/subapps/admin/views/ProjectView.less
+++ b/src/subapps/admin/views/ProjectView.less
@@ -1,15 +1,16 @@
 @import '../../../shared/lib.less';
 
 .project-view {
-  padding: 0 @default-pad;
-
+  .view-container {
+    max-width: 100%;
+  }
   .tabs-container {
     .ant-tabs-top > .ant-tabs-nav {
       margin: 0 !important;
     }
     .ant-tabs-content-holder {
       background: #fff;
-	  padding: 0 @default-pad;
+      padding: 0 @default-pad;
     }
     .ant-tabs-nav {
       padding: 0 1rem;

--- a/src/subapps/admin/views/ProjectView.less
+++ b/src/subapps/admin/views/ProjectView.less
@@ -1,0 +1,20 @@
+@import '../../../shared/lib.less';
+
+.project-view {
+  padding: 0 @default-pad;
+
+  .tabs-container {
+	  .ant-tabs-top > .ant-tabs-nav {
+		  margin: 0 !important;
+	  }
+    .ant-tabs-content-holder {
+      background: #fff;
+    }
+    .ant-tabs-nav {
+      padding: 0 1rem;
+      .ant-tabs-tab-active .ant-tabs-tab-btn {
+        text-shadow: unset;
+      }
+    }
+  }
+}

--- a/src/subapps/admin/views/ProjectView.tsx
+++ b/src/subapps/admin/views/ProjectView.tsx
@@ -56,6 +56,7 @@ const ProjectView: React.FunctionComponent = () => {
   const [formBusy, setFormBusy] = React.useState<boolean>(false);
 
   const [refreshLists, setRefreshLists] = React.useState(false);
+  const [activeKey, setActiveKey] = React.useState('browse');
   const [statisticsPollingPaused, setStatisticsPollingPaused] = React.useState(
     false
   );
@@ -104,7 +105,7 @@ const ProjectView: React.FunctionComponent = () => {
 
   React.useEffect(() => {
     /* if location has changed, check to see if we should refresh our
-    resources and reset initial statistics state */
+		resources and reset initial statistics state */
     const refresh =
       location.state && (location.state as { refresh?: boolean }).refresh;
     if (refresh) {
@@ -173,6 +174,10 @@ const ProjectView: React.FunctionComponent = () => {
         });
       });
   };
+  const handleTabChange = (activeKey: string) => {
+    const key = activeKey === 'studios' ? 'browse' : `${activeKey}`;
+    setActiveKey(key);
+  };
   return (
     <div className="project-view">
       {!!project && (
@@ -228,7 +233,11 @@ const ProjectView: React.FunctionComponent = () => {
             />
           )}
           <div className="tabs-container">
-            <Tabs defaultActiveKey="browse">
+            <Tabs
+              onChange={handleTabChange}
+              activeKey={activeKey}
+              defaultActiveKey="browse"
+            >
               <TabPane tab="Browse" key="browse">
                 <div className="list-board">
                   <div className="wrapper">

--- a/src/subapps/admin/views/ProjectView.tsx
+++ b/src/subapps/admin/views/ProjectView.tsx
@@ -311,8 +311,13 @@ const ProjectView: React.FunctionComponent = () => {
               <TabPane
                 tab={
                   <span>
-                    <SelectOutlined />
-                    Studios
+                    <Link
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      to={`/studios/${orgLabel}/${projectLabel}/studios`}
+                    >
+                      <SelectOutlined /> Studios
+                    </Link>
                   </span>
                 }
                 key="studios"
@@ -320,8 +325,13 @@ const ProjectView: React.FunctionComponent = () => {
               <TabPane
                 tab={
                   <span>
-                    <SelectOutlined />
-                    Workflows
+                    <Link
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      to={`/workflow/${orgLabel}/${projectLabel}`}
+                    >
+                      <SelectOutlined /> Workflows
+                    </Link>
                   </span>
                 }
                 key="workflows"

--- a/src/subapps/admin/views/ProjectView.tsx
+++ b/src/subapps/admin/views/ProjectView.tsx
@@ -17,7 +17,6 @@ import ProjectForm from '../components/Projects/ProjectForm';
 import ViewStatisticsContainer from '../components/Views/ViewStatisticsProgress';
 import ResourceListBoardContainer from '../../../shared/containers/ResourceListBoardContainer';
 import FileUploadContainer from '../../../shared/containers/FileUploadContainer';
-import ProjectTools from '../components/Projects/ProjectTools';
 import ACLsView from './ACLsView';
 import QueryEditor from '../components/Projects/QueryEditor';
 import { useAdminSubappContext } from '..';

--- a/src/subapps/admin/views/ProjectView.tsx
+++ b/src/subapps/admin/views/ProjectView.tsx
@@ -8,6 +8,7 @@ import {
 } from '@bbp/nexus-sdk';
 import { useNexusContext, AccessControl } from '@bbp/react-nexus';
 import { Tabs, Popover, Button, Divider } from 'antd';
+import { SelectOutlined } from '@ant-design/icons';
 import { Link, useHistory, useLocation } from 'react-router-dom';
 
 import StoragesContainer from '../containers/StoragesContainer';
@@ -307,19 +308,24 @@ const ProjectView: React.FunctionComponent = () => {
                   <br />
                 </>
               </TabPane>
-              <TabPane tab="Studios" key="studios"></TabPane>
-              <TabPane tab="Workflows" key="workflows"></TabPane>
-              <TabPane tab="Tools" key="2">
-                <ProjectTools
-                  orgLabel={orgLabel}
-                  projectLabel={projectLabel}
-                  onUpdate={() => {
-                    setRefreshLists(!refreshLists);
-                    // Statistics aren't immediately updated so pause polling briefly
-                    pauseStatisticsPolling(5000);
-                  }}
-                />
-              </TabPane>
+              <TabPane
+                tab={
+                  <span>
+                    <SelectOutlined />
+                    Studios
+                  </span>
+                }
+                key="studios"
+              ></TabPane>
+              <TabPane
+                tab={
+                  <span>
+                    <SelectOutlined />
+                    Workflows
+                  </span>
+                }
+                key="workflows"
+              ></TabPane>
             </Tabs>
           </div>
         </>

--- a/src/subapps/admin/views/ProjectView.tsx
+++ b/src/subapps/admin/views/ProjectView.tsx
@@ -13,6 +13,7 @@ import { Link, useHistory, useLocation } from 'react-router-dom';
 import ViewStatisticsContainer from '../components/Views/ViewStatisticsProgress';
 import ResourceListBoardContainer from '../../../shared/containers/ResourceListBoardContainer';
 import ProjectTools from '../components/Projects/ProjectTools';
+import QueryEditor from '../components/Projects/QueryEditor';
 import { useAdminSubappContext } from '..';
 import useNotification from '../../../shared/hooks/useNotification';
 import ProjectToDeleteContainer from '../containers/ProjectToDeleteContainer';
@@ -206,7 +207,17 @@ const ProjectView: React.FunctionComponent = () => {
                   </div>
                 </div>
               </TabPane>
-              <TabPane tab="Query" key="query"></TabPane>
+              <TabPane tab="Query" key="query">
+                <QueryEditor
+                  orgLabel={orgLabel}
+                  projectLabel={projectLabel}
+                  onUpdate={() => {
+                    setRefreshLists(!refreshLists);
+                    // Statistics aren't immediately updated so pause polling briefly
+                    pauseStatisticsPolling(5000);
+                  }}
+                />
+              </TabPane>
               <TabPane tab="Create and Upload" key="create_upload"></TabPane>
               <TabPane tab="Statistics" key="stats"></TabPane>
               <TabPane tab="Settings" key="settings"></TabPane>

--- a/src/subapps/admin/views/ProjectView.tsx
+++ b/src/subapps/admin/views/ProjectView.tsx
@@ -17,6 +17,8 @@ import ViewStatisticsContainer from '../components/Views/ViewStatisticsProgress'
 import ResourceListBoardContainer from '../../../shared/containers/ResourceListBoardContainer';
 import FileUploadContainer from '../../../shared/containers/FileUploadContainer';
 import ProjectTools from '../components/Projects/ProjectTools';
+import ACLsForm from '../components/ACLs/ACLsForm';
+import ACLsView from './ACLsView';
 import QueryEditor from '../components/Projects/QueryEditor';
 import { useAdminSubappContext } from '..';
 import useNotification from '../../../shared/hooks/useNotification';
@@ -280,23 +282,27 @@ const ProjectView: React.FunctionComponent = () => {
               </TabPane>
               <TabPane tab="Settings" key="settings">
                 <>
-                  <h3>Project Settings</h3>
+									<br />
+									<h3>Settings</h3>
+                  <div style={{ flexGrow: 1 }}>
+                    <ProjectForm
+                      project={{
+                        _label: project._label,
+                        _rev: project._rev,
+                        description: project.description || '',
+                        base: project.base,
+                        vocab: project.vocab,
+                        apiMappings: project.apiMappings,
+                      }}
+                      onSubmit={(p: ProjectResponseCommon) =>
+                        saveAndModify(project, p)
+                      }
+                      busy={formBusy}
+                      mode="edit"
+                    />
+                  </div>
                   <br />
-                  <ProjectForm
-                    project={{
-                      _label: project._label,
-                      _rev: project._rev,
-                      description: project.description || '',
-                      base: project.base,
-                      vocab: project.vocab,
-                      apiMappings: project.apiMappings,
-                    }}
-                    onSubmit={(p: ProjectResponseCommon) =>
-                      saveAndModify(project, p)
-                    }
-                    busy={formBusy}
-                    mode="edit"
-                  />
+                  <ACLsView />
                   <br />
                 </>
               </TabPane>

--- a/src/subapps/admin/views/ProjectView.tsx
+++ b/src/subapps/admin/views/ProjectView.tsx
@@ -17,7 +17,6 @@ import ViewStatisticsContainer from '../components/Views/ViewStatisticsProgress'
 import ResourceListBoardContainer from '../../../shared/containers/ResourceListBoardContainer';
 import FileUploadContainer from '../../../shared/containers/FileUploadContainer';
 import ProjectTools from '../components/Projects/ProjectTools';
-import ACLsForm from '../components/ACLs/ACLsForm';
 import ACLsView from './ACLsView';
 import QueryEditor from '../components/Projects/QueryEditor';
 import { useAdminSubappContext } from '..';
@@ -242,15 +241,17 @@ const ProjectView: React.FunctionComponent = () => {
                 </div>
               </TabPane>
               <TabPane tab="Query" key="query">
-                <QueryEditor
-                  orgLabel={orgLabel}
-                  projectLabel={projectLabel}
-                  onUpdate={() => {
-                    setRefreshLists(!refreshLists);
-                    // Statistics aren't immediately updated so pause polling briefly
-                    pauseStatisticsPolling(5000);
-                  }}
-                />
+                <div style={{ flexGrow: 1 }}>
+                  <QueryEditor
+                    orgLabel={orgLabel}
+                    projectLabel={projectLabel}
+                    onUpdate={() => {
+                      setRefreshLists(!refreshLists);
+                      // Statistics aren't immediately updated so pause polling briefly
+                      pauseStatisticsPolling(5000);
+                    }}
+                  />
+                </div>
               </TabPane>
               <TabPane tab="Create and Upload" key="create_upload">
                 <AccessControl
@@ -282,8 +283,8 @@ const ProjectView: React.FunctionComponent = () => {
               </TabPane>
               <TabPane tab="Settings" key="settings">
                 <>
-									<br />
-									<h3>Settings</h3>
+                  <br />
+                  <h3>Settings</h3>
                   <div style={{ flexGrow: 1 }}>
                     <ProjectForm
                       project={{

--- a/src/subapps/admin/views/ProjectView.tsx
+++ b/src/subapps/admin/views/ProjectView.tsx
@@ -7,7 +7,7 @@ import {
   Statistics,
 } from '@bbp/nexus-sdk';
 import { useNexusContext } from '@bbp/react-nexus';
-import { Popover, Button } from 'antd';
+import { Tabs, Popover, Button } from 'antd';
 import { Link, useHistory, useLocation } from 'react-router-dom';
 
 import ViewStatisticsContainer from '../components/Views/ViewStatisticsProgress';
@@ -17,6 +17,7 @@ import { useAdminSubappContext } from '..';
 import useNotification from '../../../shared/hooks/useNotification';
 import ProjectToDeleteContainer from '../containers/ProjectToDeleteContainer';
 import { RootState } from '../../../shared/store/reducers';
+import './ProjectView.less';
 
 const ProjectView: React.FunctionComponent = () => {
   const notification = useNotification();
@@ -24,6 +25,7 @@ const ProjectView: React.FunctionComponent = () => {
   const location = useLocation();
   const history = useHistory();
   const subapp = useAdminSubappContext();
+  const { TabPane } = Tabs;
   const match = useRouteMatch<{ orgLabel: string; projectLabel: string }>(
     `/${subapp.namespace}/:orgLabel/:projectLabel`
   );
@@ -191,23 +193,37 @@ const ProjectView: React.FunctionComponent = () => {
               projectLabel={project._label}
             />
           )}
-          <div className="list-board">
-            <div className="wrapper">
-              <ResourceListBoardContainer
-                orgLabel={orgLabel}
-                projectLabel={projectLabel}
-                refreshLists={refreshLists}
-              />
-              <ProjectTools
-                orgLabel={orgLabel}
-                projectLabel={projectLabel}
-                onUpdate={() => {
-                  setRefreshLists(!refreshLists);
-                  // Statistics aren't immediately updated so pause polling briefly
-                  pauseStatisticsPolling(5000);
-                }}
-              />
-            </div>
+          <div className="tabs-container">
+            <Tabs defaultActiveKey="browse">
+              <TabPane tab="Browse" key="browse">
+                <div className="list-board">
+                  <div className="wrapper">
+                    <ResourceListBoardContainer
+                      orgLabel={orgLabel}
+                      projectLabel={projectLabel}
+                      refreshLists={refreshLists}
+                    />
+                  </div>
+                </div>
+              </TabPane>
+              <TabPane tab="Query" key="query"></TabPane>
+              <TabPane tab="Create and Upload" key="create_upload"></TabPane>
+              <TabPane tab="Statistics" key="stats"></TabPane>
+              <TabPane tab="Settings" key="settings"></TabPane>
+              <TabPane tab="Studios" key="studios"></TabPane>
+              <TabPane tab="Workflows" key="workflows"></TabPane>
+              <TabPane tab="Tools" key="2">
+                <ProjectTools
+                  orgLabel={orgLabel}
+                  projectLabel={projectLabel}
+                  onUpdate={() => {
+                    setRefreshLists(!refreshLists);
+                    // Statistics aren't immediately updated so pause polling briefly
+                    pauseStatisticsPolling(5000);
+                  }}
+                />
+              </TabPane>
+            </Tabs>
           </div>
         </>
       )}

--- a/src/subapps/admin/views/ProjectsView.tsx
+++ b/src/subapps/admin/views/ProjectsView.tsx
@@ -209,26 +209,6 @@ const ProjectsView: React.FunctionComponent = () => {
                 <ListItem
                   key={i['@id']}
                   onClick={() => goTo(i._organizationLabel, i._label)}
-                  actions={[
-                    <AccessControl
-                      key={`access-control-${i['@id']}`}
-                      path={`/${i._organizationLabel}/${i._label}`}
-                      permissions={['projects/write']}
-                    >
-                      <Button
-                        className="edit-button"
-                        size="small"
-                        type="primary"
-                        tabIndex={1}
-                        onClick={(e: React.SyntheticEvent) => {
-                          e.stopPropagation();
-                          setSelectedProject(i);
-                        }}
-                      >
-                        Settings
-                      </Button>
-                    </AccessControl>,
-                  ]}
                 >
                   <ProjectItem {...i} />
                 </ListItem>

--- a/src/subapps/admin/views/SparqlQueryView.tsx
+++ b/src/subapps/admin/views/SparqlQueryView.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import * as queryString from 'query-string';
 import { Menu, Dropdown } from 'antd';
 import { DownOutlined } from '@ant-design/icons';
-import { ViewList, View } from '@bbp/nexus-sdk';
+import { ViewList, View, DEFAULT_SPARQL_VIEW_ID } from '@bbp/nexus-sdk';
 import { useNexusContext } from '@bbp/react-nexus';
 
 import ViewStatisticsProgress from '../components/Views/ViewStatisticsProgress';
@@ -12,7 +12,6 @@ import SparqlQueryContainer from '../containers/SparqlQuery';
 import { getResourceLabel, labelOf } from '../../../shared/utils';
 import { useAdminSubappContext } from '..';
 import useNotification from '../../../shared/hooks/useNotification';
-import { DEFAULT_SPARQL_VIEW_ID } from '@bbp/nexus-sdk';
 
 const SparqlQueryView: React.FunctionComponent = (): JSX.Element => {
   const match = useRouteMatch<{

--- a/src/subapps/admin/views/SparqlQueryView.tsx
+++ b/src/subapps/admin/views/SparqlQueryView.tsx
@@ -12,6 +12,7 @@ import SparqlQueryContainer from '../containers/SparqlQuery';
 import { getResourceLabel, labelOf } from '../../../shared/utils';
 import { useAdminSubappContext } from '..';
 import useNotification from '../../../shared/hooks/useNotification';
+import { DEFAULT_SPARQL_VIEW_ID } from '@bbp/nexus-sdk';
 
 const SparqlQueryView: React.FunctionComponent = (): JSX.Element => {
   const match = useRouteMatch<{
@@ -25,6 +26,7 @@ const SparqlQueryView: React.FunctionComponent = (): JSX.Element => {
   const {
     params: { orgLabel, projectLabel, viewId },
   } = match;
+
   const [{ _results: views }, setViews] = React.useState<ViewList>({
     '@context': {},
     _total: 0,
@@ -57,8 +59,6 @@ const SparqlQueryView: React.FunctionComponent = (): JSX.Element => {
           ? '_search'
           : 'sparql';
 
-        console.log('encodeURIComponent');
-        console.log(encodeURIComponent(view['@id']));
         return (
           <Menu.Item key={index}>
             <Link
@@ -81,7 +81,7 @@ const SparqlQueryView: React.FunctionComponent = (): JSX.Element => {
           orgLabel={orgLabel}
           projectLabel={projectLabel}
           initialQuery={Array.isArray(query) ? query.join(',') : query}
-          viewId={viewId}
+          viewId={viewId ? viewId : encodeURIComponent(DEFAULT_SPARQL_VIEW_ID)}
         />
       </div>
     </>

--- a/src/subapps/admin/views/SparqlQueryView.tsx
+++ b/src/subapps/admin/views/SparqlQueryView.tsx
@@ -1,13 +1,10 @@
 import * as React from 'react';
 import { useLocation, useRouteMatch } from 'react-router';
-import { Link } from 'react-router-dom';
 import * as queryString from 'query-string';
-import { Menu } from 'antd';
-import { ViewList, View, DEFAULT_SPARQL_VIEW_ID } from '@bbp/nexus-sdk';
+import { ViewList, DEFAULT_SPARQL_VIEW_ID } from '@bbp/nexus-sdk';
 import { useNexusContext } from '@bbp/react-nexus';
 
 import SparqlQueryContainer from '../containers/SparqlQuery';
-import { getResourceLabel } from '../../../shared/utils';
 import { useAdminSubappContext } from '..';
 import useNotification from '../../../shared/hooks/useNotification';
 
@@ -19,7 +16,6 @@ const SparqlQueryView: React.FunctionComponent = (): JSX.Element => {
   }>();
   const location = useLocation();
   const notification = useNotification();
-  const { namespace } = useAdminSubappContext();
   const {
     params: { orgLabel, projectLabel, viewId },
   } = match;

--- a/src/subapps/admin/views/SparqlQueryView.tsx
+++ b/src/subapps/admin/views/SparqlQueryView.tsx
@@ -5,7 +5,6 @@ import { ViewList, DEFAULT_SPARQL_VIEW_ID } from '@bbp/nexus-sdk';
 import { useNexusContext } from '@bbp/react-nexus';
 
 import SparqlQueryContainer from '../containers/SparqlQuery';
-import { useAdminSubappContext } from '..';
 import useNotification from '../../../shared/hooks/useNotification';
 
 const SparqlQueryView: React.FunctionComponent = (): JSX.Element => {

--- a/src/subapps/admin/views/SparqlQueryView.tsx
+++ b/src/subapps/admin/views/SparqlQueryView.tsx
@@ -73,33 +73,6 @@ const SparqlQueryView: React.FunctionComponent = (): JSX.Element => {
 
   return (
     <>
-      <div className="project-banner no-bg" style={{ marginBottom: 20 }}>
-        <div className="label">
-          <h1 className="name">
-            <span>
-              <Link to={`/${namespace}/${orgLabel}`}>{orgLabel}</Link>
-              {' | '}
-              <Link to={`/${namespace}/${orgLabel}/${projectLabel}`}>
-                {projectLabel}
-              </Link>
-              {' | '}
-            </span>
-            <Dropdown overlay={menu}>
-              <span>
-                {labelOf(decodedViewId)}
-                <DownOutlined />
-              </span>
-            </Dropdown>{' '}
-          </h1>
-          <div style={{ marginLeft: 10 }}>
-            <ViewStatisticsProgress
-              orgLabel={orgLabel}
-              projectLabel={projectLabel}
-              resourceId={viewId}
-            />
-          </div>
-        </div>
-      </div>
       <div className="view-view view-container -unconstrained-width">
         <SparqlQueryContainer
           orgLabel={orgLabel}

--- a/src/subapps/admin/views/SparqlQueryView.tsx
+++ b/src/subapps/admin/views/SparqlQueryView.tsx
@@ -56,6 +56,9 @@ const SparqlQueryView: React.FunctionComponent = (): JSX.Element => {
           .includes('elastic')
           ? '_search'
           : 'sparql';
+
+        console.log('encodeURIComponent');
+        console.log(encodeURIComponent(view['@id']));
         return (
           <Menu.Item key={index}>
             <Link

--- a/src/subapps/admin/views/SparqlQueryView.tsx
+++ b/src/subapps/admin/views/SparqlQueryView.tsx
@@ -2,14 +2,12 @@ import * as React from 'react';
 import { useLocation, useRouteMatch } from 'react-router';
 import { Link } from 'react-router-dom';
 import * as queryString from 'query-string';
-import { Menu, Dropdown } from 'antd';
-import { DownOutlined } from '@ant-design/icons';
+import { Menu } from 'antd';
 import { ViewList, View, DEFAULT_SPARQL_VIEW_ID } from '@bbp/nexus-sdk';
 import { useNexusContext } from '@bbp/react-nexus';
 
-import ViewStatisticsProgress from '../components/Views/ViewStatisticsProgress';
 import SparqlQueryContainer from '../containers/SparqlQuery';
-import { getResourceLabel, labelOf } from '../../../shared/utils';
+import { getResourceLabel } from '../../../shared/utils';
 import { useAdminSubappContext } from '..';
 import useNotification from '../../../shared/hooks/useNotification';
 
@@ -26,13 +24,12 @@ const SparqlQueryView: React.FunctionComponent = (): JSX.Element => {
     params: { orgLabel, projectLabel, viewId },
   } = match;
 
-  const [{ _results: views }, setViews] = React.useState<ViewList>({
+  const [, setViews] = React.useState<ViewList>({
     '@context': {},
     _total: 0,
     _results: [],
   });
   const nexus = useNexusContext();
-  const decodedViewId = decodeURIComponent(viewId);
   const query = queryString.parse(location.search).query;
 
   React.useEffect(() => {
@@ -45,33 +42,6 @@ const SparqlQueryView: React.FunctionComponent = (): JSX.Element => {
         });
       });
   }, [orgLabel, projectLabel]);
-
-  const menu = (
-    <Menu>
-      {views.map((view: View, index: number) => {
-        const stringifiedViewType = Array.isArray(view['@type'])
-          ? view['@type'].join('')
-          : view['@type'];
-        const pathAppendage = (stringifiedViewType || '')
-          .toLowerCase()
-          .includes('elastic')
-          ? '_search'
-          : 'sparql';
-
-        return (
-          <Menu.Item key={index}>
-            <Link
-              to={`/${namespace}/${orgLabel}/${projectLabel}/${encodeURIComponent(
-                view['@id']
-              )}/${pathAppendage}`}
-            >
-              {getResourceLabel(view)}
-            </Link>
-          </Menu.Item>
-        );
-      })}
-    </Menu>
-  );
 
   return (
     <>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #

## Description

Updated the project admin view to include a few more options. Permissions are now combined with settings (previously only accessible from projects list view).
Statistics and Querying is also now in a separate tab and does not follow an external link.
Studios, Workflow links are embedded in the tab layout but go to the original page via new browser tab.
Create upload moved to new tab, no changes to component.

## How has this been tested?

Dev and local environment using the compositepoc org and all of the projects within it. 
I have removed the banners from the query, stats, settings components because it is now redundant.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ x] I have added screenshots (if applicable), in the comment section.
