### PR TITLE
Feature/3357 enable id self search

### DIFF
--- a/src/shared/containers/ResourceListContainer.tsx
+++ b/src/shared/containers/ResourceListContainer.tsx
@@ -1,7 +1,11 @@
 import * as React from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 import { useNexusContext } from '@bbp/react-nexus';
-import { Resource } from '@bbp/nexus-sdk';
+import {
+  DEFAULT_ELASTIC_SEARCH_VIEW_ID,
+  ElasticSearchViewQueryResponse,
+  Resource,
+} from '@bbp/nexus-sdk';
 
 import ResourceListComponent, {
   ResourceBoardList,
@@ -125,28 +129,73 @@ const ResourceListContainer: React.FunctionComponent<{
       error: null,
     });
 
-    let resourceListResponse: any = [];
-
-    nexus.Resource.list(orgLabel, projectLabel, list.query)
-      .then(response => {
-        resourceListResponse = response;
+    (async () => {
+      const [resourcesByIdOrSelf, resourcesResults] = await Promise.allSettled([
+        nexus.View.elasticSearchQuery(
+          orgLabel,
+          projectLabel,
+          encodeURIComponent(DEFAULT_ELASTIC_SEARCH_VIEW_ID),
+          {
+            query: {
+              bool: {
+                should: [
+                  {
+                    term: {
+                      '@id': list.query.q,
+                    },
+                  },
+                  {
+                    term: {
+                      _self: list.query.q,
+                    },
+                  },
+                ],
+              },
+            },
+            size: 10,
+          }
+        ),
+        nexus.Resource.list(orgLabel, projectLabel, list.query),
+      ]);
+      if (resourcesByIdOrSelf.status === 'fulfilled') {
+        const resultsLength = resourcesByIdOrSelf.value.hits.hits.length;
+        const hits = resourcesByIdOrSelf.value.hits.hits;
+        if (resultsLength) {
+          setResources({
+            next: null,
+            // @ts-ignore
+            resources: hits.map(hit => {
+              return {
+                ...JSON.parse(hit._source['_original_source']),
+                '@id': hit._source['@id'],
+              };
+            }),
+            total: resultsLength,
+            busy: false,
+            error: null,
+          });
+          return;
+        }
+      }
+      if (resourcesResults.status === 'fulfilled') {
         setResources({
           next: null,
-          resources: resourceListResponse._results,
-          total: resourceListResponse._total,
+          // @ts-ignore
+          resources: resourcesResults.value._results,
+          total: resourcesResults.value._total,
           busy: false,
           error: null,
         });
-      })
-      .catch(error => {
+      } else {
         setResources({
           next,
-          error,
+          error: resourcesResults.reason,
           resources,
           total,
           busy: false,
         });
-      });
+      }
+    })();
   }, [
     orgLabel,
     projectLabel,
@@ -154,7 +203,6 @@ const ResourceListContainer: React.FunctionComponent<{
     toggleForceReload,
     refreshList,
   ]);
-
   const handleDelete = () => {
     onDeleteList(list.id);
   };

--- a/src/shared/containers/ResourceListContainer.tsx
+++ b/src/shared/containers/ResourceListContainer.tsx
@@ -189,10 +189,10 @@ const ResourceListContainer: React.FunctionComponent<{
       } else {
         setResources({
           next,
-          error: resourcesResults.reason,
           resources,
           total,
           busy: false,
+          error: resourcesResults.reason,
         });
       }
     })();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #https://github.com/BlueBrain/nexus/issues/3357

## Description

1. add new query using `View.elasticSearchQuery` to filter resources by term (`@id, _self`)
2. first show the results if an `@id` or `_self` match
3. else show full text search using `Resource.list`

<!--- Describe your changes in detail -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
