### PR TITLE
Only show graph analytics tab when plugin enabled in Delta

### DIFF
--- a/src/subapps/admin/views/ProjectView.tsx
+++ b/src/subapps/admin/views/ProjectView.tsx
@@ -384,12 +384,14 @@ const ProjectView: React.FunctionComponent = () => {
                   <br />
                 </>
               </TabPane>
-              <TabPane tab="Graph Analytics" key="graph-analytics">
-                <ProjectStatsContainer
-                  orgLabel={orgLabel}
-                  projectLabel={projectLabel}
-                />
-              </TabPane>
+              {deltaPlugins && 'graph-analytics' in deltaPlugins && (
+                <TabPane tab="Graph Analytics" key="graph-analytics">
+                  <ProjectStatsContainer
+                    orgLabel={orgLabel}
+                    projectLabel={projectLabel}
+                  />
+                </TabPane>
+              )}
               <TabPane
                 tab={
                   <span>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes https://github.com/BlueBrain/nexus/issues/3022

## Description

<!--- Describe your changes in detail -->
Only show graph analytics tab in project view when plugin is enabled in Delta

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
