### PR TITLE
Clicking icon in search config opens select

### DIFF
--- a/src/subapps/search/components/Layouts/SearchLayouts.less
+++ b/src/subapps/search/components/Layouts/SearchLayouts.less
@@ -1,0 +1,5 @@
+.search-layout {
+  .ant-select-arrow .anticon:not(.ant-select-suffix) {
+    pointer-events: none;
+  }
+}

--- a/src/subapps/search/components/Layouts/index.tsx
+++ b/src/subapps/search/components/Layouts/index.tsx
@@ -2,6 +2,7 @@ import { TableOutlined } from '@ant-design/icons';
 import { Select } from 'antd';
 import * as React from 'react';
 import { SearchLayout } from '../../hooks/useGlobalSearch';
+import './SearchLayouts.less';
 
 const SearchLayouts: React.FC<{
   layouts?: SearchLayout[];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes https://github.com/BlueBrain/nexus/issues/3179

## Description

<!--- Describe your changes in detail -->
Fix issue where clicking icon in the search config select form item would not open the select menu.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
