### PR TITLE
Use Resource end point for studio listing

### DIFF
--- a/src/subapps/studioLegacy/studio.less
+++ b/src/subapps/studioLegacy/studio.less
@@ -1,3 +1,5 @@
+@import '../../shared/lib.less';
+
 .studio-header {
   max-width: 600px;
   display: flex;
@@ -19,7 +21,7 @@
   margin: 0 auto;
   .studio-list-item {
     list-style: none;
-    background-color: #f2f2f2;
+    background-color: @fusion-component-background-color;
     border-radius: 2px;
     cursor: pointer;
     margin: 2em 0;
@@ -30,7 +32,7 @@
     .studio {
       font-weight: 900;
       .studio-name {
-        color: #0083cb;
+        color: @fusion-primary-color;
       }
     }
   }

--- a/src/subapps/studioLegacy/studio.less
+++ b/src/subapps/studioLegacy/studio.less
@@ -1,0 +1,37 @@
+.studio-header {
+  max-width: 600px;
+  display: flex;
+  margin-bottom: 2px;
+  h1 {
+    max-width: 200px;
+  }
+  .studio-search {
+    max-width: 400px;
+  }
+}
+.studio-description {
+  width: 600px;
+}
+
+.studio-list {
+  padding: 2em 1rem;
+  max-width: 600px;
+  margin: 0 auto;
+  .studio-list-item {
+    list-style: none;
+    background-color: #f2f2f2;
+    border-radius: 2px;
+    cursor: pointer;
+    margin: 2em 0;
+    padding: 0.5em;
+    position: relative;
+    justify-content: space-between;
+    max-width: 100%;
+    .studio {
+      font-weight: 900;
+      .studio-name {
+        color: #0083cb;
+      }
+    }
+  }
+}

--- a/src/subapps/studioLegacy/views/StudioListView.tsx
+++ b/src/subapps/studioLegacy/views/StudioListView.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { useNexusContext } from '@bbp/react-nexus';
-import { Spin, Empty, List, Input } from 'antd';
+import { Spin, List, Input } from 'antd';
 import { useHistory } from 'react-router-dom';
 import { useQuery } from 'react-query';
 import { getOrgAndProjectFromProjectId } from '../../../shared/utils';
 import '../studio.less';
-import { classNames } from 'react-mde/lib/definitions/util/ClassNames';
+
 const DEFAULT_STUDIO_TYPE =
   'https://bluebrainnexus.io/studio/vocabulary/Studio';
 const STUDIO_RESULTS_DEFAULT_SIZE = 1000;
@@ -57,7 +57,7 @@ const StudioListView: React.FC = () => {
 
   React.useEffect(() => {
     if (data) {
-      const list: StudioItem[] = data?._results
+      const list: StudioItem[] = data._results
         .map(r => {
           const labels = getOrgAndProjectFromProjectId(r._project);
           return {

--- a/src/subapps/studioLegacy/views/StudioListView.tsx
+++ b/src/subapps/studioLegacy/views/StudioListView.tsx
@@ -101,9 +101,6 @@ const StudioListView: React.FC = () => {
             <List
               pagination={{
                 total: studioList.length,
-                onChange: page => {
-                  console.log(page);
-                },
                 showTotal: total => ` ${total} results`,
                 pageSize: 10,
               }}

--- a/src/subapps/studioLegacy/views/StudioListView.tsx
+++ b/src/subapps/studioLegacy/views/StudioListView.tsx
@@ -1,31 +1,29 @@
 import * as React from 'react';
 import { useNexusContext } from '@bbp/react-nexus';
-import { Spin, Empty } from 'antd';
-import { useSelector } from 'react-redux';
+import { Spin, Empty, List, Input } from 'antd';
 import { useHistory } from 'react-router-dom';
-
-import { RootState } from '../../../shared/store/reducers';
-import ExpandableStudioList from '../components/ExpandableStudioList';
+import { useQuery } from 'react-query';
 import { getOrgAndProjectFromProjectId } from '../../../shared/utils';
-
+import '../studio.less';
+import { classNames } from 'react-mde/lib/definitions/util/ClassNames';
 const DEFAULT_STUDIO_TYPE =
   'https://bluebrainnexus.io/studio/vocabulary/Studio';
+const STUDIO_RESULTS_DEFAULT_SIZE = 1000;
 
-const ES_QUERY = {
-  from: 0,
-  size: 100,
-  query: {
-    bool: {
-      must: [
-        {
-          term: { _deprecated: false },
-        },
-        {
-          term: { '@type': DEFAULT_STUDIO_TYPE },
-        },
-      ],
-    },
-  },
+/*
+ * Returns studio uri
+ *
+ * @param {string} orgLabel
+ * @param {string} projectLabel
+ * @param {string} studioId
+ * @returns {string} studio uri
+ */
+export const makeStudioUri = (
+  orgLabel: string,
+  projectLabel: string,
+  studioId: string
+) => {
+  return `/${orgLabel}/${projectLabel}/studios/${encodeURIComponent(studioId)}`;
 };
 
 export type StudioItem = {
@@ -38,111 +36,116 @@ export type StudioItem = {
 };
 
 const StudioListView: React.FC = () => {
-  const studioView = useSelector((state: RootState) => state.config.studioView);
   const nexus = useNexusContext();
   const history = useHistory();
+  const [studioList, setStudioList] = React.useState<StudioItem[]>([]);
+  const [searchFilter, setSearchFilter] = React.useState<string>('');
 
-  const [{ busy, error, studios, total }, setStudios] = React.useState<{
-    busy: boolean;
-    error: Error | null;
-    studios: StudioItem[];
-    total: number;
-  }>({
-    busy: false,
-    error: null,
-    studios: [],
-    total: 0,
+  const fetchStudios = async () =>
+    nexus.Resource.list(undefined, undefined, {
+      size: STUDIO_RESULTS_DEFAULT_SIZE,
+      deprecated: false,
+      type: DEFAULT_STUDIO_TYPE,
+    });
+
+  const { data, status } = useQuery({
+    queryKey: 'studios',
+    queryFn: fetchStudios,
+    enabled: true,
+    retry: 2,
   });
 
   React.useEffect(() => {
-    if (studioView && studioView !== '') {
-      setStudios({
-        total: 0,
-        busy: true,
-        error: null,
-        studios: [],
-      });
-      const studioPath = studioView && studioView.split('/');
-      const [studiosOrg, studiosProject, studiosView] = studioPath;
-
-      nexus.View.elasticSearchQuery(
-        studiosOrg,
-        studiosProject,
-        studiosView,
-        ES_QUERY
-      )
-        .then(response => {
-          const total = response.hits.total.value;
-          const studioList = parseStudiosFromES(response);
-
-          setStudios({
-            total,
-            busy: false,
-            error: null,
-            studios: studioList,
-          });
+    if (data) {
+      const list: StudioItem[] = data?._results
+        .map(r => {
+          const labels = getOrgAndProjectFromProjectId(r._project);
+          return {
+            id: r['@id'],
+            label: r.label,
+            description: r.description,
+            projectLabel: labels.projectLabel,
+            orgLabel: labels.orgLabel,
+          };
         })
-        .catch(error => {
-          setStudios({
-            error,
-            busy: false,
-            studios: [],
-            total: 0,
-          });
-        });
-    } else {
-    }
-  }, []);
-
-  const parseStudiosFromES = (response: any) => {
-    const results = response.hits;
-
-    if (results && results.hits && results.hits.length) {
-      return results.hits.map((studio: any) => {
-        const source = JSON.parse(studio._source._original_source || {});
-        const { orgLabel, projectLabel } = getOrgAndProjectFromProjectId(
-          studio._source._project
+        .filter(
+          s =>
+            s.label.toLowerCase().includes(searchFilter) ||
+            s.orgLabel.includes(searchFilter) ||
+            s.projectLabel.includes(searchFilter)
         );
-        const { label, description, workspaces } = source;
-
-        return {
-          label,
-          description,
-          workspaces,
-          orgLabel,
-          projectLabel,
-          id: studio._id,
-        };
-      });
+      setStudioList(list);
     }
-  };
-
+    return () => {
+      // do nothing
+    };
+  }, [data, searchFilter]);
   const goToStudio = (studioUrl: string) => {
     history.push(studioUrl);
   };
 
-  if (studioView === '') {
-    return (
-      <div className="view-container">
-        <div className="global-studio-list">
-          <h1>Studios</h1>
-          <Empty description="There is no Studio list configured. Please contact your administrator." />
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div className="view-container">
       <div className="global-studio-list">
-        <h1>Studios</h1>
-        <Spin spinning={busy}>
-          <ExpandableStudioList
-            studios={studios}
-            error={error}
-            goToStudio={goToStudio}
-          />
-        </Spin>
+        <div className={'studio-header'}>
+          <h1>Studios</h1>
+          <Input.Search
+            className={'studio-search'}
+            placeholder={'Type to filter'}
+            onChange={e => {
+              setSearchFilter(e.target.value.toLowerCase());
+            }}
+          ></Input.Search>
+        </div>
+        <div className={'studio-description'}>
+          <p>
+            You can see all the studios in Nexus projects where you have read
+            access. The list is alphabetically sorted.
+          </p>
+        </div>
+        {status === 'error' ? (
+          <>A Error Occured</>
+        ) : (
+          <Spin
+            spinning={status === 'loading'}
+            size={'large'}
+            style={{ display: 'flex' }}
+          >
+            <List
+              pagination={{
+                total: studioList.length,
+                onChange: page => {
+                  console.log(page);
+                },
+                showTotal: total => ` ${total} results`,
+                pageSize: 10,
+              }}
+              className={'studio-list'}
+              dataSource={studioList}
+              renderItem={item => {
+                return (
+                  <List.Item
+                    onClick={() => {
+                      const { orgLabel, projectLabel, id } = item;
+                      const studioUri = makeStudioUri(
+                        orgLabel,
+                        projectLabel,
+                        id
+                      );
+                      goToStudio(studioUri);
+                    }}
+                    className={'studio-list-item'}
+                  >
+                    <div className={'studio'}>
+                      {`${item.orgLabel}/${item.projectLabel}/`}
+                      <span className={'studio-name'}>{item.label}</span>
+                    </div>
+                  </List.Item>
+                );
+              }}
+            ></List>
+          </Spin>
+        )}
       </div>
     </div>
   );

--- a/src/subapps/studioLegacy/views/StudioListView.tsx
+++ b/src/subapps/studioLegacy/views/StudioListView.tsx
@@ -3,28 +3,15 @@ import { useNexusContext } from '@bbp/react-nexus';
 import { Spin, List, Input } from 'antd';
 import { useHistory } from 'react-router-dom';
 import { useQuery } from 'react-query';
-import { getOrgAndProjectFromProjectId } from '../../../shared/utils';
+import {
+  getOrgAndProjectFromProjectId,
+  makeStudioUri,
+} from '../../../shared/utils';
 import '../studio.less';
 
 const DEFAULT_STUDIO_TYPE =
   'https://bluebrainnexus.io/studio/vocabulary/Studio';
 const STUDIO_RESULTS_DEFAULT_SIZE = 1000;
-
-/*
- * Returns studio uri
- *
- * @param {string} orgLabel
- * @param {string} projectLabel
- * @param {string} studioId
- * @returns {string} studio uri
- */
-export const makeStudioUri = (
-  orgLabel: string,
-  projectLabel: string,
-  studioId: string
-) => {
-  return `/${orgLabel}/${projectLabel}/studios/${encodeURIComponent(studioId)}`;
-};
 
 export type StudioItem = {
   id: string;


### PR DESCRIPTION
Use resouce end point to fetch the global list of studios.

<!--- Provide a general summary of your changes in the Title above -->

Fixes #BlueBrain/nexus/issues/2548

## Description

<!--- Describe your changes in detail -->

## How has this been tested?
Manual. /studios path should display studios as seen in the mocks.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [x] I have added screenshots (if applicable), in the comment section.
