### PR TITLE
2932 Prevent Resource side drawer from closing when it shouldn't

### DIFF
--- a/src/shared/views/GalleryView.less
+++ b/src/shared/views/GalleryView.less
@@ -1,13 +1,15 @@
 @import '~antd/dist/antd.less';
 
-.ant-drawer-left.ant-drawer-open,
-.ant-drawer-right.ant-drawer-open {
-  width: 60% !important;
-  margin-top: 52px; // do not overlay app header
-}
-@media only screen and (max-width: @screen-sm-max) {
-  .ant-drawer-left.ant-drawer-open,
-  .ant-drawer-right.ant-drawer-open {
-    width: 100% !important;
+.gallery-drawer {
+  &.ant-drawer-left.ant-drawer-open,
+  &.ant-drawer-right.ant-drawer-open {
+    width: 60% !important;
+    margin-top: 52px; // do not overlay app header
+  }
+  @media only screen and (max-width: @screen-sm-max) {
+    &.ant-drawer-left.ant-drawer-open,
+    &.ant-drawer-right.ant-drawer-open {
+      width: 100% !important;
+    }
   }
 }

--- a/src/shared/views/GalleryView.tsx
+++ b/src/shared/views/GalleryView.tsx
@@ -71,12 +71,12 @@ const GalleryView: React.FC = () => {
         const currentWrapperRef = wrapperRef.current;
 
         if (
-          event.target &&
-          !currentWrapperRef.contains(event.target as Node) &&
+          (event.target &&
+            !currentWrapperRef.contains(event.target as Node) &&
+            // @ts-ignore
+            event.target.closest('#app')) ||
           // @ts-ignore
-          event.target.getAttribute('role') !== 'menuitem' &&
-          // @ts-ignore
-          !event.target.parentNode.classList.contains('ant-btn')
+          event.target.closest('.ant-drawer-close')
         ) {
           // @ts-ignore
           history.push(`${background.pathname}${background.search}`, {
@@ -109,6 +109,7 @@ const GalleryView: React.FC = () => {
           render={routeProps =>
             drawerVisible && (
               <Drawer
+                className="gallery-drawer"
                 maskClosable={false}
                 destroyOnClose={false}
                 visible={true}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes https://github.com/BlueBrain/nexus/issues/2932

## Description

<!--- Describe your changes in detail -->
Fix bug where clicking on some ui elements within resource view results in the side drawer closing unexpectedly.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested with various resources and various plugins.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
