### PR TITLE
Update default client id used in auth flow

### DIFF
--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -89,7 +89,7 @@ app.get('*', async (req: express.Request, res: express.Response) => {
         ? '/proxy'
         : process.env.API_ENDPOINT || '',
       basePath: base,
-      clientId: process.env.CLIENT_ID || 'nexus-web',
+      clientId: process.env.CLIENT_ID || 'bbp-nise-dev-nexus-fusion',
       redirectHostName: `${process.env.HOST_NAME ||
         `${req.protocol}://${req.headers.host}`}${base}`,
       serviceAccountsRealm:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

New dev environment uses different client ID (bbp-nise-dev-nexus-fusion) from our previous default (nexus-web). Update the default client ID to this new value.

Note, other environments yet to be migrated continue to use 'nexus-web' as the client id for the time being. Set CLIENT_ID environment variable to nexus-web to override in the meantime.

## Description

<!--- Describe your changes in detail -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested locally

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
