### PR TITLE
Fix Datacart Download.

### DIFF
--- a/src/shared/containers/DataCartContainer.tsx
+++ b/src/shared/containers/DataCartContainer.tsx
@@ -21,11 +21,12 @@ import {
   Input,
   Tooltip,
   Popconfirm,
+  message,
 } from 'antd';
 import { CartContext } from '../hooks/useDataCart';
 import ResultPreviewItemContainer from './ResultPreviewItemContainer';
 import DefaultResourcePreviewCard from '!!raw-loader!../templates/DefaultResourcePreviewCard.hbs';
-import useNotification from '../hooks/useNotification';
+import useNotification, { NexusError } from '../hooks/useNotification';
 
 type DownloadResourcePayload = {
   '@type': string;
@@ -65,11 +66,10 @@ async function downloadArchive(
       as: format || 'x-tar',
     }
   );
-  const blob = new Blob([
+  const blob =
     !format || format === 'x-tar'
-      ? archive.toString()
-      : JSON.stringify(archive),
-  ]);
+      ? (archive as Blob)
+      : new Blob([archive.toString()]);
   const url = window.URL.createObjectURL(blob);
   setDownloadUrl(url);
   refContainer.current.click();
@@ -78,7 +78,7 @@ async function downloadArchive(
 const DataCartContainer = () => {
   const nexus = useNexusContext();
   const [downloadUrl, setDownloadUrl] = React.useState<any>(null);
-  const [extension, setExtension] = React.useState<string>('.tar.gz');
+  const [extension, setExtension] = React.useState<string>('tar');
   const refContainer = React.useRef<any>(null);
   const { emptyCart, removeCartItem, length, resources } = React.useContext(
     CartContext
@@ -149,7 +149,13 @@ const DataCartContainer = () => {
             path: `/${parsedSelf.project}/${parsedSelf.id}`,
           };
         });
-      setExtension('tar.gz');
+      if (resourcesPayload.length === 0) {
+        notification.info({
+          message: 'There are no downloadable files in the cart.',
+        });
+        return;
+      }
+      setExtension('tar');
       const {
         payload,
         archiveId,
@@ -169,6 +175,7 @@ const DataCartContainer = () => {
       } catch (ex) {
         notification.error({
           message: `Download failed`,
+          description: (ex as NexusError).reason,
         });
       }
     }
@@ -192,7 +199,7 @@ const DataCartContainer = () => {
       }: { payload: ArchivePayload; archiveId: string } = makePayload(
         resourcesPayload
       );
-      setExtension('tar.gz');
+      setExtension('tar');
       try {
         await downloadArchive(
           nexus,
@@ -203,9 +210,9 @@ const DataCartContainer = () => {
           refContainer
         );
       } catch (ex) {
-        console.log(ex);
         notification.error({
           message: `Download failed`,
+          description: (ex as NexusError).reason,
         });
       }
     }
@@ -233,7 +240,6 @@ const DataCartContainer = () => {
       }: { payload: ArchivePayload; archiveId: string } = makePayload(
         resourcesPayload
       );
-      setExtension('json');
       try {
         await downloadArchive(
           nexus,
@@ -241,13 +247,13 @@ const DataCartContainer = () => {
           payload,
           archiveId,
           setDownloadUrl,
-          refContainer,
-          'json'
+          refContainer
         );
       } catch (ex) {
         console.log(ex);
         notification.error({
           message: `Download failed`,
+          description: (ex as NexusError).reason,
         });
       }
     }

--- a/src/shared/containers/DataCartContainer.tsx
+++ b/src/shared/containers/DataCartContainer.tsx
@@ -21,7 +21,6 @@ import {
   Input,
   Tooltip,
   Popconfirm,
-  message,
 } from 'antd';
 import { CartContext } from '../hooks/useDataCart';
 import ResultPreviewItemContainer from './ResultPreviewItemContainer';


### PR DESCRIPTION
- When there are no files in the list, display a message saying there are no files to the user.
- For meatadata download use tar as the extention/header. JSON will only download archive metadata.
- Remove .gz from all types of download.
- Show delta error message in description on failiure.

<!--- Provide a general summary of your changes in the Title above -->

Fixes BlueBrain/nexus/issues/3238

## Description

<!--- Describe your changes in detail -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
