### PR TITLE
Changing filter value triggers on finish automatically vs apply button

### DIFF
--- a/src/subapps/search/containers/FilterOptions.less
+++ b/src/subapps/search/containers/FilterOptions.less
@@ -2,6 +2,10 @@
   width: 100%;
 }
 
+.ant-form-item {
+	max-height:182px !important;
+}
+
 .filter-value-row {
   display: 'flex';
   flex-wrap: wrap;

--- a/src/subapps/search/containers/FilterOptions.less
+++ b/src/subapps/search/containers/FilterOptions.less
@@ -4,13 +4,13 @@
 
 .filter-value-row {
   display: 'flex';
-	flex-wrap: wrap;
+  flex-wrap: wrap;
 
   &__chk {
-		flex: 1;
+    flex: 1;
   }
 
   &__count {
-    margin-left: auto;
+    float: right;
   }
 }

--- a/src/subapps/search/containers/FilterOptions.less
+++ b/src/subapps/search/containers/FilterOptions.less
@@ -3,7 +3,7 @@
 }
 
 .ant-form-item {
-	max-height:182px !important;
+  max-height: 182px !important;
 }
 
 .filter-value-row {

--- a/src/subapps/search/containers/FilterOptions.less
+++ b/src/subapps/search/containers/FilterOptions.less
@@ -4,9 +4,10 @@
 
 .filter-value-row {
   display: 'flex';
+	flex-wrap: wrap;
 
   &__chk {
-    width: 240px;
+		flex: 1;
   }
 
   &__count {

--- a/src/subapps/search/containers/FilterOptions.tsx
+++ b/src/subapps/search/containers/FilterOptions.tsx
@@ -164,20 +164,7 @@ const FilterOptions: React.FC<{
   );
 
   return (
-    <Form
-      form={form}
-      onFinish={(values: any) => {
-        onFinish({
-          filterType,
-          filters:
-            filterType === 'missing'
-              ? []
-              : aggregations.filter(a => a.selected).map(a => a.filterValue),
-          filterTerm: filterKeyWord,
-        });
-      }}
-      className="field-filter-menu"
-    >
+    <Form form={form} className="field-filter-menu">
       <Form.Item
         label="Operator"
         rules={[

--- a/src/subapps/search/containers/FilterOptions.tsx
+++ b/src/subapps/search/containers/FilterOptions.tsx
@@ -62,14 +62,6 @@ const FilterOptions: React.FC<{
     }[]
   >([]);
 
-  React.useEffect(() => {
-    onFinish({
-      filterType,
-      filters: aggregations.filter(a => a.selected).map(a => a.filterValue),
-      filterTerm: filterKeyWord,
-    });
-  }, [aggregations]);
-
   const filterTypeDefault = () => {
     if (fieldFilter?.filterType) {
       return fieldFilter?.filterType;
@@ -86,6 +78,7 @@ const FilterOptions: React.FC<{
     const selectedFilters = aggregations
       .filter(a => a.selected)
       .map(a => a.filterValue);
+
     if (selectedFilters.length > 0) {
       onFinish({
         filterType,
@@ -93,7 +86,7 @@ const FilterOptions: React.FC<{
         filterTerm: filterKeyWord,
       });
     }
-  }, [filterType]);
+  }, [aggregations, filterType]);
 
   React.useEffect(() => {
     const allSuggestions = constructQuery(query)

--- a/src/subapps/search/containers/FilterOptions.tsx
+++ b/src/subapps/search/containers/FilterOptions.tsx
@@ -1,4 +1,4 @@
-import { Form, Select, Checkbox, Button, Row, Input } from 'antd';
+import { Form, Select, Checkbox, Row, Input } from 'antd';
 import { labelOf } from '../../../shared/utils';
 import { NexusClient } from '@bbp/nexus-sdk';
 import * as React from 'react';

--- a/src/subapps/search/containers/FilterOptions.tsx
+++ b/src/subapps/search/containers/FilterOptions.tsx
@@ -186,7 +186,6 @@ const FilterOptions: React.FC<{
           )}
         </Select>
       </Form.Item>
-<<<<<<< HEAD
       {filterType !== 'missing' && (
         <>
           <Input.Search
@@ -211,31 +210,6 @@ const FilterOptions: React.FC<{
           </Form.Item>
         </>
       )}
-      <Form.Item>
-        <Button type="primary" htmlType="submit">
-          Apply
-        </Button>
-      </Form.Item>
-=======
-      <Input.Search
-        onChange={event => {
-          const val = event.target.value;
-
-          const filteredSuggestions = aggregations.map(a => ({
-            ...a,
-            matching:
-              val && val.length > 0
-                ? a.filterValue.toLowerCase().indexOf(val.toLowerCase()) > -1
-                : true,
-          }));
-          setAggregations(filteredSuggestions);
-        }}
-      ></Input.Search>
-      <Form.Item style={{ maxHeight: '91px', overflow: 'scroll' }}>
-        {filterValues}
-      </Form.Item>
-      <Form.Item></Form.Item>
->>>>>>> 78c9962... removed button
     </Form>
   );
 };

--- a/src/subapps/search/containers/FilterOptions.tsx
+++ b/src/subapps/search/containers/FilterOptions.tsx
@@ -81,6 +81,20 @@ const FilterOptions: React.FC<{
   const [form] = Form.useForm();
 
   const filterKeyWord = createKeyWord(field);
+
+  React.useEffect(() => {
+    const selectedFilters = aggregations
+      .filter(a => a.selected)
+      .map(a => a.filterValue);
+    if (selectedFilters.length > 0) {
+      onFinish({
+        filterType,
+        filters: selectedFilters,
+        filterTerm: filterKeyWord,
+      });
+    }
+  }, [filterType]);
+
   React.useEffect(() => {
     const allSuggestions = constructQuery(query)
       .aggregation('terms', filterKeyWord, 'suggestions', { size: 1000 })

--- a/src/subapps/search/containers/FilterOptions.tsx
+++ b/src/subapps/search/containers/FilterOptions.tsx
@@ -62,6 +62,14 @@ const FilterOptions: React.FC<{
     }[]
   >([]);
 
+  React.useEffect(() => {
+    onFinish({
+      filterType,
+      filters: aggregations.filter(a => a.selected).map(a => a.filterValue),
+      filterTerm: filterKeyWord,
+    });
+  }, [aggregations]);
+
   const filterTypeDefault = () => {
     if (fieldFilter?.filterType) {
       return fieldFilter?.filterType;

--- a/src/subapps/search/containers/FilterOptions.tsx
+++ b/src/subapps/search/containers/FilterOptions.tsx
@@ -186,6 +186,7 @@ const FilterOptions: React.FC<{
           )}
         </Select>
       </Form.Item>
+<<<<<<< HEAD
       {filterType !== 'missing' && (
         <>
           <Input.Search
@@ -215,6 +216,26 @@ const FilterOptions: React.FC<{
           Apply
         </Button>
       </Form.Item>
+=======
+      <Input.Search
+        onChange={event => {
+          const val = event.target.value;
+
+          const filteredSuggestions = aggregations.map(a => ({
+            ...a,
+            matching:
+              val && val.length > 0
+                ? a.filterValue.toLowerCase().indexOf(val.toLowerCase()) > -1
+                : true,
+          }));
+          setAggregations(filteredSuggestions);
+        }}
+      ></Input.Search>
+      <Form.Item style={{ maxHeight: '91px', overflow: 'scroll' }}>
+        {filterValues}
+      </Form.Item>
+      <Form.Item></Form.Item>
+>>>>>>> 78c9962... removed button
     </Form>
   );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
![Screenshot 2021-11-08 at 13 08 23](https://user-images.githubusercontent.com/1838164/140739468-2ed518f9-379a-44e7-bff4-a2298ebbfb30.png)


Fixes #
Search view's filter component used to trigger changes when 'apply' button was clicked. Now changes are triggered on changes to filter component.
Also, adjusted styles so count is far right aligned on the same row.

## Description

<!--- Describe your changes in detail -->

## How has this been tested?
Tested by using relevant part of application
<!--- Please describe in detail how you tested your changes. -->
Local developer environment using dev.nexus elastic search endpoints.
<!--- Include details of your testing environment, tests ran to see how -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [x ] I have added screenshots (if applicable), in the comment section.
