### PR TITLE
Fix bug where external plugins cannot be opened

### DIFF
--- a/src/shared/containers/ResourcePlugins.tsx
+++ b/src/shared/containers/ResourcePlugins.tsx
@@ -104,16 +104,29 @@ const ResourcePlugins: React.FunctionComponent<{
         const pluginData = pluginDataMap.find(p => p?.key === plugin);
 
         return pluginData ? (
-          <Collapse
+          <ErrorBoundary
+            fallback={() => (
+              <Collapse key={pluginData.name}>
+                <Panel key={pluginData.name} header={pluginData.name}>
+                  <h1>Something went wrong.</h1>
+                  <p>
+                    Check that the shape of the data matches the plugin's
+                    expectations.
+                  </p>
+                </Panel>
+              </Collapse>
+            )}
             key={pluginData.name}
-            onChange={e => handleCollapseChange(pluginData.name)}
-            activeKey={
-              openPlugins.includes(pluginData.name)
-                ? pluginData.name
-                : undefined
-            }
           >
-            <ErrorBoundary fallback={Fallback}>
+            <Collapse
+              key={pluginData.name}
+              onChange={e => handleCollapseChange(pluginData.name)}
+              activeKey={
+                openPlugins.includes(pluginData.name)
+                  ? pluginData.name
+                  : undefined
+              }
+            >
               <Panel
                 header={pluginData.name}
                 key={`${pluginData.name}`}
@@ -132,8 +145,8 @@ const ResourcePlugins: React.FunctionComponent<{
                   />
                 </div>
               </Panel>
-            </ErrorBoundary>
-          </Collapse>
+            </Collapse>
+          </ErrorBoundary>
         ) : null;
       })}
     </>


### PR DESCRIPTION
ErrorBoundary wrapped around Panel causing issue. Moved ErrorBoundary
outside and updated fallback to show message within panel.

<!--- Provide a general summary of your changes in the Title above -->

Fixes https://github.com/BlueBrain/nexus/issues/3446

## Description

<!--- Describe your changes in detail -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
