### PR TITLE
Correct the behaviour of 'missing' filter

### DIFF
--- a/src/subapps/search/containers/NumberFilterOptions.tsx
+++ b/src/subapps/search/containers/NumberFilterOptions.tsx
@@ -49,7 +49,13 @@ const NumberFilterOptions: React.FC<{
 
   const firstRender = React.useRef<boolean>(true);
 
-  const [missingValues, setMissingValues] = React.useState<boolean>(false);
+  // check if 'isMissing' filter is applied
+  const isMissing = filter
+    .find(f => f.filterTerm === field.name)
+    ?.filters.includes('isMissing');
+  const [missingValues, setMissingValues] = React.useState<boolean>(
+    isMissing || false
+  );
 
   const [rangeMin, setRangeMin] = React.useState<number>(
     fieldFilter?.filters[2] ? parseFloat(fieldFilter?.filters[2]) : 0
@@ -165,11 +171,13 @@ const NumberFilterOptions: React.FC<{
       });
     }
   }, [rangeStart, rangeEnd, missingValues]);
-  const renderMissing = () => {
+
+  const renderMissing = React.useCallback(() => {
     return missingCount ? (
       <Form.Item>
         <Checkbox
           disabled={missingCount === 0}
+          checked={missingValues}
           onChange={e => {
             setMissingValues(e.target.checked);
           }}
@@ -178,7 +186,8 @@ const NumberFilterOptions: React.FC<{
         </Checkbox>
       </Form.Item>
     ) : null;
-  };
+  }, [missingValues, missingCount]);
+
   return (
     <>
       <Form.Item>

--- a/src/subapps/search/utils/index.ts
+++ b/src/subapps/search/utils/index.ts
@@ -61,7 +61,7 @@ export const constructNumberFilter = (
   filterTerm: string
 ) => {
   if (filters[0] === 'isMissing') {
-    body.orFilter('bool', missingFilterValueAdder(filterTerm));
+    body.andFilter('bool', missingFilterValueAdder(filterTerm));
     return body;
   }
   const filterObject: any = {};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes BlueBrain/nexus/issues/3152

## Description
When other filters like 'type' is applied, missing filter should be an 'and', instead of an 'or' to make it aligned with user's expectation. Also fixes the issue with the check box value retention for missing values check box.

<!--- Describe your changes in detail -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
