### PR TITLE
2082 admin plugin link support navigation versioned identifiers

### DIFF
--- a/src/shared/components/ResourceLinks/ResourceLinkItem.tsx
+++ b/src/shared/components/ResourceLinks/ResourceLinkItem.tsx
@@ -1,15 +1,19 @@
 import * as React from 'react';
 import { Tooltip } from 'antd';
 import { ResourceLink, Resource } from '@bbp/nexus-sdk';
-
 import TypesIconList from '../Types/TypesIcon';
-
 import './ResourceLinkItem.less';
 import { labelOf } from '../../utils';
 
+export type ResourceLinkAugmented = ResourceLink &
+  Resource & {
+    isRevisionSpecific: boolean;
+    originalLinkID: string;
+  };
+
 const ResourceLinkItem: React.FunctionComponent<{
-  link: ResourceLink;
-  onInternalClick?: (internalLink: ResourceLink) => void;
+  link: ResourceLinkAugmented;
+  onInternalClick?: (internalLink: ResourceLinkAugmented) => void;
 }> = ({ link, onInternalClick }) => {
   const isInternal = !!(link as Resource)._self;
   const paths = link.paths
@@ -26,16 +30,16 @@ const ResourceLinkItem: React.FunctionComponent<{
           ? // link inside nexus
             onInternalClick && onInternalClick(link)
           : // normal link to the internet
-            window && window.open(link['@id'], '_blanl');
+            window && window.open(link['@id'], '_blank');
       }}
     >
       <div className="label">
-        <Tooltip title={link['@id']}>
+        <Tooltip title={link['originalLinkID']}>
           {isInternal ? (
-            labelOf(link['@id'])
+            labelOf(link['originalLinkID'])
           ) : (
-            <a href={link['@id']} target="_blank">
-              {link['@id']}
+            <a href={link['originalLinkID']} target="_blank">
+              {link['originalLinkID']}
             </a>
           )}
         </Tooltip>

--- a/src/shared/components/ResourceLinks/index.tsx
+++ b/src/shared/components/ResourceLinks/index.tsx
@@ -1,18 +1,16 @@
 import * as React from 'react';
 import { Empty, Skeleton } from 'antd';
-import { ResourceLink } from '@bbp/nexus-sdk';
-
 import ListItem from '../List/Item';
-import ResourceLinkItem from './ResourceLinkItem';
+import ResourceLinkItem, { ResourceLinkAugmented } from './ResourceLinkItem';
 import InfiniteSearch from '../List/InfiniteSearch';
 
 const ResourceLinks: React.FunctionComponent<{
   busy: boolean;
   error: Error | null;
-  links: ResourceLink[];
+  links: ResourceLinkAugmented[];
   total: number;
   onLoadMore: () => void;
-  onClick?: (link: ResourceLink) => void;
+  onClick?: (link: ResourceLinkAugmented) => void;
 }> = props => {
   const { busy, error, links, total, onLoadMore, onClick } = props;
   const scrollParent = React.useRef<HTMLDivElement>(null);

--- a/src/shared/containers/AdminPluginContainer.tsx
+++ b/src/shared/containers/AdminPluginContainer.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Resource, ResourceLink } from '@bbp/nexus-sdk';
+import { Resource } from '@bbp/nexus-sdk';
 import { Tabs, Collapse, Alert } from 'antd';
 import HistoryContainer from '../containers/HistoryContainer';
 import ResourceLinksContainer from '../containers/ResourceLinks';

--- a/src/shared/containers/AdminPluginContainer.tsx
+++ b/src/shared/containers/AdminPluginContainer.tsx
@@ -9,6 +9,7 @@ import GraphContainer from '../containers/GraphContainer';
 import MarkdownEditorContainer from './MarkdownEditorContainer';
 import { AccessControl } from '@bbp/react-nexus';
 import { EditOutlined } from '@ant-design/icons';
+import { ResourceLinkAugmented } from '../components/ResourceLinks/ResourceLinkItem';
 
 const { Panel } = Collapse;
 const TabPane = Tabs.TabPane;
@@ -34,7 +35,7 @@ type AdminProps = {
     }
   ) => void;
   handleTabChange: (activeTabKey: string) => void;
-  handleGoToInternalLink: (link: ResourceLink) => void;
+  handleGoToInternalLink: (link: ResourceLinkAugmented) => void;
   handleEditFormSubmit: (value: any) => void;
   handleExpanded: (expanded: boolean) => void;
   refreshResource: () => void;

--- a/src/shared/containers/ResourceLinks.tsx
+++ b/src/shared/containers/ResourceLinks.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
 import { useAsyncEffect } from 'use-async-effect';
 import { useNexusContext } from '@bbp/react-nexus';
-import { ResourceLink } from '@bbp/nexus-sdk';
-
+import { Resource } from '@bbp/nexus-sdk';
 import ResourceLinks from '../components/ResourceLinks';
+import { useSelector } from 'react-redux';
+import { RootState } from '../store/reducers';
+import { ResourceLinkAugmented } from '../components/ResourceLinks/ResourceLinkItem';
 
 const PAGE_SIZE = 10;
 
@@ -13,13 +15,13 @@ const ResourceLinksContainer: React.FunctionComponent<{
   projectLabel: string;
   rev: number;
   direction: 'incoming' | 'outgoing';
-  onClick?: (link: ResourceLink) => void;
+  onClick?: (link: ResourceLinkAugmented) => void;
 }> = ({ resourceId, orgLabel, projectLabel, rev, direction, onClick }) => {
   const nexus = useNexusContext();
   const [{ busy, error, links, total, next }, setLinks] = React.useState<{
     busy: boolean;
     error: Error | null;
-    links: ResourceLink[];
+    links: ResourceLinkAugmented[];
     next: string | null;
     total: number;
   }>({
@@ -29,6 +31,12 @@ const ResourceLinksContainer: React.FunctionComponent<{
     links: [],
     total: 0,
   });
+  const { apiEndpoint } = useSelector((state: RootState) => state.config);
+  const splits = apiEndpoint.split('/');
+  const apiBase = splits.slice(0, splits.length - 1).join('/');
+
+  const isLinkRevisionSpecific = (link: Resource) =>
+    !(link as Resource)._self && link['@id'].startsWith(apiBase);
 
   const handleLoadMore = async () => {
     if (busy || !next) {
@@ -45,6 +53,7 @@ const ResourceLinksContainer: React.FunctionComponent<{
       const response = await nexus.httpGet({
         path: next,
       });
+      // do we also need to get augmented links here?
       setLinks({
         next: response._next || null,
         links: [...links, ...response._results],
@@ -88,9 +97,31 @@ const ResourceLinksContainer: React.FunctionComponent<{
             from: 0,
           }
         );
+        const augmentedLinks = (
+          await Promise.all(
+            response._results.map(link => {
+              if (isLinkRevisionSpecific(link as Resource)) {
+                return nexus.httpGet({
+                  path: link['@id'],
+                });
+              }
+              return new Promise(resolve => resolve(link));
+            })
+          )
+        ).map((link, ix) => ({
+          // replace @id with @id from resource
+          // add isRevisionSpecific and originalLinkID params
+          ...(link as Resource),
+          paths: response._results[ix]['paths'],
+          isRevisionSpecific: isLinkRevisionSpecific(
+            response._results[ix] as Resource
+          ),
+          originalLinkID: response._results[ix]['@id'],
+        }));
+
         setLinks({
           next: response._next || null,
-          links: response._results,
+          links: augmentedLinks,
           total: response._total,
           busy: false,
           error: null,

--- a/src/shared/containers/ResourceViewContainer.tsx
+++ b/src/shared/containers/ResourceViewContainer.tsx
@@ -4,12 +4,7 @@ import { useLocation, useHistory, useParams } from 'react-router';
 import { Spin, Alert, Collapse, Typography, Divider } from 'antd';
 import * as queryString from 'query-string';
 import { useNexusContext } from '@bbp/react-nexus';
-import {
-  Resource,
-  ResourceLink,
-  IncomingLink,
-  ExpandedResource,
-} from '@bbp/nexus-sdk';
+import { Resource, IncomingLink, ExpandedResource } from '@bbp/nexus-sdk';
 import AdminPlugin from '../containers/AdminPluginContainer';
 import VideoPluginContainer from '../containers/VideoPluginContainer';
 import ResourcePlugins from './ResourcePlugins';
@@ -32,6 +27,7 @@ import { DeleteOutlined } from '@ant-design/icons';
 import { Link } from 'react-router-dom';
 import ResourceViewActionsContainer from './ResourceViewActionsContainer';
 import ResourceMetadata from '../components/ResourceMetadata';
+import { ResourceLinkAugmented } from '../components/ResourceLinks/ResourceLinkItem';
 
 export type PluginMapping = {
   [pluginKey: string]: object;
@@ -202,12 +198,17 @@ const ResourceViewContainer: React.FunctionComponent<{
     }
   };
 
-  const handleGoToInternalLink = (link: ResourceLink) => {
+  const handleGoToInternalLink = (link: ResourceLinkAugmented) => {
     const { orgLabel, projectLabel } = getOrgAndProjectFromProjectId(
       (link as IncomingLink)._project
     );
 
+    const revisionOption = link.isRevisionSpecific
+      ? { revision: link._rev }
+      : {};
+
     goToResource(orgLabel, projectLabel, encodeURIComponent(link['@id']), {
+      ...revisionOption,
       tab: '#links',
     });
   };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes https://github.com/BlueBrain/nexus/issues/2082

## Description

<!--- Describe your changes in detail -->
The links section in Project Admin list resources linked in the resource didn't work with versioned identifiers, i.e. when @id=someid?rev=2. Delta doesn't support this functionality fully and it is difficult to implement. Therefore this change introduces support for versioned identifiers directly in Fusion i.e. displays them correctly and navigates to a specific revision when specified.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
