### PR TITLE
3113 search reset bug fix

### DIFF
--- a/src/shared/layouts/FusionMainLayout.less
+++ b/src/shared/layouts/FusionMainLayout.less
@@ -2,7 +2,6 @@
 
 .fusion-main-layout {
   .project-panel,
-  .search-table-header,
   .workflow-step-view__panel {
     left: 80px;
   }

--- a/src/shared/layouts/SeoHeaders.tsx
+++ b/src/shared/layouts/SeoHeaders.tsx
@@ -25,7 +25,8 @@ const SeoHeaders: React.FC = () => {
       <meta property="og:site_name" content="Nexus" />
       <meta property="og:title" content={TITLE} />
       <meta property="og:description" content={DESCRIPTION} />
-      <meta name="theme-color" content="#00c9fd" />
+      {/* If browser supports customizing color of surroding UI via theme-color set to @fusion-secondary-color */}
+      <meta name="theme-color" content="#7cb4fa" />
     </Helmet>
   );
 };

--- a/src/subapps/search/components/Layouts/index.tsx
+++ b/src/subapps/search/components/Layouts/index.tsx
@@ -15,6 +15,7 @@ const SearchLayouts: React.FC<{
         onChange={layout => onChangeLayout(layout as string)}
         value={selectedLayout}
         dropdownMatchSelectWidth={false}
+        className="search-layout"
       >
         {layouts?.map(layout => {
           return (

--- a/src/subapps/search/components/TableHeightWrapper.tsx
+++ b/src/subapps/search/components/TableHeightWrapper.tsx
@@ -30,26 +30,31 @@ const TableHeightWrapper: React.FC<{
             className={'result-table heightTest'}
             style={{ display: 'none', opacity: '0' }}
           >
-            <Table
-              key="HeightTestTable"
-              dataSource={[
-                {
-                  key: '1',
-                  name: 'HeightTest',
-                },
-              ]}
-              columns={[
-                {
-                  title: 'Name',
-                  dataIndex: 'name',
-                  key: 'name',
-                },
-              ]}
-              pagination={{
-                position: ['topRight'],
-                showSizeChanger: true,
-              }}
-            ></Table>
+            <div className="search-table">
+              <Table
+                key="HeightTestTable"
+                dataSource={[
+                  {
+                    key: '1',
+                    name: 'HeightTest',
+                  },
+                ]}
+                columns={[
+                  {
+                    title: 'Name',
+                    dataIndex: 'name',
+                    key: 'name',
+                    render: value => (
+                      <div className="row-selection-checkbox">
+                        <span className="row-index">1</span>
+                      </div>
+                    ),
+                  },
+                ]}
+                rowSelection={{}}
+                pagination={false}
+              ></Table>
+            </div>
           </div>
           <div
             className="result-table"

--- a/src/subapps/search/containers/SearchContainer.less
+++ b/src/subapps/search/containers/SearchContainer.less
@@ -1,15 +1,20 @@
+@import '../../../shared/lib.less';
+
 .search-table-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   height: 43px;
-  padding: 0 0.5em;
+  padding: 0 24px 0 1em;
   position: fixed;
   top: 55px;
-  right: 0;
-  left: 200px;
+  left: 0;
+  width: 100%;
   z-index: 21;
   transition: all 0.2s ease-out;
+  /* background-color set here to prevent table overflow
+  on scroll being seen above table header */
+  background-color: @fusion-background-color;
 
   &__paginator {
     margin-left: auto !important;
@@ -18,6 +23,11 @@
 
   &__options {
     flex-shrink: 0;
+  }
+
+  .search-layout {
+    min-width: 160px;
+    max-width: 280px;
   }
 }
 

--- a/src/subapps/search/containers/SearchContainer.tsx
+++ b/src/subapps/search/containers/SearchContainer.tsx
@@ -4,7 +4,7 @@ import { useNexusContext } from '@bbp/react-nexus';
 import TableHeightWrapper from '../components/TableHeightWrapper';
 import { Spin, Pagination, Table, Button, Checkbox, Result } from 'antd';
 import { CloseCircleOutlined } from '@ant-design/icons';
-import useGlobalSearchData, { FieldVisibility } from '../hooks/useGlobalSearch';
+import useGlobalSearchData from '../hooks/useGlobalSearch';
 import useQueryString from '../../../shared/hooks/useQueryString';
 import useSearchPagination, {
   useAdjustTableHeight,
@@ -13,7 +13,6 @@ import useSearchPagination, {
 } from '../hooks/useSearchPagination';
 import ColumnsVisibilityConfig from '../components/ColumnsVisibilityConfig';
 import './SearchContainer.less';
-import useColumnsToFitPage from '../hooks/useColumnsToFitPage';
 import FiltersConfig from '../components/FiltersConfig';
 import SortConfig from '../components/SortConfig';
 import SearchLayouts from '../components/Layouts';
@@ -160,34 +159,9 @@ const SearchContainer: React.FC = () => {
     nexus
   );
 
-  function makeColumnsVisible(columnCount: number) {
-    const columnVisibilities = columns?.map((el, ix) => {
-      return {
-        name: el.label,
-        key: el.key,
-        visible: ix < columnCount,
-      };
-    });
-    dispatchFieldVisibility({
-      type: 'initialize',
-      payload: columnVisibilities as FieldVisibility[],
-    });
-  }
-
-  const { tableRef, calculateNumberOfColumnsToFit } = useColumnsToFitPage(
-    columnCount => {
-      if (columns && !fieldsVisibilityState.isPersistent) {
-        makeColumnsVisible(columnCount);
-      }
-    }
-  );
-
   const clearAllCustomisation = () => {
     handlePaginationChange(1);
     resetAll();
-
-    const numColumnsFit = calculateNumberOfColumnsToFit();
-    makeColumnsVisible(numColumnsFit);
   };
 
   const handleSelect = (record: any, selected: any) => {
@@ -313,7 +287,7 @@ const SearchContainer: React.FC = () => {
                   className="search-table-header__paginator"
                 />
               </div>
-              <div ref={tableRef} className="search-table">
+              <div className="search-table">
                 <Table
                   rowSelection={rowSelection}
                   tableLayout="fixed"

--- a/src/subapps/search/hooks/useGlobalSearch.tsx
+++ b/src/subapps/search/hooks/useGlobalSearch.tsx
@@ -596,8 +596,8 @@ function useGlobalSearchData(
 
   const resetAll = () => {
     if (config?.layouts && config.layouts.length > 0) {
-      // default to first layout
-      setSelectedSearchLayout(config.layouts[0].name);
+      const layout = config.layouts.find(l => l.name === selectedSearchLayout);
+      layout && applyLayout(layout, columns);
       return;
     }
     clearAllFilters();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes https://github.com/BlueBrain/nexus/issues/3113

## Description

<!--- Describe your changes in detail -->
* Fixes search reset bug - will now reload the currently selected search config
* Update theme-color to match our updated styles - used by Safari to set browser tab color
* Fix styling of search table options - remove left space and fill same width as table
* Fix auto height calculations to correctly calculate number of rows to fit on page
* Remove unused logic to calculate number of columns to fit on page which was also causing issues with reset

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
