### PR TITLE
3834 // Handle errors in studios

### DIFF
--- a/package.json
+++ b/package.json
@@ -210,7 +210,8 @@
     ],
     "globals": {
       "FUSION_VERSION": "1.0.0"
-    }
+    },
+    "watchPathIgnorePatterns": ["node_modules"]
   },
   "prettier": {
     "singleQuote": true,

--- a/src/shared/components/ErrorComponent.tsx
+++ b/src/shared/components/ErrorComponent.tsx
@@ -1,0 +1,30 @@
+import { Alert, Collapse } from 'antd';
+import React from 'react';
+
+interface ErrorComponentProps {
+  message: string;
+  details?: string;
+}
+const { Panel } = Collapse;
+
+export const ErrorComponent = ({ message, details }: ErrorComponentProps) => {
+  return (
+    <>
+      {details ? (
+        <Collapse
+          style={{
+            background: '#fff2f0',
+            borderColor: '#ffccc7',
+            margin: '20px',
+          }}
+        >
+          <Panel header={message} key={message}>
+            <pre>{details}</pre>
+          </Panel>
+        </Collapse>
+      ) : (
+        <Alert message={message} type="error" style={{ margin: '20px' }} />
+      )}
+    </>
+  );
+};

--- a/src/shared/views/Login.tsx
+++ b/src/shared/views/Login.tsx
@@ -44,6 +44,7 @@ const Login: React.FunctionComponent<LoginViewProps> = props => {
           const redirectUri = destination
             ? `${window.location.origin}/${destination}`
             : null;
+
           props.userManager &&
             (await props.userManager.signinRedirect({
               redirect_uri: redirectUri,

--- a/src/subapps/admin/components/ViewForm/SparqlQueryResults.tsx
+++ b/src/subapps/admin/components/ViewForm/SparqlQueryResults.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
-import { Card, Empty, Table, Tooltip, Alert } from 'antd';
+import { Card, Table, Tooltip } from 'antd';
 import Column from 'antd/lib/table/Column';
 import * as hash from 'object-hash';
 import { matchResultUrls } from '../../../../shared/utils';
-import { CloseCircleFilled } from '@ant-design/icons';
 import {
   AskQueryResponse,
   SelectQueryResponse,
@@ -12,6 +11,7 @@ import {
 
 import './view-form.less';
 import useNotification from '../../../../shared/hooks/useNotification';
+import { ErrorComponent } from '../../../../shared/components/ErrorComponent';
 
 export type NexusSparqlError =
   | string
@@ -63,29 +63,12 @@ const SparqlQueryResults: React.FunctionComponent<{
   };
   return (
     <Card bordered className="results">
-      {error && (
-        <Empty
-          image={<CloseCircleFilled style={{ fontSize: 70, color: 'red' }} />}
-          description={
-            typeof error === 'string' ? (
-              <Alert message={error} type="error" closable={false} showIcon />
-            ) : (
-              <div>
-                <Alert
-                  message={error.reason}
-                  type="error"
-                  closable={false}
-                  showIcon
-                  style={{ textAlign: 'left' }}
-                />
-                <pre style={{ textAlign: 'left', marginTop: 10 }}>
-                  {error.details}
-                </pre>
-              </div>
-            )
-          }
-        />
-      )}
+      {error &&
+        (typeof error === 'string' ? (
+          <ErrorComponent message={error} />
+        ) : (
+          <ErrorComponent message={error.reason} details={error.details} />
+        ))}
       {!error && (
         <Table
           dataSource={data}

--- a/src/subapps/admin/containers/SparqlQuery.tsx
+++ b/src/subapps/admin/containers/SparqlQuery.tsx
@@ -31,7 +31,7 @@ const SparqlQueryContainer: React.FunctionComponent<{
   const [{ response, busy, error }, setResponse] = React.useState<{
     response: SparqlViewQueryResponse | null;
     busy: boolean;
-    error: string | { reason: string; details: string } | null;
+    error: string | null;
   }>({
     response: null,
     busy: false,

--- a/src/subapps/studioLegacy/containers/DashBoardEditor/DashboardEditorContainer.tsx
+++ b/src/subapps/studioLegacy/containers/DashBoardEditor/DashboardEditorContainer.tsx
@@ -58,7 +58,6 @@ const DashboardEditorContainer: React.FunctionComponent<{
   const handleSubmit = async (dashboardPayload: DashboardPayload) => {
     try {
       setBusy(true);
-
       await nexus.Resource.update(
         orgLabel,
         projectLabel,

--- a/src/subapps/studioLegacy/containers/WorkspaceMenuContainer.tsx
+++ b/src/subapps/studioLegacy/containers/WorkspaceMenuContainer.tsx
@@ -25,6 +25,7 @@ import DataTableContainer, {
 import STUDIO_CONTEXT from '../components/StudioContext';
 import { createTableContext } from '../../../subapps/projects/utils/workFlowMetadataUtils';
 import { find } from 'lodash';
+import { ErrorComponent } from '../../../shared/components/ErrorComponent';
 
 const DASHBOARD_TYPE = 'StudioDashboard';
 
@@ -205,7 +206,9 @@ const WorkspaceMenu: React.FC<WorkspaceMenuProps> = ({
     false
   );
   const [isBusy, setIsBusy] = React.useState(false);
-
+  const [tableDataError, setTableDataError] = React.useState<Error | null>(
+    null
+  );
   const saveDashboardAndDataTable = async (
     table: TableResource | UnsavedTableResource
   ) => {
@@ -474,6 +477,7 @@ const WorkspaceMenu: React.FC<WorkspaceMenuProps> = ({
         notification.error({
           message: 'Failed to fetch dashboards',
         });
+        setDashboardSpinner(false);
       });
     setDashboardSpinner(false);
   };
@@ -497,7 +501,9 @@ const WorkspaceMenu: React.FC<WorkspaceMenuProps> = ({
           description: data.description,
           label: data['name'],
         }
-      );
+      ).catch(err => {
+        throw err;
+      });
       onListUpdate();
     }
   };
@@ -720,6 +726,13 @@ const WorkspaceMenu: React.FC<WorkspaceMenuProps> = ({
       </Menu>
       <div>
         {renderResults()}
+        {tableDataError && (
+          <ErrorComponent
+            message={tableDataError.message}
+            // @ts-ignore TODO: Remove ts-ignore when we support es2022 for ts.
+            details={(tableDataError.cause as any)?.details}
+          />
+        )}
         <AddWorkspaceContainer
           key={studioResource['@id']}
           orgLabel={orgLabel}
@@ -776,6 +789,7 @@ const WorkspaceMenu: React.FC<WorkspaceMenuProps> = ({
             onSave={data => {
               saveDashboardAndDataTable(data);
             }}
+            onError={err => setTableDataError(err)}
             onClose={() => setShowEditTableForm(false)}
             busy={isBusy}
             orgLabel={orgLabel}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #[3256](https://app.zenhub.com/workspaces/blue-brain-nexus-60ace035034cae00105c9307/issues/gh/bluebrain/nexus/3256)

## Description

Shows errors to the user in a collapsible box if there was error in fetching resouces, or error in syntax of the query.

<img width="803" alt="Screenshot 2023-04-28 at 10 38 54" src="https://user-images.githubusercontent.com/11242410/235722108-b5faacfe-978a-423b-9aa5-21b2b88e5842.png">


## How to test:

1. Go to studios and create a workspace if there isn't one already.
2. Add a dashboard with sparql query
3. Save the table => No error should be shown
4. Edit table and add a type in the sparql query
5. Click on "Configure Columns" => Error message should be displayed in the dilog
6. When you click "Save" error message should also be displayed under the table.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added necessary unit and integration tests.
- [X] I have added screenshots (if applicable), in the comment section.
