### PR TITLE
Prevent search table header controls from overflowing onto new line

### DIFF
--- a/src/subapps/search/containers/SearchContainer.less
+++ b/src/subapps/search/containers/SearchContainer.less
@@ -14,6 +14,11 @@
 
   &__paginator {
     margin-left: auto !important;
+    flex-shrink: 0;
+  }
+
+  &__options {
+    flex-shrink: 0;
   }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes https://github.com/BlueBrain/nexus/issues/2931

## Description

<!--- Describe your changes in detail -->
Prevent search header options and pagination overflowing onto new line and looking weird when browser window width reduced such that there isn't enough room for all controls.

<img width="860" alt="Screenshot 2021-11-04 at 13 58 56" src="https://user-images.githubusercontent.com/11296166/140319438-b72a856f-32a4-49eb-9b07-4becb18df08c.png">

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested in Chrome

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
