### PR TITLE
3347 // Remove page size selector options from studio tables

### DIFF
--- a/src/shared/components/EditTableForm.tsx
+++ b/src/shared/components/EditTableForm.tsx
@@ -616,25 +616,6 @@ const EditTableForm: React.FC<{
             <br />
           </div>
         </div>
-        <Row>
-          <Col xs={6} sm={6} md={6}>
-            <h3>Results per page</h3>
-          </Col>
-          <Col>
-            <Select
-              value={resultsPerPage}
-              onChange={value => {
-                setResultsPerPage(value);
-              }}
-            >
-              {PAGES_OPTIONS.map(pages => (
-                <Option key={pages} value={pages}>
-                  {pages}
-                </Option>
-              ))}
-            </Select>
-          </Col>
-        </Row>
         <div className="edit-table-form__query">
           <h3>Query</h3>
           <div className="code">

--- a/src/shared/containers/DataTableContainer.spec.tsx
+++ b/src/shared/containers/DataTableContainer.spec.tsx
@@ -93,7 +93,7 @@ describe('DataTableContainer.spec.tsx', () => {
     return container.querySelectorAll(`td.testid-${name}`);
   };
 
-  const waitForTableRows = async (expectedRowsCount = 5) => {
+  const waitForTableRows = async (expectedRowsCount = 6) => {
     return await waitFor(() => {
       const rows = visibleTableRows();
       expect(rows.length).toEqual(expectedRowsCount);
@@ -135,6 +135,7 @@ describe('DataTableContainer.spec.tsx', () => {
         ORIGINAL_3_SORTED_3,
         ORIGINAL_4_SORTED_4,
         ORIGINAL_5_SORTED_6,
+        ORIGINAL_6_SORTED_5,
       ]);
     });
   });
@@ -145,7 +146,7 @@ describe('DataTableContainer.spec.tsx', () => {
     // Click on sort button once to sort in ascending order
     await user.click(sortableHeader!);
 
-    await waitForTableRows(5);
+    await waitForTableRows(6);
 
     assertDataOrderInColumn('givenName', [
       ORIGINAL_2_SORTED_1,
@@ -153,6 +154,7 @@ describe('DataTableContainer.spec.tsx', () => {
       ORIGINAL_3_SORTED_3,
       ORIGINAL_4_SORTED_4,
       ORIGINAL_6_SORTED_5,
+      ORIGINAL_5_SORTED_6,
     ]);
   });
 
@@ -163,7 +165,7 @@ describe('DataTableContainer.spec.tsx', () => {
     await user.click(sortableHeader!);
     await user.click(sortableHeader!);
 
-    await waitForTableRows(5);
+    await waitForTableRows(6);
 
     assertDataOrderInColumn('givenName', [
       ORIGINAL_5_SORTED_6,
@@ -171,6 +173,7 @@ describe('DataTableContainer.spec.tsx', () => {
       ORIGINAL_6_SORTED_5,
       ORIGINAL_3_SORTED_3,
       ORIGINAL_1_SORTED_2,
+      ORIGINAL_2_SORTED_1,
     ]);
   });
 

--- a/src/shared/containers/DataTableContainer.tsx
+++ b/src/shared/containers/DataTableContainer.tsx
@@ -402,8 +402,7 @@ const DataTableContainer: React.FC<DataTableProps> = ({
               },
             })}
             pagination={{
-              pageSize:
-                tableData.tableResult.data.tableResource['resultsPerPage'],
+              pageSize: 50,
               responsive: true,
               showLessItems: true,
             }}

--- a/src/shared/styles/data-table.less
+++ b/src/shared/styles/data-table.less
@@ -21,3 +21,7 @@ h3.ant-typography.table-title {
     margin-left: auto;
   }
 }
+
+.ant-pagination-options .ant-pagination-options-size-changer {
+  display: none !important;
+}

--- a/src/subapps/studioLegacy/containers/__tests__/WorkSpaceMenuContainer.spec.tsx
+++ b/src/subapps/studioLegacy/containers/__tests__/WorkSpaceMenuContainer.spec.tsx
@@ -212,7 +212,7 @@ describe('workSpaceMenu', () => {
         const text = await screen.getAllByText(
           'https://bluebrain.github.io/nexus/vocabulary/apiMappings'
         );
-        expect(text.length).toBe(5);
+        expect(text.length).toBe(9);
       });
       expect(container).toMatchSnapshot();
     });

--- a/src/subapps/studioLegacy/containers/__tests__/__snapshots__/WorkSpaceMenuContainer.spec.tsx.snap
+++ b/src/subapps/studioLegacy/containers/__tests__/__snapshots__/WorkSpaceMenuContainer.spec.tsx.snap
@@ -614,6 +614,181 @@ exports[`workSpaceMenu renders with a single workspace and dashboard  1`] = `
                             t98
                           </td>
                         </tr>
+                        <tr
+                          class="ant-table-row ant-table-row-level-0 data-table-row"
+                          data-row-key="tr_5"
+                        >
+                          <td
+                            class="ant-table-cell ant-table-selection-column"
+                          >
+                            <label
+                              class="ant-checkbox-wrapper"
+                            >
+                              <span
+                                class="ant-checkbox"
+                              >
+                                <input
+                                  class="ant-checkbox-input"
+                                  type="checkbox"
+                                  value=""
+                                />
+                                <span
+                                  class="ant-checkbox-inner"
+                                />
+                              </span>
+                            </label>
+                          </td>
+                          <td
+                            class="ant-table-cell testid-p"
+                          >
+                            https://bluebrain.github.io/nexus/vocabulary/apiMappings
+                          </td>
+                          <td
+                            class="ant-table-cell testid-o"
+                          >
+                            t100
+                          </td>
+                        </tr>
+                        <tr
+                          class="ant-table-row ant-table-row-level-0 data-table-row"
+                          data-row-key="tr_6"
+                        >
+                          <td
+                            class="ant-table-cell ant-table-selection-column"
+                          >
+                            <label
+                              class="ant-checkbox-wrapper"
+                            >
+                              <span
+                                class="ant-checkbox"
+                              >
+                                <input
+                                  class="ant-checkbox-input"
+                                  type="checkbox"
+                                  value=""
+                                />
+                                <span
+                                  class="ant-checkbox-inner"
+                                />
+                              </span>
+                            </label>
+                          </td>
+                          <td
+                            class="ant-table-cell testid-p"
+                          >
+                            https://bluebrain.github.io/nexus/vocabulary/apiMappings
+                          </td>
+                          <td
+                            class="ant-table-cell testid-o"
+                          >
+                            t114
+                          </td>
+                        </tr>
+                        <tr
+                          class="ant-table-row ant-table-row-level-0 data-table-row"
+                          data-row-key="tr_7"
+                        >
+                          <td
+                            class="ant-table-cell ant-table-selection-column"
+                          >
+                            <label
+                              class="ant-checkbox-wrapper"
+                            >
+                              <span
+                                class="ant-checkbox"
+                              >
+                                <input
+                                  class="ant-checkbox-input"
+                                  type="checkbox"
+                                  value=""
+                                />
+                                <span
+                                  class="ant-checkbox-inner"
+                                />
+                              </span>
+                            </label>
+                          </td>
+                          <td
+                            class="ant-table-cell testid-p"
+                          >
+                            https://bluebrain.github.io/nexus/vocabulary/apiMappings
+                          </td>
+                          <td
+                            class="ant-table-cell testid-o"
+                          >
+                            t120
+                          </td>
+                        </tr>
+                        <tr
+                          class="ant-table-row ant-table-row-level-0 data-table-row"
+                          data-row-key="tr_8"
+                        >
+                          <td
+                            class="ant-table-cell ant-table-selection-column"
+                          >
+                            <label
+                              class="ant-checkbox-wrapper"
+                            >
+                              <span
+                                class="ant-checkbox"
+                              >
+                                <input
+                                  class="ant-checkbox-input"
+                                  type="checkbox"
+                                  value=""
+                                />
+                                <span
+                                  class="ant-checkbox-inner"
+                                />
+                              </span>
+                            </label>
+                          </td>
+                          <td
+                            class="ant-table-cell testid-p"
+                          >
+                            https://bluebrain.github.io/nexus/vocabulary/apiMappings
+                          </td>
+                          <td
+                            class="ant-table-cell testid-o"
+                          >
+                            t127
+                          </td>
+                        </tr>
+                        <tr
+                          class="ant-table-row ant-table-row-level-0 data-table-row"
+                          data-row-key="tr_9"
+                        >
+                          <td
+                            class="ant-table-cell ant-table-selection-column"
+                          >
+                            <label
+                              class="ant-checkbox-wrapper"
+                            >
+                              <span
+                                class="ant-checkbox"
+                              >
+                                <input
+                                  class="ant-checkbox-input"
+                                  type="checkbox"
+                                  value=""
+                                />
+                                <span
+                                  class="ant-checkbox-inner"
+                                />
+                              </span>
+                            </label>
+                          </td>
+                          <td
+                            class="ant-table-cell testid-p"
+                          >
+                            https://bluebrain.github.io/nexus/vocabulary/base
+                          </td>
+                          <td
+                            class="ant-table-cell testid-o"
+                          >
+                            https://bbp.epfl.ch/neurosciencegraph/data/
+                          </td>
+                        </tr>
                       </tbody>
                     </table>
                   </div>
@@ -666,24 +841,13 @@ exports[`workSpaceMenu renders with a single workspace and dashboard  1`] = `
                   </a>
                 </li>
                 <li
-                  class="ant-pagination-item ant-pagination-item-2"
-                  tabindex="0"
-                  title="2"
-                >
-                  <a
-                    rel="nofollow"
-                  >
-                    2
-                  </a>
-                </li>
-                <li
-                  aria-disabled="false"
-                  class="ant-pagination-next"
-                  tabindex="0"
+                  aria-disabled="true"
+                  class="ant-pagination-next ant-pagination-disabled"
                   title="Next Page"
                 >
                   <button
                     class="ant-pagination-item-link"
+                    disabled=""
                     tabindex="-1"
                     type="button"
                   >


### PR DESCRIPTION
As discussed during backlog grooming, we will remove display 50 items in the studio tables and remove the page size configuration options we today show to the UI. So, the following parts are removed from the UI 

![Screenshot 2023-04-26 at 16 54 51](https://user-images.githubusercontent.com/11242410/234616039-9f743b29-2e1a-414f-b31d-523a3d6c4a23.png)
![Screenshot 2023-04-26 at 16 54 10](https://user-images.githubusercontent.com/11242410/234616055-1bbc9dd2-0ea5-4367-87ed-575611a87511.png)

Fixes #[3347](https://app.zenhub.com/workspaces/blue-brain-nexus-60ace035034cae00105c9307/issues/gh/bluebrain/nexus/3347)


## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [X] I have added screenshots (if applicable), in the comment section.
