### PR TITLE
Prevent creating multiple dashboards when clicking multiple times

### DIFF
--- a/src/subapps/studioLegacy/containers/WorkspaceMenuContainer.tsx
+++ b/src/subapps/studioLegacy/containers/WorkspaceMenuContainer.tsx
@@ -175,10 +175,12 @@ const WorkspaceMenu: React.FC<WorkspaceMenuProps> = ({
   const [showEditTableForm, setShowEditTableForm] = React.useState<boolean>(
     false
   );
+  const [isBusy, setIsBusy] = React.useState(false);
 
   const saveDashboardAndDataTable = async (
     table: TableResource | UnsavedTableResource
   ) => {
+    setIsBusy(true);
     try {
       if (!selectedWorkspace) throw new Error();
       const workspaceId = selectedWorkspace['@id'];
@@ -238,6 +240,7 @@ const WorkspaceMenu: React.FC<WorkspaceMenuProps> = ({
     } catch (e) {
       notification.error({ message: 'Failed to save dashboard' });
     }
+    setIsBusy(false);
   };
 
   const deleteWorkSpaceCallBack = React.useCallback(async () => {
@@ -697,7 +700,7 @@ const WorkspaceMenu: React.FC<WorkspaceMenuProps> = ({
               saveDashboardAndDataTable(data);
             }}
             onClose={() => setShowEditTableForm(false)}
-            busy={false}
+            busy={isBusy}
             orgLabel={orgLabel}
             projectLabel={projectLabel}
             formName="Create Dashboard"


### PR DESCRIPTION
Prevent creating multiple dashboards at the same time

Show loading indicator and prevent clicks whilst waiting for response

<!--- Provide a general summary of your changes in the Title above -->

Fixes https://github.com/BlueBrain/nexus/issues/3258

## Description

<!--- Describe your changes in detail -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
