### PR TITLE
Load from ENV the name of service account realm to be hidden for Login

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ docker build . --tag=nexus-web
 - `HOST_NAME`: name of host where application is available from: i.e. `https://bbp-nexus.epfl.ch` (default is protocol + host where server is running from)
 - `CLIENT_ID`: The application name used for _OpenID Connect_ authentication (default is `nexus-web`)
 - `API_ENDPOINT`: The URL pointing to Nexus API. Default is '/'
+- `SERVICE_ACCOUNTS_REALM`: The realm that is configured for service accounts that should be hidden for Login. Default is 'serviceaccounts'.
 - `SECURE`: Is Nexus Fusion running in https or not. Default is `false`
 - `GTM_CODE`: The Google Analytics Identifier. GA won't be present unless an ID is specified.
 - `SENTRY_DSN`: The sentry URL Nexus Fusion needs to report errors to. Default is undefined.

--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -9,7 +9,10 @@ import setUpDeltaProxy from './proxy';
 import silentRefreshHtml from './silent_refresh';
 import { RootState } from '../shared/store/reducers';
 import { DEFAULT_UI_SETTINGS } from '../shared/store/reducers/ui-settings';
-import { DEFAULT_SEARCH_CONFIG_PROJECT } from '../shared/store/reducers/config';
+import {
+  DEFAULT_SEARCH_CONFIG_PROJECT,
+  DEFAULT_SERVICE_ACCOUNTS_REALM,
+} from '../shared/store/reducers/config';
 import { DEFAULT_SEARCH_STATE } from '../shared/store/reducers/search';
 
 const PORT_NUMBER = 8000;
@@ -87,8 +90,11 @@ app.get('*', async (req: express.Request, res: express.Response) => {
         : process.env.API_ENDPOINT || '',
       basePath: base,
       clientId: process.env.CLIENT_ID || 'nexus-web',
-      redirectHostName: `${process.env.HOST_NAME ||
-        `${req.protocol}://${req.headers.host}`}${base}`,
+      redirectHostName: `${
+        process.env.HOST_NAME || `${req.protocol}://${req.headers.host}`
+      }${base}`,
+      serviceAccountsRealm:
+        process.env.SERVICE_ACCOUNTS_REALM || DEFAULT_SERVICE_ACCOUNTS_REALM,
       sentryDsn: process.env.SENTRY_DSN,
       gtmCode: process.env.GTM_CODE,
       studioView: process.env.STUDIO_VIEW || '',

--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -90,9 +90,8 @@ app.get('*', async (req: express.Request, res: express.Response) => {
         : process.env.API_ENDPOINT || '',
       basePath: base,
       clientId: process.env.CLIENT_ID || 'nexus-web',
-      redirectHostName: `${
-        process.env.HOST_NAME || `${req.protocol}://${req.headers.host}`
-      }${base}`,
+      redirectHostName: `${process.env.HOST_NAME ||
+        `${req.protocol}://${req.headers.host}`}${base}`,
       serviceAccountsRealm:
         process.env.SERVICE_ACCOUNTS_REALM || DEFAULT_SERVICE_ACCOUNTS_REALM,
       sentryDsn: process.env.SENTRY_DSN,

--- a/src/shared/components/Header/__tests__/Header.test.tsx
+++ b/src/shared/components/Header/__tests__/Header.test.tsx
@@ -22,6 +22,7 @@ const shallowHeader = shallow(
   <Header
     name="Mark Hamill"
     realms={[]}
+    serviceAccountsRealm="serviceaccounts"
     links={links}
     githubIssueURL=""
     forgeLink=""
@@ -37,6 +38,7 @@ const wrapper = mount(
     <Header
       name="Mark Hamill"
       realms={[]}
+      serviceAccountsRealm="serviceaccounts"
       links={links}
       githubIssueURL=""
       forgeLink=""
@@ -69,6 +71,7 @@ describe('Header component', () => {
           <Header
             name=""
             realms={[]}
+            serviceAccountsRealm="serviceaccounts"
             links={links}
             githubIssueURL=""
             forgeLink=""
@@ -89,6 +92,7 @@ describe('Header component', () => {
           <Header
             name=""
             realms={[]}
+            serviceAccountsRealm="serviceaccounts"
             links={links}
             githubIssueURL=""
             forgeLink=""

--- a/src/shared/components/Header/index.tsx
+++ b/src/shared/components/Header/index.tsx
@@ -87,6 +87,7 @@ export interface HeaderProps {
   token?: string;
   links?: React.ReactNode[];
   realms: Realm[];
+  serviceAccountsRealm: string;
   displayLogin?: boolean;
   children?: React.ReactChild;
   consent?: ConsentType;
@@ -101,6 +102,7 @@ export interface HeaderProps {
 const Header: React.FunctionComponent<HeaderProps> = ({
   name,
   realms,
+  serviceAccountsRealm,
   token,
   displayLogin = true,
   links = [],
@@ -125,7 +127,7 @@ const Header: React.FunctionComponent<HeaderProps> = ({
   );
 
   const realmsFilter = realms.filter(
-    r => r._label !== 'serviceaccounts' && !r._deprecated
+    r => r._label !== serviceAccountsRealm && !r._deprecated
   );
 
   const realmMenu = (

--- a/src/shared/layouts/FusionMainLayout.tsx
+++ b/src/shared/layouts/FusionMainLayout.tsx
@@ -32,6 +32,7 @@ declare var COMMIT_HASH: string;
 export interface FusionMainLayoutProps {
   authenticated: boolean;
   realms: Realm[];
+  serviceAccountsRealm: string;
   token?: string;
   name?: string;
   canLogin?: boolean;
@@ -70,6 +71,7 @@ export type SubAppProps = {
 const FusionMainLayout: React.FC<FusionMainLayoutProps> = ({
   authenticated,
   realms,
+  serviceAccountsRealm,
   token,
   name,
   children,
@@ -184,6 +186,7 @@ const FusionMainLayout: React.FC<FusionMainLayoutProps> = ({
           name={authenticated ? name : undefined}
           token={token}
           realms={realms}
+          serviceAccountsRealm={serviceAccountsRealm}
           performLogin={login}
           links={[
             <a
@@ -249,10 +252,11 @@ const mapStateToProps = (state: RootState) => {
       auth.identities.data &&
       auth.identities.data.identities) ||
     [];
-  const { layoutSettings } = config;
+  const { layoutSettings, serviceAccountsRealm } = config;
 
   return {
     realms,
+    serviceAccountsRealm,
     layoutSettings,
     authenticated: !!oidc.user,
     token: oidc.user && oidc.user.access_token,

--- a/src/shared/store/reducers/config.ts
+++ b/src/shared/store/reducers/config.ts
@@ -1,6 +1,7 @@
 import { ConfigActions } from '../actions/config';
 
 export const DEFAULT_SEARCH_CONFIG_PROJECT = 'webapps/nexus-web';
+export const DEFAULT_SERVICE_ACCOUNTS_REALM = 'serviceaccounts';
 
 export interface ConfigState {
   apiEndpoint: string;
@@ -8,6 +9,7 @@ export interface ConfigState {
   clientId: string;
   redirectHostName: string;
   preferredRealm?: string;
+  serviceAccountsRealm: string;
   sentryDsn?: string;
   pluginsManifestPath: string;
   subAppsManifestPath: string;
@@ -31,6 +33,7 @@ const initialState: ConfigState = {
   redirectHostName: '',
   pluginsManifestPath: '/public/plugins',
   subAppsManifestPath: '/public/sub-apps',
+  serviceAccountsRealm: DEFAULT_SERVICE_ACCOUNTS_REALM,
   gtmCode: '',
   layoutSettings: {
     docsLink: '',


### PR DESCRIPTION
## Description

Previously the service account realm name that was hidden for Login was hardcoded. The change allows the realm name to be picked up from environment variables.

The env variable is: SERVICE_ACCOUNTS_REALM

<!--- Describe your changes in detail -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
