### PR TITLE
Strip leading v from the docker version on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,10 @@ jobs:
           fetch-depth: 0
       - name: Build
         run: |
-          docker build -t bluebrain/nexus-web:${{ github.ref_name }} .
+          VERSION=`echo "${{ github.ref_name }}" | 's/^v//gi'`
+          docker build -t bluebrain/nexus-web:$VERSION .
       - name: Publish To DockerHub
         run: |
+          VERSION=`echo "${{ github.ref_name }}" | 's/^v//gi'`
           echo ${{ secrets.DOCKER_PASS }} | docker login --username ${{ secrets.DOCKER_USER }} --password-stdin
-          docker push bluebrain/nexus-web:${{ github.ref_name }}
+          docker push bluebrain/nexus-web:$VERSION


### PR DESCRIPTION
Fixes BlueBrain/nexus#3391

## Description

The `${{ github.ref_name }}` used to extract the version would contain a leading `v`, however the docker image versions should not include it.

The change strips the leading character from the version if it's a `v`.

## How has this been tested?

It will be tested in the next release.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
