### PR TITLE
3084 app crash when adding to cart from data table

### DIFF
--- a/src/shared/components/ErrorBoundary.tsx
+++ b/src/shared/components/ErrorBoundary.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+
+interface Error {
+  stack?: string;
+}
+
+interface ErrorBoundaryProps {
+  fallback?: React.FunctionComponent<{ resetErrorState?: () => void }>;
+}
+
+class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  { hasError: boolean }
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(error: Error) {
+    // Update state so the next render will show the fallback UI.
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    console.error('Uncaught error:', error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      if (this.props.fallback) {
+        return (
+          <this.props.fallback
+            resetErrorState={() => this.setState({ hasError: false })}
+          />
+        );
+      }
+      return <h1>Something went wrong.</h1>;
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/shared/containers/DataCartContainer.tsx
+++ b/src/shared/containers/DataCartContainer.tsx
@@ -7,6 +7,8 @@ import {
   ShoppingCartOutlined,
   DownloadOutlined,
   CloseCircleFilled,
+  WarningFilled,
+  ExclamationCircleOutlined,
 } from '@ant-design/icons';
 import {
   Badge,
@@ -18,6 +20,7 @@ import {
   Dropdown,
   Input,
   Tooltip,
+  Popconfirm,
 } from 'antd';
 import { CartContext } from '../hooks/useDataCart';
 import ResultPreviewItemContainer from '../../subapps/search/containers/ResultPreviewItemContainer';
@@ -403,5 +406,32 @@ const DataCartContainer = () => {
     </>
   );
 };
+
+const FallbackCart: React.FC<{ resetErrorState?: () => void }> = ({
+  resetErrorState,
+}) => {
+  const { emptyCart } = React.useContext(CartContext);
+  return (
+    <Popconfirm
+      title="An error has occurred and the data cart is unavailable. Do you want to try re-initializing the cart?"
+      icon={<ExclamationCircleOutlined style={{ color: '#f5222d' }} />}
+      onConfirm={() => {
+        if (!emptyCart) return;
+        emptyCart().then(() => resetErrorState && resetErrorState());
+      }}
+      okText="Yes"
+      cancelText="No"
+    >
+      <Badge
+        size="small"
+        count={<WarningFilled style={{ color: '#f5222d' }} />}
+      >
+        <Button className="cart" icon={<ShoppingCartOutlined />}></Button>
+      </Badge>
+    </Popconfirm>
+  );
+};
+
+export { FallbackCart };
 
 export default DataCartContainer;

--- a/src/shared/layouts/FusionMainLayout.tsx
+++ b/src/shared/layouts/FusionMainLayout.tsx
@@ -18,9 +18,12 @@ import { getLogoutUrl, getDestinationParam } from '../utils';
 import { url as githubIssueURL } from '../../../package.json';
 import useLocalStorage from '../hooks/useLocalStorage';
 import SearchBarContainer from '../containers/SearchBarContainer';
-import DataCartContainer from '../containers/DataCartContainer';
+import DataCartContainer, {
+  FallbackCart,
+} from '../containers/DataCartContainer';
 import './FusionMainLayout.less';
 import useNotification from '../hooks/useNotification';
+import ErrorBoundary from '../components/ErrorBoundary';
 
 const { Content } = Layout;
 
@@ -203,7 +206,11 @@ const FusionMainLayout: React.FC<FusionMainLayoutProps> = ({
           consent={consent}
           commitHash={COMMIT_HASH}
           onClickRemoveConsent={() => setConsent(undefined)}
-          dataCart={<DataCartContainer />}
+          dataCart={
+            <ErrorBoundary fallback={FallbackCart}>
+              <DataCartContainer />
+            </ErrorBoundary>
+          }
           subApps={subApps}
           authenticated={authenticated}
         >


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes https://github.com/BlueBrain/nexus/issues/3084

## Description

<!--- Describe your changes in detail -->

* Created ErrorBoundary re-usable component that takes a fallback component to display if there's an error.
* Created Fallback data cart component for if there's an error, wrapped data cart in ErrorBoundary component. Example of component below where the data cart fallback component will show an error icon and when clicked will allow recovery by clearing the cart
![Datacart_Fallback](https://user-images.githubusercontent.com/11296166/152350124-c97116fa-be75-4164-8e4c-6aeaf92e2161.gif)
* Fix bug that is causing the data cart component to error. Where a Sparql or Elasticsearch query's results don't include _project property of resource the data cart will error as it expects this property.
 
## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [x] I have added screenshots (if applicable), in the comment section.
