### PR TITLE
Switch logic - multi-value field has and, single-valued not

### DIFF
--- a/src/subapps/search/containers/FilterOptions.tsx
+++ b/src/subapps/search/containers/FilterOptions.tsx
@@ -66,7 +66,7 @@ const FilterOptions: React.FC<{
     if (fieldFilter?.filterType) {
       return fieldFilter?.filterType;
     }
-    return field.array ? 'anyof' : 'allof';
+    return 'anyof';
   };
   const [filterType, setFilterType] = React.useState(filterTypeDefault);
 
@@ -189,14 +189,14 @@ const FilterOptions: React.FC<{
           value={filterType}
           onChange={v => setFilterType(v)}
         >
-          {!field.array ? (
+          {field.array && (
             <Select.Option value="allof">is all of (AND)</Select.Option>
-          ) : null}
+          )}
           <Select.Option value="anyof">is any of (OR)</Select.Option>
           <Select.Option value="noneof">is none of (NOT)</Select.Option>
-          {field.optional ? (
+          {field.optional && (
             <Select.Option value="missing">is missing</Select.Option>
-          ) : null}
+          )}
         </Select>
       </Form.Item>
       {filterType !== 'missing' && (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes https://github.com/BlueBrain/nexus/issues/2940

## Description

<!--- Describe your changes in detail -->
Multi-value fields have and operator, single-valued fields do not. Default to 'any of' operator

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested expected behaviour in Chrome.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
