### PR TITLE
Fix creation of resources list from "copy resource list" shortcut link

### DIFF
--- a/src/shared/containers/ResourceListBoardContainer.tsx
+++ b/src/shared/containers/ResourceListBoardContainer.tsx
@@ -82,12 +82,13 @@ const ResourceListBoardContainer: React.FunctionComponent<{
   };
 
   const handleListChanged = (updatedList: ResourceBoardList) => {
-    const index = resourceLists.findIndex(list => list.id === updatedList.id);
-
-    const newResourceList = [...resourceLists];
-    newResourceList[index] = updatedList;
-
-    setResourceLists(newResourceList);
+    setResourceLists(lists => {
+      if (lists === undefined) return [updatedList];
+      const index = lists.findIndex(list => list.id === updatedList.id);
+      const newResourceList = [...lists];
+      newResourceList[index] = updatedList;
+      return newResourceList;
+    });
   };
 
   return (

--- a/src/shared/hooks/useLocalStorage.ts
+++ b/src/shared/hooks/useLocalStorage.ts
@@ -9,19 +9,16 @@ export default function useLocalStorage<T = any>(
     !!val ? JSON.parse(val) : defaultValue
   );
 
-  const setLocalStorage = (value: T | undefined) => {
+  React.useEffect(() => {
     if (value === undefined) {
       localStorage.removeItem(key);
-      setValue(value);
       return;
     }
-
     localStorage.setItem(key, JSON.stringify(value));
-    setValue(value);
-  };
+  }, [value]);
 
-  return [value, setLocalStorage] as [
+  return [value, setValue] as [
     T | undefined,
-    (value: T | undefined) => void
+    React.Dispatch<React.SetStateAction<T | undefined>>
   ];
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes https://github.com/BlueBrain/nexus/issues/2985

## Description

<!--- Describe your changes in detail -->
The functionality where a user can copy a shortcut to a resources list and share with others was broken. When
the link was visited the new resources list would get overwritten. Rewrote the useLocalStorage hook that was being used to make it work with async code as expected.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
