### PR TITLE
PDF Viewer not loading fix

### DIFF
--- a/src/shared/components/Preview/PDFPreview.tsx
+++ b/src/shared/components/Preview/PDFPreview.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { Button } from 'antd';
-import { Document, Page } from 'react-pdf/dist/esm/entry.webpack';
+import { Document, Page, pdfjs } from 'react-pdf/dist/esm/entry.webpack';
+pdfjs.GlobalWorkerOptions.workerSrc = 'public/pdf.worker.min.js';
+
 import './PDFPreview.less';
 import {
   LeftOutlined,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -53,12 +53,22 @@ const config = [
           ],
         },
         {
-          test: /\.(jpg|png|svg|ttf)$/,
+          test: /\.(jpg|png|svg)$/,
           use: {
             loader: 'file-loader',
             options: {
               outputPath: 'assets/',
               publicPath: 'public/assets/',
+            },
+          },
+        },
+        {
+          test: /\.(ttf)$/,
+          use: {
+            loader: 'file-loader',
+            options: {
+              outputPath: 'assets/',
+              publicPath: 'assets/',
             },
           },
         },
@@ -103,7 +113,7 @@ const config = [
           loader: 'null-loader',
         },
         {
-          test: /\.(jpg|png|svg|ttf)$/,
+          test: /\.(jpg|png|svg)$/,
           use: {
             loader: 'file-loader',
             options: {
@@ -126,6 +136,10 @@ const config = [
             from: 'plugins/',
             to: 'public/plugins/',
             ignore: ['.gitkeep'],
+          },
+          {
+            from: 'node_modules/pdfjs-dist/build/pdf.worker.min.js',
+            to: 'public/pdf.worker.min.js',
           },
         ],
         { debug: true }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes https://github.com/BlueBrain/nexus/issues/2969

## Description

<!--- Describe your changes in detail -->
PDF viewer was only working in dev. In dev/staging/production the pdf worker file could not be found.

Changed webpack config to copy pdfjs worker file to public directory. Specify this path for the worker.
Also specify ttf font file type separately to fix issue where path included public/public

## How has this been tested?

Built for production and hosted locally to test. Confirmed the pdf worker file now loads and the pdf viewer works as expected.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
