### PR TITLE
Add redirect params to login call back

### DIFF
--- a/src/shared/layouts/FusionMainLayout.tsx
+++ b/src/shared/layouts/FusionMainLayout.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { connect, useDispatch } from 'react-redux';
 import { push } from 'connected-react-router';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useHistory } from 'react-router-dom';
 import { NexusClient, Identity, Realm } from '@bbp/nexus-sdk';
 import { useNexus } from '@bbp/react-nexus';
 import { UserManager } from 'oidc-client';
@@ -14,7 +14,7 @@ import * as configActions from '../store/actions/config';
 import * as authActions from '../store/actions/auth';
 import { RootState } from '../store/reducers';
 import getUserManager from '../../client/userManager';
-import { getLogoutUrl } from '../utils';
+import { getLogoutUrl, getDestinationParam } from '../utils';
 import { url as githubIssueURL } from '../../../package.json';
 import useLocalStorage from '../hooks/useLocalStorage';
 import SearchBarContainer from '../containers/SearchBarContainer';
@@ -95,6 +95,7 @@ const FusionMainLayout: React.FC<FusionMainLayoutProps> = ({
 }) => {
   const subApps = [homeApp, ...propSubApps];
   const location = useLocation();
+  const history = useHistory();
   const dispatch = useDispatch();
   const notification = useNotification();
   //   TODO: collapsed version https://github.com/BlueBrain/nexus/issues/1322
@@ -157,6 +158,7 @@ const FusionMainLayout: React.FC<FusionMainLayoutProps> = ({
   };
 
   const login = async (realmName: string) => {
+    history.push(`${location.pathname}/${getDestinationParam()}`);
     setPreferredRealm(realmName);
     performLogin();
   };

--- a/src/shared/store/actions/auth.ts
+++ b/src/shared/store/actions/auth.ts
@@ -145,8 +145,7 @@ function performLogin() {
       const destination = new URL(window.location.href).searchParams.get(
         'destination'
       );
-      console.log(destination);
-      console.log(window.location.href);
+
       const redirectUri = destination
         ? `${window.location.origin}/${destination}`
         : null;

--- a/src/shared/store/actions/auth.ts
+++ b/src/shared/store/actions/auth.ts
@@ -145,6 +145,8 @@ function performLogin() {
       const destination = new URL(window.location.href).searchParams.get(
         'destination'
       );
+      console.log(destination);
+      console.log(window.location.href);
       const redirectUri = destination
         ? `${window.location.origin}/${destination}`
         : null;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes  BlueBrain/nexus/issues/2328

## Description

When a user logins in using the right top login button, after login , the user is redirected to the path they started from. eg: if they were on a studio, they land back on that studio.
<!--- Describe your changes in detail -->

## How has this been tested?

Manual testing. Go to a studio url (with out logging in ), then log in using the button on right top, you should be redirected to the page you started at.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
