### PR TITLE
2835 Search bar text and searching for things with same value as project or studio

### DIFF
--- a/src/shared/components/SearchBar/index.tsx
+++ b/src/shared/components/SearchBar/index.tsx
@@ -40,6 +40,8 @@ const SearchBar: React.FC<{
   const [value, setValue] = React.useState(query || '');
   const [focused, setFocused] = React.useState(false);
   const inputRef = React.useRef<Input>(null);
+  const projectOptionValueSuffix = '______project';
+  const studioOptionValueSuffix = '______studio';
 
   React.useEffect(() => {
     focusOnSlash(focused, inputRef);
@@ -124,7 +126,8 @@ const SearchBar: React.FC<{
               </span>
             </Hit>
           ),
-          value: `${projectHit.organisation}/${projectHit.project}`,
+          // add suffix to value to differentiate from search term
+          value: `${projectHit.organisation}/${projectHit.project}${projectOptionValueSuffix}`,
         };
       });
       options = [...options, ...projectOptions];
@@ -154,7 +157,8 @@ const SearchBar: React.FC<{
               </span>
             </Hit>
           ),
-          value: `${studioHit.project}/${studioHit.label}`,
+          // add suffix to value to differentiate from search term
+          value: `${studioHit.project}/${studioHit.label}${studioOptionValueSuffix}`,
         };
       });
       options = [...options, ...studioOptions];
@@ -164,7 +168,7 @@ const SearchBar: React.FC<{
 
   return (
     <AutoComplete
-      backfill
+      backfill={false}
       defaultActiveFirstOption
       className="search-bar"
       onFocus={handleSetFocused(true)}
@@ -175,7 +179,18 @@ const SearchBar: React.FC<{
       onKeyDown={handleKeyDown}
       dropdownClassName="search-bar__drop"
       dropdownMatchSelectWidth={false}
-      value={value}
+      /**
+       * Autocomplete uses option value rather than key to differentiate so if there are multiple
+       * options with the same value it's as if the last one was selected always which results in
+       * us not being able to search when the search term matches a project or studio value. We add
+       * a suffix to project and studio values to prevent this and remove it here for display. Bit
+       * hacky!
+       *
+       * See Antd autocomplete bug here https://github.com/ant-design/ant-design/issues/11909
+       */
+      value={value
+        .replace(projectOptionValueSuffix, '')
+        .replace(studioOptionValueSuffix, '')}
       listHeight={310}
     >
       <Input


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes https://github.com/BlueBrain/nexus/issues/2835

## Description

<!--- Describe your changes in detail -->
* When not in search view, search bar is empty and when clicked remains empty.
* When user searches for text that matches project or studio name it should still search rather than navigate to the project/studio.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
