### PR TITLE
Provide a friendlier error message when unable to access authentication provider

### DIFF
--- a/src/shared/layouts/FusionMainLayout.tsx
+++ b/src/shared/layouts/FusionMainLayout.tsx
@@ -135,13 +135,27 @@ const FusionMainLayout: React.FC<FusionMainLayoutProps> = ({
 
   React.useEffect(() => {
     if (loginError) {
+      const errorDescription =
+        loginError.error.message === 'Network Error' ? (
+          <>
+            Nexus Web could not connect to the authentication provider.
+            <br />
+            <br />
+            Check your network connection
+          </>
+        ) : (
+          <>
+            The following error occurred:
+            <br />
+            <br />
+            {loginError.error.message}
+          </>
+        );
       notification.error({
         message: 'We could not log you in',
         description: (
           <div>
-            <p>We could not log you in due to :</p>{' '}
-            <p>{loginError.error.message}</p>
-            <p>Please contact your system administrators.</p>
+            <p>{errorDescription}</p>
           </div>
         ),
       });


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

Fixes https://github.com/BlueBrain/nexus/issues/2970

## Description

<!--- Describe your changes in detail -->
Display a more user-friendly error message when authentication provider is not accessible

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
