### PR TITLE
Copy notification for button dropdowns

### DIFF
--- a/src/shared/components/Copy/index.tsx
+++ b/src/shared/components/Copy/index.tsx
@@ -3,10 +3,9 @@ import { triggerCopy } from '../../utils/copy';
 
 const DEFAULT_REVERT_DELAY = 2500;
 
-type triggerCopy = () => void;
+type triggerCopy = (textToCopy: string) => void;
 
 interface CopyProps {
-  textToCopy: string;
   revertDelay?: number;
   render(
     copySuccess: boolean,
@@ -16,7 +15,6 @@ interface CopyProps {
 
 // https://stackoverflow.com/questions/39501289/in-reactjs-how-to-copy-text-to-clipboard/39504692
 const Copy: React.FunctionComponent<CopyProps> = ({
-  textToCopy,
   render,
   revertDelay = DEFAULT_REVERT_DELAY,
 }) => {
@@ -24,7 +22,7 @@ const Copy: React.FunctionComponent<CopyProps> = ({
 
   // Must use browser dom manipulation in order to hide the fake textArea,
   // otherwise must use react references and that's too slow
-  const handleTriggerCopy = () => {
+  const handleTriggerCopy = (textToCopy: string) => {
     if (document && document.queryCommandSupported('copy')) {
       triggerCopy(textToCopy);
       setCopySuccess(true);

--- a/src/shared/components/Header/index.tsx
+++ b/src/shared/components/Header/index.tsx
@@ -156,12 +156,11 @@ const Header: React.FunctionComponent<HeaderProps> = ({
         )}
         {token && (
           <Copy
-            textToCopy={token}
             render={(copySuccess, triggerCopy) => (
               <button
                 className="copy-token-button"
                 onClick={() => {
-                  triggerCopy();
+                  triggerCopy(token);
                 }}
               >
                 <img src={copyIcon} />{' '}

--- a/src/shared/components/ResourceCard/index.tsx
+++ b/src/shared/components/ResourceCard/index.tsx
@@ -43,7 +43,6 @@ const ResourceCardComponent: React.FunctionComponent<{
       extra={
         <div className="actions">
           <Copy
-            textToCopy={id}
             render={(copySuccess, triggerCopy) => (
               <Tooltip title={copySuccess ? 'Copied!' : `Copy ${id}`}>
                 <Button
@@ -52,7 +51,7 @@ const ResourceCardComponent: React.FunctionComponent<{
                   onClick={(e: React.MouseEvent) => {
                     e.preventDefault();
                     e.stopPropagation();
-                    triggerCopy();
+                    triggerCopy(id);
                   }}
                 >
                   Identifier
@@ -61,7 +60,6 @@ const ResourceCardComponent: React.FunctionComponent<{
             )}
           />{' '}
           <Copy
-            textToCopy={self}
             render={(copySuccess, triggerCopy) => (
               <Tooltip title={copySuccess ? 'Copied!' : `Copy ${self}`}>
                 <Button
@@ -70,7 +68,7 @@ const ResourceCardComponent: React.FunctionComponent<{
                   onClick={(e: React.MouseEvent) => {
                     e.preventDefault();
                     e.stopPropagation();
-                    triggerCopy();
+                    triggerCopy(self);
                   }}
                 >
                   Nexus Address

--- a/src/shared/components/ResourceList/index.tsx
+++ b/src/shared/components/ResourceList/index.tsx
@@ -263,13 +263,12 @@ const ResourceListComponent: React.FunctionComponent<{
         </h3>
         <div className="controls -squished">
           <Copy
-            textToCopy={shareableLink}
             render={(copySuccess, triggerCopy) => (
               <a
                 href={shareableLink}
                 onClick={e => {
                   e.preventDefault();
-                  triggerCopy();
+                  triggerCopy(shareableLink);
                 }}
               >
                 <Tooltip title={copySuccess ? 'Copied' : 'Copy shareable link'}>

--- a/src/shared/containers/ResourceViewActionsContainer.tsx
+++ b/src/shared/containers/ResourceViewActionsContainer.tsx
@@ -4,9 +4,9 @@ import { useNexusContext } from '@bbp/react-nexus';
 import { Button, Col, Dropdown, Menu, Row } from 'antd';
 import * as React from 'react';
 import { generatePath, useHistory, useLocation } from 'react-router-dom';
+import Copy from '../components/Copy';
 import { CartContext } from '../hooks/useDataCart';
 import { makeResourceUri } from '../utils';
-import { triggerCopy } from '../utils/copy';
 
 const ResourceViewActionsContainer: React.FC<{
   resource: Resource;
@@ -108,96 +108,104 @@ const ResourceViewActionsContainer: React.FC<{
         </Dropdown>
       </Col>
       <Col>
-        <Dropdown.Button
-          onClick={() => {
-            const pathToResource = generatePath(
-              '/:orgLabel/:projectLabel/resources/:resourceId',
-              {
-                orgLabel,
-                projectLabel,
-                resourceId: encodedResourceId,
-              }
+        <Copy
+          render={(copySuccess, triggerCopy) => {
+            return (
+              <Dropdown.Button
+                onClick={() => {
+                  const pathToResource = generatePath(
+                    '/:orgLabel/:projectLabel/resources/:resourceId',
+                    {
+                      orgLabel,
+                      projectLabel,
+                      resourceId: encodedResourceId,
+                    }
+                  );
+
+                  if (!isLatest) {
+                    triggerCopy(
+                      `${window.location.origin.toString()}${pathToResource}?rev=${
+                        resource._rev
+                      }`
+                    );
+                  } else {
+                    triggerCopy(
+                      `${window.location.origin.toString()}${pathToResource}`
+                    );
+                  }
+                }}
+                overlay={
+                  <Menu>
+                    <Menu.Item
+                      onClick={() => {
+                        const pathToResource = generatePath(
+                          '/:orgLabel/:projectLabel/resources/:resourceId',
+                          {
+                            orgLabel,
+                            projectLabel,
+                            resourceId: encodedResourceId,
+                          }
+                        );
+
+                        triggerCopy(
+                          `${window.location.origin.toString()}${pathToResource}`
+                        );
+                      }}
+                    >
+                      URL
+                    </Menu.Item>
+                    <Menu.Item
+                      onClick={() => {
+                        const pathToResource = generatePath(
+                          '/:orgLabel/:projectLabel/resources/:resourceId',
+                          {
+                            orgLabel,
+                            projectLabel,
+                            resourceId: encodedResourceId,
+                          }
+                        );
+
+                        triggerCopy(
+                          `${window.location.origin.toString()}${pathToResource}?rev=${
+                            resource._rev
+                          }`
+                        );
+                      }}
+                    >
+                      URL (with revision)
+                    </Menu.Item>
+                    <Menu.Item onClick={() => triggerCopy(resource['@id'])}>
+                      ID
+                    </Menu.Item>
+                    <Menu.Item
+                      onClick={() =>
+                        triggerCopy(`${resource['@id']}?rev=${resource._rev}`)
+                      }
+                    >
+                      ID (with revision)
+                    </Menu.Item>
+                    <Menu.Item onClick={() => triggerCopy(self ? self : '')}>
+                      Nexus address
+                    </Menu.Item>
+                    <Menu.Item
+                      onClick={() =>
+                        triggerCopy(
+                          self
+                            ? `${self}?rev=${resource ? resource._rev : ''}`
+                            : ''
+                        )
+                      }
+                    >
+                      Nexus address (with revision)
+                    </Menu.Item>
+                  </Menu>
+                }
+              >
+                {copySuccess ? 'Copied!' : 'Copy'}
+              </Dropdown.Button>
             );
-
-            if (!isLatest) {
-              triggerCopy(
-                `${window.location.origin.toString()}${pathToResource}?rev=${
-                  resource._rev
-                }`
-              );
-            } else {
-              triggerCopy(
-                `${window.location.origin.toString()}${pathToResource}`
-              );
-            }
           }}
-          overlay={
-            <Menu>
-              <Menu.Item
-                onClick={() => {
-                  const pathToResource = generatePath(
-                    '/:orgLabel/:projectLabel/resources/:resourceId',
-                    {
-                      orgLabel,
-                      projectLabel,
-                      resourceId: encodedResourceId,
-                    }
-                  );
-
-                  triggerCopy(
-                    `${window.location.origin.toString()}${pathToResource}`
-                  );
-                }}
-              >
-                URL
-              </Menu.Item>
-              <Menu.Item
-                onClick={() => {
-                  const pathToResource = generatePath(
-                    '/:orgLabel/:projectLabel/resources/:resourceId',
-                    {
-                      orgLabel,
-                      projectLabel,
-                      resourceId: encodedResourceId,
-                    }
-                  );
-
-                  triggerCopy(
-                    `${window.location.origin.toString()}${pathToResource}?rev=${
-                      resource._rev
-                    }`
-                  );
-                }}
-              >
-                URL (with revision)
-              </Menu.Item>
-              <Menu.Item onClick={() => triggerCopy(resource['@id'])}>
-                ID
-              </Menu.Item>
-              <Menu.Item
-                onClick={() =>
-                  triggerCopy(`${resource['@id']}%3Frev=${resource._rev}`)
-                }
-              >
-                ID (with revision)
-              </Menu.Item>
-              <Menu.Item onClick={() => triggerCopy(self ? self : '')}>
-                Nexus address
-              </Menu.Item>
-              <Menu.Item
-                onClick={() =>
-                  triggerCopy(
-                    self ? `${self}%3Frev=${resource ? resource._rev : ''}` : ''
-                  )
-                }
-              >
-                Nexus address (with revision)
-              </Menu.Item>
-            </Menu>
-          }
-        >
-          Copy
-        </Dropdown.Button>
+        ></Copy>
       </Col>
       <Col>
         <Button onClick={handleAddToCart}>Add to Cart</Button>

--- a/src/subapps/projects/components/InputsTable.tsx
+++ b/src/subapps/projects/components/InputsTable.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Table, Tag, Button } from 'antd';
+import { Table, Button } from 'antd';
 import * as moment from 'moment';
 
 import { getDateString } from '../../../shared/utils';
@@ -37,13 +37,12 @@ const InputsTable: React.FC<{ inputs: Input[] }> = ({ inputs }) => {
         render={text => {
           return (
             <Copy
-              textToCopy={text}
               render={(copySuccess, triggerCopy) => (
                 <Button
                   onClick={(e: React.MouseEvent) => {
                     e.preventDefault();
                     e.stopPropagation();
-                    triggerCopy();
+                    triggerCopy(text);
                   }}
                 >
                   {copySuccess ? 'Copied!' : 'Copy ID'}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes https://github.com/BlueBrain/nexus/issues/3014

## Description

* Pass text to copy as function param rather than Copy component prop. This allows us to support dropdown copy buttons that have more than one possible copy text value.
* Update references to component to use new interface
* Use copy component to add notification to our dropdown button when text is copied

![Copy notification](https://user-images.githubusercontent.com/11296166/150812694-91743013-1d3a-43c8-8c3a-077e515119ec.gif)

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
