### PR TITLE
Fix to allow user to scroll all the way to bottom of gallery drawer

### DIFF
--- a/src/shared/views/GalleryView.less
+++ b/src/shared/views/GalleryView.less
@@ -6,6 +6,9 @@
     width: 60% !important;
     margin-top: 52px; // do not overlay app header
   }
+  & .ant-drawer-body {
+    margin-bottom: 62px; // compensate for margin-top and some
+  }
   @media only screen and (max-width: @screen-sm-max) {
     &.ant-drawer-left.ant-drawer-open,
     &.ant-drawer-right.ant-drawer-open {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes https://github.com/BlueBrain/nexus/issues/3007

## Description

<!--- Describe your changes in detail -->
Fix to allow scrolling all the way to the bottom of the gallery drawer.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
