### PR TITLE
Persist open/close state of plugins

### DIFF
--- a/src/shared/components/Preview/Preview.tsx
+++ b/src/shared/components/Preview/Preview.tsx
@@ -39,7 +39,14 @@ const isSupportedFile = (asset: any) =>
 const Preview: React.FC<{
   resource: Resource;
   nexus: NexusClient;
-}> = ({ resource, nexus }) => {
+  collapsed: boolean;
+  handleCollapseChanged: () => void;
+}> = ({
+  resource,
+  nexus,
+  collapsed,
+  handleCollapseChanged: handleCollapsedChanged,
+}) => {
   const notification = useNotification();
   const [previewAsset, setPreviewAsset] = React.useState<any | undefined>();
   const [orgLabel, projectLabel] = parseProjectUrl(resource._project);
@@ -199,8 +206,11 @@ const Preview: React.FC<{
           onClickClose={() => setPreviewAsset(undefined)}
         />
       )}
-      <Collapse onChange={() => {}}>
-        <Collapse.Panel header="Preview" key="99">
+      <Collapse
+        onChange={handleCollapsedChanged}
+        activeKey={collapsed ? 'preview' : undefined}
+      >
+        <Collapse.Panel header="Preview" key="preview">
           <Table
             columns={columns}
             dataSource={getResourceAssets(resource)}

--- a/src/shared/containers/AdminPluginContainer.tsx
+++ b/src/shared/containers/AdminPluginContainer.tsx
@@ -38,6 +38,8 @@ type AdminProps = {
   handleEditFormSubmit: (value: any) => void;
   handleExpanded: (expanded: boolean) => void;
   refreshResource: () => void;
+  collapsed: boolean;
+  handleCollapseChanged: () => void;
 };
 
 const AdminPlugin: React.FunctionComponent<AdminProps> = ({
@@ -56,6 +58,8 @@ const AdminPlugin: React.FunctionComponent<AdminProps> = ({
   handleEditFormSubmit,
   handleExpanded,
   refreshResource,
+  collapsed,
+  handleCollapseChanged,
 }) => {
   const [tabChange, setTabChange] = React.useState<boolean>(false);
 
@@ -66,8 +70,11 @@ const AdminPlugin: React.FunctionComponent<AdminProps> = ({
   };
 
   return (
-    <Collapse onChange={() => {}}>
-      <Panel header="Advanced View" key="1">
+    <Collapse
+      onChange={handleCollapseChanged}
+      activeKey={collapsed ? 'admin' : undefined}
+    >
+      <Panel header="Advanced View" key="admin">
         <AccessControl
           path={`/${orgLabel}/${projectLabel}`}
           permissions={['resources/write']}

--- a/src/shared/containers/ResourcePlugins.tsx
+++ b/src/shared/containers/ResourcePlugins.tsx
@@ -13,7 +13,15 @@ const ResourcePlugins: React.FunctionComponent<{
   resource?: Resource;
   goToResource?: (selfURL: string) => void;
   empty?: React.ReactElement;
-}> = ({ resource, goToResource, empty = null }) => {
+  openPlugins: string[];
+  handleCollapseChange: (pluginName: string) => void;
+}> = ({
+  resource,
+  goToResource,
+  empty = null,
+  openPlugins,
+  handleCollapseChange,
+}) => {
   const nexus = useNexusContext();
   const { data: pluginManifest } = usePlugins();
   const availablePlugins = Object.keys(pluginManifest || {});
@@ -54,27 +62,40 @@ const ResourcePlugins: React.FunctionComponent<{
     : [];
 
   return filteredPlugins && filteredPlugins.length > 0 ? (
-    <Collapse onChange={() => {}}>
+    <>
       {pluginDataMap.map((pluginData, index) => {
         return pluginData ? (
-          <Panel
-            header={pluginData.name}
-            key={(index + 1).toString()}
-            extra={<PluginInfo plugin={pluginData} />}
+          <Collapse
+            key={pluginData.name}
+            onChange={e => handleCollapseChange(pluginData.name)}
+            activeKey={
+              openPlugins.includes(pluginData.name)
+                ? pluginData.name
+                : undefined
+            }
           >
-            <div className="resource-plugin" key={`plugin-${pluginData.name}`}>
-              <NexusPlugin
-                nexusClient={nexus}
-                url={pluginData.absoluteModulePath}
-                pluginName={pluginData.name}
-                resource={resource}
-                goToResource={goToResource}
-              />
-            </div>
-          </Panel>
+            <Panel
+              header={pluginData.name}
+              key={`${pluginData.name}`}
+              extra={<PluginInfo plugin={pluginData} />}
+            >
+              <div
+                className="resource-plugin"
+                key={`plugin-${pluginData.name}`}
+              >
+                <NexusPlugin
+                  nexusClient={nexus}
+                  url={pluginData.absoluteModulePath}
+                  pluginName={pluginData.name}
+                  resource={resource}
+                  goToResource={goToResource}
+                />
+              </div>
+            </Panel>
+          </Collapse>
         ) : null;
       })}
-    </Collapse>
+    </>
   ) : (
     empty
   );

--- a/src/shared/containers/ResourceViewContainer.tsx
+++ b/src/shared/containers/ResourceViewContainer.tsx
@@ -310,6 +310,37 @@ const ResourceViewContainer: React.FunctionComponent<{
     setResources();
   }, [orgLabel, projectLabel, resourceId, rev, tag]);
 
+  const [openPlugins, setOpenPlugins] = React.useState<string[]>([]);
+
+  const LOCAL_STORAGE_EXPANDED_PLUGINS_KEY_NAME = 'expanded_plugins';
+
+  React.useEffect(() => {
+    if (localStorage.getItem(LOCAL_STORAGE_EXPANDED_PLUGINS_KEY_NAME)) {
+      setOpenPlugins(
+        JSON.parse(
+          localStorage.getItem(
+            LOCAL_STORAGE_EXPANDED_PLUGINS_KEY_NAME
+          ) as string
+        )
+      );
+    }
+  }, []);
+
+  React.useEffect(() => {
+    localStorage.setItem(
+      LOCAL_STORAGE_EXPANDED_PLUGINS_KEY_NAME,
+      JSON.stringify(openPlugins)
+    );
+  }, [openPlugins]);
+
+  const pluginCollapsedToggle = (pluginName: string) => {
+    setOpenPlugins(
+      openPlugins.includes(pluginName)
+        ? openPlugins.filter(p => p !== pluginName)
+        : [...openPlugins, pluginName]
+    );
+  };
+
   return (
     <>
       <div className="resource-details">
@@ -436,6 +467,10 @@ const ResourceViewContainer: React.FunctionComponent<{
                 <ResourcePlugins
                   resource={resource}
                   goToResource={goToSelfResource}
+                  openPlugins={openPlugins}
+                  handleCollapseChange={pluginName =>
+                    pluginCollapsedToggle(pluginName)
+                  }
                 />
               )}
 
@@ -450,7 +485,14 @@ const ResourceViewContainer: React.FunctionComponent<{
                   </p>
                 )}
               {resource.distribution && (
-                <Preview nexus={nexus} resource={resource} />
+                <Preview
+                  nexus={nexus}
+                  resource={resource}
+                  collapsed={openPlugins.includes('preview')}
+                  handleCollapseChanged={() => {
+                    pluginCollapsedToggle('preview');
+                  }}
+                />
               )}
               <AdminPlugin
                 editable={isLatest && !isDeprecated(resource)}
@@ -468,11 +510,19 @@ const ResourceViewContainer: React.FunctionComponent<{
                 handleEditFormSubmit={handleEditFormSubmit}
                 handleExpanded={handleExpanded}
                 refreshResource={refreshResource}
+                collapsed={openPlugins.includes('advanced')}
+                handleCollapseChanged={() => {
+                  pluginCollapsedToggle('advanced');
+                }}
               />
               <VideoPluginContainer
                 resource={resource}
                 orgLabel={orgLabel}
                 projectLabel={projectLabel}
+                collapsed={openPlugins.includes('video')}
+                handleCollapseChanged={() => {
+                  pluginCollapsedToggle('video');
+                }}
               />
             </>
           )}

--- a/src/shared/containers/VideoPluginContainer.tsx
+++ b/src/shared/containers/VideoPluginContainer.tsx
@@ -13,6 +13,8 @@ type VideoProps = {
   orgLabel: string;
   projectLabel: string;
   resource: Resource;
+  collapsed: boolean;
+  handleCollapseChanged: () => void;
 };
 
 type VideoObject = {
@@ -28,6 +30,8 @@ const VideoPluginContainer: React.FunctionComponent<VideoProps> = ({
   resource,
   orgLabel,
   projectLabel,
+  collapsed,
+  handleCollapseChanged,
 }) => {
   const nexus = useNexusContext();
   const [videoData, setVideoData] = React.useState<any>();
@@ -71,9 +75,12 @@ const VideoPluginContainer: React.FunctionComponent<VideoProps> = ({
 
   if (!videoData) return null;
   return (
-    <Collapse onChange={() => {}}>
+    <Collapse
+      activeKey={collapsed ? 'video' : undefined}
+      onChange={e => handleCollapseChanged()}
+    >
       {videoData[0] && videoData[0].embedUrl ? (
-        <Panel header="Video" key="1">
+        <Panel header="Video" key="video">
           <List
             itemLayout="horizontal"
             dataSource={videoData}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes https://github.com/BlueBrain/nexus/issues/2942

## Description

<!--- Describe your changes in detail -->
Persist open/close state of plugins in local storage. If a resource has a plugin open then viewing another resource will also show that plugin open (assuming it has the plugin), this applies to multiple too. Opening resources that do not have certain plugins with an open state won't have any effect, i.e. they will show as open on the next resource with that plugin.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
