### PR TITLE
3255 numerics bugs

### DIFF
--- a/src/subapps/search/components/SortMenuOptions/index.tsx
+++ b/src/subapps/search/components/SortMenuOptions/index.tsx
@@ -1,6 +1,5 @@
 import {
   CloseCircleOutlined,
-  ConsoleSqlOutlined,
   SortAscendingOutlined,
   SortDescendingOutlined,
 } from '@ant-design/icons';

--- a/src/subapps/search/components/SortMenuOptions/index.tsx
+++ b/src/subapps/search/components/SortMenuOptions/index.tsx
@@ -1,5 +1,6 @@
 import {
   CloseCircleOutlined,
+  ConsoleSqlOutlined,
   SortAscendingOutlined,
   SortDescendingOutlined,
 } from '@ant-design/icons';
@@ -12,12 +13,14 @@ import './SortMenuOptions.less';
 
 const SortMenuOptions: React.FC<{
   sortField?: ESSortField;
+  disabled: boolean;
   onSortField: (sortOption: SortDirection) => void;
   onRemoveSort: (sortOption: ESSortField) => void;
-}> = ({ sortField, onSortField, onRemoveSort }) => {
+}> = ({ sortField, disabled, onSortField, onRemoveSort }) => {
   return (
     <div className="sort-menu-options">
       <Button
+        disabled={disabled}
         className="sort-menu-options__sort-button"
         type={
           sortField?.direction === SortDirection.ASCENDING
@@ -32,6 +35,7 @@ const SortMenuOptions: React.FC<{
         Ascending
       </Button>{' '}
       <Button
+        disabled={disabled}
         className="sort-menu-options__sort-button"
         type={
           sortField?.direction === SortDirection.DESCENDING
@@ -47,6 +51,7 @@ const SortMenuOptions: React.FC<{
       </Button>
       {sortField && (
         <Button
+          disabled={disabled}
           type="text"
           shape="round"
           icon={<CloseCircleOutlined />}

--- a/src/subapps/search/containers/NumberFilterOptions.tsx
+++ b/src/subapps/search/containers/NumberFilterOptions.tsx
@@ -93,6 +93,12 @@ const NumberFilterOptions: React.FC<{
   // }, []);
 
   React.useEffect(() => {
+    if (!firstRender.current) {
+      console.log("FIRST RENDER AND MAJOR USE EFFECT");
+      console.log(firstRender.current);
+      return;
+    }
+
     const allSuggestions = constructQuery(query)
       .aggregation('terms', `${field.name}.value`, 'suggestions', {
         size: 1000,
@@ -100,7 +106,9 @@ const NumberFilterOptions: React.FC<{
       .aggregation('missing', filterKeyWord, '(missing)')
       .aggregation('stats', `${field.name}.value`, 'stats')
       .build();
-
+    // if(filter.length > 0) {
+    //   const withFilter = constructFilterSet(allSuggestions, filter)
+    // }
     const allSuggestionsPromise = nexusClient.Search.query(allSuggestions);
 
     Promise.all([allSuggestionsPromise]).then(([all]) => {

--- a/src/subapps/search/containers/NumberFilterOptions.tsx
+++ b/src/subapps/search/containers/NumberFilterOptions.tsx
@@ -94,7 +94,7 @@ const NumberFilterOptions: React.FC<{
 
   React.useEffect(() => {
     if (!firstRender.current) {
-      console.log("FIRST RENDER AND MAJOR USE EFFECT");
+      console.log('FIRST RENDER AND MAJOR USE EFFECT');
       console.log(firstRender.current);
       return;
     }

--- a/src/subapps/search/containers/NumberFilterOptions.tsx
+++ b/src/subapps/search/containers/NumberFilterOptions.tsx
@@ -148,13 +148,12 @@ const NumberFilterOptions: React.FC<{
     nexusClient.Search.query(withFilter);
   };
   React.useEffect(() => {
-    missingValues
-      ? onFinish({
-          filters: ['isMissing'],
-          filterType: 'missing',
-          filterTerm: field.name,
-        })
-      : missingQuery();
+    const filters = missingValues ? ['isMissing'] : [];
+    onFinish({
+      filters,
+      filterType: 'missing',
+      filterTerm: field.name,
+    });
   }, [missingValues]);
 
   React.useEffect(() => {

--- a/src/subapps/search/containers/NumberFilterOptions.tsx
+++ b/src/subapps/search/containers/NumberFilterOptions.tsx
@@ -12,12 +12,11 @@ import {
 import { NexusClient } from '@bbp/nexus-sdk';
 import * as React from 'react';
 import { FilterState } from '../hooks/useGlobalSearch';
-import { constructQuery, constructFilterSet } from '../utils';
+import { constructQuery } from '../utils';
 import './FilterOptions.less';
 import { createKeyWord } from './FilterOptions';
 import './NumberFilterOptionsContainer.less';
 import { Line, Column } from '@ant-design/charts';
-import { remove } from 'lodash';
 
 type ConfigField =
   | {

--- a/src/subapps/search/containers/NumberFilterOptions.tsx
+++ b/src/subapps/search/containers/NumberFilterOptions.tsx
@@ -148,13 +148,13 @@ const NumberFilterOptions: React.FC<{
     nexusClient.Search.query(withFilter);
   };
   React.useEffect(() => {
-    if (missingValues) {
-      onFinish({
-        filters: ['isMissing'],
-        filterType: 'missing',
-        filterTerm: field.name,
-      });
-    }
+    missingValues
+      ? onFinish({
+          filters: ['isMissing'],
+          filterType: 'missing',
+          filterTerm: field.name,
+        })
+      : missingQuery();
   }, [missingValues]);
 
   React.useEffect(() => {

--- a/src/subapps/search/containers/NumberFilterOptions.tsx
+++ b/src/subapps/search/containers/NumberFilterOptions.tsx
@@ -149,13 +149,11 @@ const NumberFilterOptions: React.FC<{
   const onChange = (e: any) => {
     setGraphValue(e.target.value);
   };
-  const missingQuery = () => {
-    const allSuggestions = constructQuery(query);
-    const withFilter = constructFilterSet(allSuggestions, filter).build();
 
-    nexusClient.Search.query(withFilter);
-  };
   React.useEffect(() => {
+    if (firstRender.current) {
+      return;
+    }
     const filters = missingValues ? ['isMissing'] : [];
     onFinish({
       filters,

--- a/src/subapps/search/containers/NumberFilterOptions.tsx
+++ b/src/subapps/search/containers/NumberFilterOptions.tsx
@@ -147,27 +147,34 @@ const NumberFilterOptions: React.FC<{
     nexusClient.Search.query(withFilter);
   };
   React.useEffect(() => {
-    if (firstRender.current) {
-      firstRender.current = false;
-      return;
-    }
-
     if (missingValues) {
       onFinish({
-        filterType: 'number',
         filters: ['isMissing'],
+        filterType: 'number',
         filterTerm: field.name,
       });
     } else {
       missingQuery();
-      const filters = [rangeStart || rangeMin, rangeEnd || rangeMax];
       onFinish({
-        filters,
+        filters: [],
         filterType: 'number',
         filterTerm: field.name,
       });
     }
-  }, [rangeStart, rangeEnd, missingValues]);
+  }, [missingValues]);
+
+  React.useEffect(() => {
+    if (firstRender.current) {
+      firstRender.current = false;
+      return;
+    }
+    const filters = [rangeStart || rangeMin, rangeEnd || rangeMax];
+    onFinish({
+      filters,
+      filterType: 'number',
+      filterTerm: field.name,
+    });
+  }, [rangeStart, rangeEnd]);
 
   const renderMissing = React.useCallback(() => {
     return missingCount ? (

--- a/src/subapps/search/containers/NumberFilterOptions.tsx
+++ b/src/subapps/search/containers/NumberFilterOptions.tsx
@@ -87,18 +87,7 @@ const NumberFilterOptions: React.FC<{
 
   const filterKeyWord = createKeyWord(field);
 
-  // for missing count.
-  // React.useEffect(() => {
-  //   missingQuery();
-  // }, []);
-
   React.useEffect(() => {
-    if (!firstRender.current) {
-      console.log('FIRST RENDER AND MAJOR USE EFFECT');
-      console.log(firstRender.current);
-      return;
-    }
-
     const allSuggestions = constructQuery(query)
       .aggregation('terms', `${field.name}.value`, 'suggestions', {
         size: 1000,
@@ -106,9 +95,7 @@ const NumberFilterOptions: React.FC<{
       .aggregation('missing', filterKeyWord, '(missing)')
       .aggregation('stats', `${field.name}.value`, 'stats')
       .build();
-    // if(filter.length > 0) {
-    //   const withFilter = constructFilterSet(allSuggestions, filter)
-    // }
+
     const allSuggestionsPromise = nexusClient.Search.query(allSuggestions);
 
     Promise.all([allSuggestionsPromise]).then(([all]) => {
@@ -151,9 +138,7 @@ const NumberFilterOptions: React.FC<{
   };
 
   React.useEffect(() => {
-    if (firstRender.current) {
-      return;
-    }
+    if (firstRender.current) return;
     const filters = missingValues ? ['isMissing'] : [];
     onFinish({
       filters,

--- a/src/subapps/search/containers/NumberFilterOptions.tsx
+++ b/src/subapps/search/containers/NumberFilterOptions.tsx
@@ -17,6 +17,7 @@ import './FilterOptions.less';
 import { createKeyWord } from './FilterOptions';
 import './NumberFilterOptionsContainer.less';
 import { Line, Column } from '@ant-design/charts';
+import { remove } from 'lodash';
 
 type ConfigField =
   | {
@@ -87,9 +88,9 @@ const NumberFilterOptions: React.FC<{
   const filterKeyWord = createKeyWord(field);
 
   // for missing count.
-  React.useEffect(() => {
-    missingQuery();
-  }, []);
+  // React.useEffect(() => {
+  //   missingQuery();
+  // }, []);
 
   React.useEffect(() => {
     const allSuggestions = constructQuery(query)
@@ -150,14 +151,7 @@ const NumberFilterOptions: React.FC<{
     if (missingValues) {
       onFinish({
         filters: ['isMissing'],
-        filterType: 'number',
-        filterTerm: field.name,
-      });
-    } else {
-      missingQuery();
-      onFinish({
-        filters: [],
-        filterType: 'number',
+        filterType: 'missing',
         filterTerm: field.name,
       });
     }
@@ -213,6 +207,7 @@ const NumberFilterOptions: React.FC<{
             <Slider
               min={rangeMin}
               max={rangeMax}
+              disabled={missingValues}
               range={{
                 draggableTrack: true,
               }}

--- a/src/subapps/search/hooks/useGlobalSearch.tsx
+++ b/src/subapps/search/hooks/useGlobalSearch.tsx
@@ -396,7 +396,7 @@ function useGlobalSearchData(
 
   const filtersWithMissing = filterState.map(el => {
     const isMissing =
-      el.filterType === 'missing' && el?.filters.includes('isMissing')
+      el?.filterType === 'missing' && el?.filters.includes('isMissing')
         ? true
         : false;
     return { isMissing, filterTerm: el.filterTerm };

--- a/src/subapps/search/hooks/useGlobalSearch.tsx
+++ b/src/subapps/search/hooks/useGlobalSearch.tsx
@@ -396,7 +396,7 @@ function useGlobalSearchData(
 
   const filtersWithMissing = filterState.map(el => {
     const isMissing =
-      el?.filterType === 'missing' && el?.filters.includes('isMissing')
+      el.filterType === 'missing' && el.filters.includes('isMissing')
         ? true
         : false;
     return { isMissing, filterTerm: el.filterTerm };

--- a/src/subapps/search/hooks/useGlobalSearch.tsx
+++ b/src/subapps/search/hooks/useGlobalSearch.tsx
@@ -394,10 +394,13 @@ function useGlobalSearchData(
 
   const filteredFields = filterState.map(el => extractFieldName(el.filterTerm));
 
-  const isMissing =
-    filterState
-      .find(f => f.filterType === 'missing')
-      ?.filters.includes('isMissing') || false;
+  const filtersWithMissing = filterState.map(el => {
+    const isMissing =
+      el.filterType === 'missing' && el?.filters.includes('isMissing')
+        ? true
+        : false;
+    return { filterTerm: el.filterTerm, isMissing: isMissing };
+  });
 
   const fieldVisibilityInitialState = React.useMemo(() => {
     const fieldVisibilityFromStorage = localStorage.getItem(
@@ -419,6 +422,13 @@ function useGlobalSearchData(
     fieldVisibilityReducer,
     fieldVisibilityInitialState
   );
+
+  function checkDisabled(field: ConfigField) {
+    const res = filtersWithMissing.find(
+      f => f.filterTerm === field.name && f.isMissing
+    );
+    return !!res;
+  }
 
   const onFilterSubmit = (values: FilterState) => {
     if (values.filters.length === 0) {
@@ -454,7 +464,7 @@ function useGlobalSearchData(
           <>
             <h1>SORT</h1>
             <SortMenuOptions
-              disabled={isMissing}
+              disabled={checkDisabled(field)}
               sortField={sortState.find(s => s.fieldName === field.name)}
               onSortField={sortOption => {
                 changeSortOption({

--- a/src/subapps/search/hooks/useGlobalSearch.tsx
+++ b/src/subapps/search/hooks/useGlobalSearch.tsx
@@ -394,6 +394,11 @@ function useGlobalSearchData(
 
   const filteredFields = filterState.map(el => extractFieldName(el.filterTerm));
 
+  const isMissing =
+    filterState
+      .find(f => f.filterType === 'missing')
+      ?.filters.includes('isMissing') || false;
+
   const fieldVisibilityInitialState = React.useMemo(() => {
     const fieldVisibilityFromStorage = localStorage.getItem(
       'search-field-visibility'
@@ -449,6 +454,7 @@ function useGlobalSearchData(
           <>
             <h1>SORT</h1>
             <SortMenuOptions
+              disabled={isMissing}
               sortField={sortState.find(s => s.fieldName === field.name)}
               onSortField={sortOption => {
                 changeSortOption({

--- a/src/subapps/search/hooks/useGlobalSearch.tsx
+++ b/src/subapps/search/hooks/useGlobalSearch.tsx
@@ -399,7 +399,7 @@ function useGlobalSearchData(
       el.filterType === 'missing' && el?.filters.includes('isMissing')
         ? true
         : false;
-    return { filterTerm: el.filterTerm, isMissing: isMissing };
+    return { filterTerm: el.filterTerm, isMissing };
   });
 
   const fieldVisibilityInitialState = React.useMemo(() => {

--- a/src/subapps/search/hooks/useGlobalSearch.tsx
+++ b/src/subapps/search/hooks/useGlobalSearch.tsx
@@ -399,7 +399,7 @@ function useGlobalSearchData(
       el.filterType === 'missing' && el?.filters.includes('isMissing')
         ? true
         : false;
-    return { filterTerm: el.filterTerm, isMissing };
+    return { isMissing, filterTerm: el.filterTerm };
   });
 
   const fieldVisibilityInitialState = React.useMemo(() => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

https://github.com/BlueBrain/nexus/issues/3255

## Description
Fixed the bugs listed in ticket 3255. 
1. Selecting missing values, unselecting, and closing numeric filter dialogue does not add filter to 'filters' in search header
2. sort, slider are disabled when filters are selected for numerical columns
3. sort is disabled for all columns when missing is selected

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
