### PR TITLE
Reselect dashboard, when user removes a selected dashboard

### DIFF
--- a/src/subapps/studioLegacy/containers/WorkspaceMenuContainer.tsx
+++ b/src/subapps/studioLegacy/containers/WorkspaceMenuContainer.tsx
@@ -26,6 +26,30 @@ import STUDIO_CONTEXT from '../components/StudioContext';
 import { createTableContext } from '../../../subapps/projects/utils/workFlowMetadataUtils';
 
 const DASHBOARD_TYPE = 'StudioDashboard';
+
+/**
+ *
+ * @param selectedWorkspace
+ * @param dashboards
+ * @param setSelectedDashboard
+ */
+function reSelectDashboard(
+  selectedWorkspace: any,
+  dashboards: any[],
+  setSelectedDashboard: React.Dispatch<any>
+) {
+  if (selectedWorkspace['dashboards'].length > 0) {
+    const newSelectedDashboard = dashboards.find(
+      d => d['@id'] === selectedWorkspace['dashboards'][0]['dashboard']
+    );
+    if (newSelectedDashboard) {
+      setSelectedDashboard(newSelectedDashboard);
+    } else {
+      setSelectedDashboard(undefined);
+    }
+  }
+}
+
 /**
  *
  * @param nexus
@@ -474,21 +498,28 @@ const WorkspaceMenu: React.FC<WorkspaceMenuProps> = ({
       const currentDashboards: any[] = selectedWorkspace['dashboards'];
       if (dashboards) {
         const indexToRemove = currentDashboards.findIndex(
-          d => d['@id'] === selectedDashboard['@id']
+          d => d['dashboard'] === selectedDashboard['@id']
         );
-        await removeDashBoard(
-          nexus,
-          orgLabel,
-          projectLabel,
-          selectedWorkspace['@id'],
-          indexToRemove,
-          [...currentDashboards]
-        );
-        notification.success({
-          message: `Removed ${selectedDashboard.label}`,
-        });
+        if (indexToRemove >= 0) {
+          await removeDashBoard(
+            nexus,
+            orgLabel,
+            projectLabel,
+            selectedWorkspace['@id'],
+            indexToRemove,
+            [...currentDashboards]
+          );
+          notification.success({
+            message: `Removed ${selectedDashboard.label}`,
+          });
+        } else {
+          notification.error({
+            message: `Failed to remove ${selectedDashboard.label}`,
+          });
+        }
         setDeleteDashBoardConfirmation(false);
         onListUpdate();
+        reSelectDashboard(selectedWorkspace, dashboards, setSelectedDashboard);
       }
     }
   }, [selectedWorkspace, selectedDashboard]);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

When user deletes/removes a dashboard, re-select the first dashboard of that workspace.

## Description

<!--- Describe your changes in detail -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
