### PR TITLE
1673 better error when try recreate deprecated org or project

### DIFF
--- a/src/shared/hooks/useNotification.ts
+++ b/src/shared/hooks/useNotification.ts
@@ -12,7 +12,7 @@ export const NotificationContext = React.createContext<NotificationContextType>(
   {} as NotificationContextType
 );
 
-type NexusError = {
+export type NexusError = {
   reason?: string;
   message?: string;
   [key: string]: any;

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -463,6 +463,16 @@ export const makeProjectUri = (orgLabel: string, projectLabel: string) => {
 };
 
 /*
+ * Returns organization uri
+ *
+ * @param {string} orgLabel
+ * @returns {string} organization uri
+ */
+export const makeOrganizationUri = (orgLabel: string) => {
+  return `/admin/${orgLabel}`;
+};
+
+/*
  * Returns search uri
  *
  * @param {string} searchQueryParam

--- a/src/subapps/admin/views/OrgsListView.tsx
+++ b/src/subapps/admin/views/OrgsListView.tsx
@@ -10,7 +10,9 @@ import OrgItem from '../components/Orgs/OrgItem';
 import ListItem from '../../../shared/components/List/Item';
 import { useHistory } from 'react-router';
 import { useAdminSubappContext } from '..';
-import useNotification from '../../../shared/hooks/useNotification';
+import useNotification, {
+  NexusError,
+} from '../../../shared/hooks/useNotification';
 
 const DEFAULT_PAGE_SIZE = 20;
 const SHOULD_INCLUDE_DEPRECATED = false;
@@ -82,11 +84,11 @@ const OrgsListView: React.FunctionComponent = () => {
         setFormBusy(false);
         goTo(newOrg.label);
       })
-      .catch((error: Error) => {
+      .catch((error: NexusError) => {
         setFormBusy(false);
         notification.error({
-          message: 'An unknown error occurred',
-          description: error.message,
+          message: 'Error creating organization',
+          description: error.reason,
         });
       });
   };

--- a/src/subapps/admin/views/ProjectView.tsx
+++ b/src/subapps/admin/views/ProjectView.tsx
@@ -19,11 +19,14 @@ import ResourceListBoardContainer from '../../../shared/containers/ResourceListB
 import ACLsView from './ACLsView';
 import QueryEditor from '../components/Projects/QueryEditor';
 import { useAdminSubappContext } from '..';
-import useNotification from '../../../shared/hooks/useNotification';
+import useNotification, {
+  NexusError,
+} from '../../../shared/hooks/useNotification';
 import ProjectToDeleteContainer from '../containers/ProjectToDeleteContainer';
 import { RootState } from '../../../shared/store/reducers';
 import './ProjectView.less';
 import ResourceCreateUploadContainer from '../../../shared/containers/ResourceCreateUploadContainer';
+import { makeOrganizationUri } from '../../../shared/utils';
 
 const ProjectView: React.FunctionComponent = () => {
   const notification = useNotification();
@@ -221,6 +224,30 @@ const ProjectView: React.FunctionComponent = () => {
         });
       });
   };
+
+  const deprecateProject = () => {
+    if (!project) {
+      return;
+    }
+    setFormBusy(true);
+    nexus.Project.deprecate(orgLabel, projectLabel, project._rev)
+      .then(() => {
+        history.push(makeOrganizationUri(orgLabel));
+        notification.success({
+          message: 'Project deprecated',
+        });
+      })
+      .catch((error: NexusError) => {
+        notification.error({
+          message: 'Error deprecating project',
+          description: error.reason,
+        });
+      })
+      .finally(() => {
+        setFormBusy(false);
+      });
+  };
+
   const handleTabChange = (activeKey: string) => {
     if (activeKey === 'studios' || activeKey === 'workflows') return;
     history.push(pathFromTab(activeKey));
@@ -342,6 +369,7 @@ const ProjectView: React.FunctionComponent = () => {
                         apiMappings: project.apiMappings,
                       }}
                       onSubmit={(p: ProjectResponseCommon) => saveAndModify(p)}
+                      onDeprecate={deprecateProject}
                       busy={formBusy}
                       mode="edit"
                     />

--- a/src/subapps/admin/views/ProjectsView.tsx
+++ b/src/subapps/admin/views/ProjectsView.tsx
@@ -58,7 +58,7 @@ const ProjectsView: React.FunctionComponent = () => {
         .catch((error: Error) => {
           setOrgLoadingBusy(false);
           notification.error({
-            message: `An error occured whilst fetching Organization ${match.params.orgLabel}`,
+            message: `Error fetching organization ${match.params.orgLabel}`,
             description: error.message,
           });
         });
@@ -86,8 +86,8 @@ const ProjectsView: React.FunctionComponent = () => {
       .catch(error => {
         setFormBusy(false);
         notification.error({
-          message: 'An error occurred',
-          description: error.message || error.reason,
+          message: 'Error creating project',
+          description: error.reason || error.message,
         });
       });
   };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes https://github.com/BlueBrain/nexus/issues/1673

## Description

<!--- Describe your changes in detail -->
Provide better error message to user when there is an error creating organization or project, including when the reason is because it existed before but has been deprecated. We show the nice error message i.e. reason, provided by Delta.
Implements missing deprecate project functionality.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
