### PR TITLE
Feature 3224 // studio data download

### DIFF
--- a/src/__mocks__/handlers/handlers.ts
+++ b/src/__mocks__/handlers/handlers.ts
@@ -601,7 +601,7 @@ export const handlers = [
             },
             self: {
               type: 'uri',
-              value: deltaPath('/nexus/v1/projects/nise/kerrien'),
+              value: deltaPath('/nexus/v1/projects/nise/kerrien1'),
             },
           },
           {
@@ -612,7 +612,7 @@ export const handlers = [
             },
             self: {
               type: 'uri',
-              value: deltaPath('/nexus/v1/projects/nise/kerrien'),
+              value: deltaPath('/nexus/v1/projects/nise/kerrien2'),
             },
           },
           {
@@ -623,7 +623,7 @@ export const handlers = [
             },
             self: {
               type: 'uri',
-              value: deltaPath('/nexus/v1/projects/nise/kerrien'),
+              value: deltaPath('/nexus/v1/projects/nise/kerrien3'),
             },
           },
           {
@@ -634,7 +634,7 @@ export const handlers = [
             },
             self: {
               type: 'uri',
-              value: deltaPath('/nexus/v1/projects/nise/kerrien'),
+              value: deltaPath('/nexus/v1/projects/nise/kerrien4'),
             },
           },
           {
@@ -645,7 +645,7 @@ export const handlers = [
             },
             self: {
               type: 'uri',
-              value: deltaPath('/nexus/v1/projects/nise/kerrien'),
+              value: deltaPath('/nexus/v1/projects/nise/kerrien5'),
             },
           },
           {
@@ -656,7 +656,7 @@ export const handlers = [
             },
             self: {
               type: 'uri',
-              value: deltaPath('/nexus/v1/projects/nise/kerrien'),
+              value: deltaPath('/nexus/v1/projects/nise/kerrien6'),
             },
           },
           {
@@ -667,7 +667,7 @@ export const handlers = [
             },
             self: {
               type: 'uri',
-              value: deltaPath('/nexus/v1/projects/nise/kerrien'),
+              value: deltaPath('/nexus/v1/projects/nise/kerrien7'),
             },
           },
           {
@@ -678,7 +678,7 @@ export const handlers = [
             },
             self: {
               type: 'uri',
-              value: deltaPath('/nexus/v1/projects/nise/kerrien'),
+              value: deltaPath('/nexus/v1/projects/nise/kerrien8'),
             },
           },
           {
@@ -689,7 +689,7 @@ export const handlers = [
             },
             self: {
               type: 'uri',
-              value: deltaPath('/nexus/v1/projects/nise/kerrien'),
+              value: deltaPath('/nexus/v1/projects/nise/kerrien9'),
             },
           },
           {
@@ -703,7 +703,7 @@ export const handlers = [
             },
             self: {
               type: 'uri',
-              value: deltaPath('/nexus/v1/projects/nise/kerrien'),
+              value: deltaPath('/nexus/v1/projects/nise/kerrien10'),
             },
           },
         ],

--- a/src/shared/containers/ResourceViewActionsContainer.tsx
+++ b/src/shared/containers/ResourceViewActionsContainer.tsx
@@ -12,11 +12,12 @@ import { RootState } from '../store/reducers';
 import { useOrganisationsSubappContext } from '../../subapps/admin';
 import Copy from '../components/Copy';
 import {
-  MAX_DATA_SELECTED_ALLOWED_SIZE,
+  MAX_DATA_SELECTED_SIZE__IN_BYTES,
   TResourceTableData,
   MAX_LOCAL_STORAGE_ALLOWED_SIZE,
   getLocalStorageSize,
   notifyTotalSizeExeeced,
+  Distribution,
 } from '../../shared/molecules/MyDataTable/MyDataTable';
 import {
   DATA_PANEL_STORAGE,
@@ -81,11 +82,12 @@ const ResourceViewActionsContainer: React.FC<{
       isRemoved = false;
     }
     const size = selectedRows.reduce(
-      (acc, item) => acc + (item.distribution?.contentSize || 0),
+      (acc, item) =>
+        acc + ((item.distribution as Distribution)?.contentSize || 0),
       0
     );
     if (
-      size > MAX_DATA_SELECTED_ALLOWED_SIZE ||
+      size > MAX_DATA_SELECTED_SIZE__IN_BYTES ||
       getLocalStorageSize() > MAX_LOCAL_STORAGE_ALLOWED_SIZE
     ) {
       return notifyTotalSizeExeeced();

--- a/src/shared/molecules/MyDataTable/MyDataTable.tsx
+++ b/src/shared/molecules/MyDataTable/MyDataTable.tsx
@@ -21,8 +21,10 @@ import { TFilterOptions } from '../MyDataHeader/MyDataHeader';
 import timeago from '../../../utils/timeago';
 import isValidUrl from '../../../utils/validUrl';
 import './styles.less';
-export const MAX_DATA_SELECTED_ALLOWED_SIZE = 1073741824;
+
+export const MAX_DATA_SELECTED_SIZE__IN_BYTES = 1_073_741_824;
 export const MAX_LOCAL_STORAGE_ALLOWED_SIZE = 4.5;
+
 type TResource = {
   [key: string]: any;
 } & {
@@ -55,6 +57,14 @@ export type TResourceTableData = {
   selectedRowKeys: React.Key[];
   selectedRows: TDataSource[];
 };
+
+export type Distribution = {
+  contentSize: number;
+  encodingFormat: string | string[];
+  label: string | string[];
+  hasDistribution: boolean;
+};
+
 export type TDataSource = {
   source?: string;
   key: React.Key;
@@ -71,6 +81,7 @@ export type TDataSource = {
     contentSize: number;
     encodingFormat: string | string[];
     label: string | string[];
+    hasDistribution?: boolean;
   };
 };
 type TProps = {
@@ -99,6 +110,7 @@ const makeResourceUri = (
     resourceId
   )}`;
 };
+
 export const getLocalStorageSize = () => {
   let size = 0;
   for (let i = 0; i < localStorage.length; i += 1) {
@@ -109,6 +121,7 @@ export const getLocalStorageSize = () => {
   size = size / 1048576;
   return size;
 };
+
 export const notifyTotalSizeExeeced = () => {
   return notification.warning({
     message: (
@@ -117,10 +130,11 @@ export const notifyTotalSizeExeeced = () => {
         storage size will reduce the performance of your app
       </div>
     ),
-    description: <em>Maximum size must be lower or equal than 1GB</em>,
+    description: <em>Maximum size must be lower than or equal to 1GB</em>,
     key: 'data-panel-size-exceeded',
   });
 };
+
 const MyDataTable: React.FC<TProps> = ({
   setFilterOptions,
   isLoading,
@@ -320,7 +334,7 @@ const MyDataTable: React.FC<TProps> = ({
       0
     );
     if (
-      size > MAX_DATA_SELECTED_ALLOWED_SIZE ||
+      size > MAX_DATA_SELECTED_SIZE__IN_BYTES ||
       getLocalStorageSize() > MAX_LOCAL_STORAGE_ALLOWED_SIZE
     ) {
       return notifyTotalSizeExeeced();
@@ -372,7 +386,7 @@ const MyDataTable: React.FC<TProps> = ({
       0
     );
     if (
-      size > MAX_DATA_SELECTED_ALLOWED_SIZE ||
+      size > MAX_DATA_SELECTED_SIZE__IN_BYTES ||
       getLocalStorageSize() > MAX_LOCAL_STORAGE_ALLOWED_SIZE
     ) {
       return notifyTotalSizeExeeced();

--- a/src/shared/styles/data-table.less
+++ b/src/shared/styles/data-table.less
@@ -25,3 +25,7 @@ h3.ant-typography.table-title {
 .ant-pagination-options .ant-pagination-options-size-changer {
   display: none !important;
 }
+
+.studio-table-container {
+  margin-bottom: 60px; // Leave space for the data-panel that shows cart objects
+}

--- a/src/subapps/search/containers/SearchContainer.tsx
+++ b/src/subapps/search/containers/SearchContainer.tsx
@@ -17,7 +17,7 @@ import ColumnsVisibilityConfig from '../components/ColumnsVisibilityConfig';
 import FiltersConfig from '../components/FiltersConfig';
 import SortConfigContainer from './SortConfigContainer';
 import {
-  MAX_DATA_SELECTED_ALLOWED_SIZE,
+  MAX_DATA_SELECTED_SIZE__IN_BYTES,
   MAX_LOCAL_STORAGE_ALLOWED_SIZE,
   TDataSource,
   TResourceTableData,
@@ -183,7 +183,7 @@ const SearchContainer: React.FC = () => {
       0
     );
     if (
-      size > MAX_DATA_SELECTED_ALLOWED_SIZE ||
+      size > MAX_DATA_SELECTED_SIZE__IN_BYTES ||
       getLocalStorageSize() > MAX_LOCAL_STORAGE_ALLOWED_SIZE
     ) {
       return notifyTotalSizeExeeced();
@@ -264,7 +264,7 @@ const SearchContainer: React.FC = () => {
       0
     );
     if (
-      size > MAX_DATA_SELECTED_ALLOWED_SIZE ||
+      size > MAX_DATA_SELECTED_SIZE__IN_BYTES ||
       getLocalStorageSize() > MAX_LOCAL_STORAGE_ALLOWED_SIZE
     ) {
       return notifyTotalSizeExeeced();

--- a/src/subapps/studioLegacy/containers/__tests__/__snapshots__/WorkSpaceMenuContainer.spec.tsx.snap
+++ b/src/subapps/studioLegacy/containers/__tests__/__snapshots__/WorkSpaceMenuContainer.spec.tsx.snap
@@ -178,7 +178,9 @@ exports[`workSpaceMenu renders with a single workspace and dashboard  1`] = `
       style="display: none;"
     />
     <div>
-      <div>
+      <div
+        class="studio-table-container"
+      >
         <div
           class="ant-table-wrapper"
         >
@@ -441,7 +443,7 @@ exports[`workSpaceMenu renders with a single workspace and dashboard  1`] = `
                         </tr>
                         <tr
                           class="ant-table-row ant-table-row-level-0 data-table-row"
-                          data-row-key="tr_0"
+                          data-row-key="https://localhost:3000/nexus/v1/projects/nise/kerrien1"
                         >
                           <td
                             class="ant-table-cell ant-table-selection-column"
@@ -476,7 +478,7 @@ exports[`workSpaceMenu renders with a single workspace and dashboard  1`] = `
                         </tr>
                         <tr
                           class="ant-table-row ant-table-row-level-0 data-table-row"
-                          data-row-key="tr_1"
+                          data-row-key="https://localhost:3000/nexus/v1/projects/nise/kerrien2"
                         >
                           <td
                             class="ant-table-cell ant-table-selection-column"
@@ -511,7 +513,7 @@ exports[`workSpaceMenu renders with a single workspace and dashboard  1`] = `
                         </tr>
                         <tr
                           class="ant-table-row ant-table-row-level-0 data-table-row"
-                          data-row-key="tr_2"
+                          data-row-key="https://localhost:3000/nexus/v1/projects/nise/kerrien3"
                         >
                           <td
                             class="ant-table-cell ant-table-selection-column"
@@ -546,7 +548,7 @@ exports[`workSpaceMenu renders with a single workspace and dashboard  1`] = `
                         </tr>
                         <tr
                           class="ant-table-row ant-table-row-level-0 data-table-row"
-                          data-row-key="tr_3"
+                          data-row-key="https://localhost:3000/nexus/v1/projects/nise/kerrien4"
                         >
                           <td
                             class="ant-table-cell ant-table-selection-column"
@@ -581,7 +583,7 @@ exports[`workSpaceMenu renders with a single workspace and dashboard  1`] = `
                         </tr>
                         <tr
                           class="ant-table-row ant-table-row-level-0 data-table-row"
-                          data-row-key="tr_4"
+                          data-row-key="https://localhost:3000/nexus/v1/projects/nise/kerrien5"
                         >
                           <td
                             class="ant-table-cell ant-table-selection-column"
@@ -616,7 +618,7 @@ exports[`workSpaceMenu renders with a single workspace and dashboard  1`] = `
                         </tr>
                         <tr
                           class="ant-table-row ant-table-row-level-0 data-table-row"
-                          data-row-key="tr_5"
+                          data-row-key="https://localhost:3000/nexus/v1/projects/nise/kerrien6"
                         >
                           <td
                             class="ant-table-cell ant-table-selection-column"
@@ -651,7 +653,7 @@ exports[`workSpaceMenu renders with a single workspace and dashboard  1`] = `
                         </tr>
                         <tr
                           class="ant-table-row ant-table-row-level-0 data-table-row"
-                          data-row-key="tr_6"
+                          data-row-key="https://localhost:3000/nexus/v1/projects/nise/kerrien7"
                         >
                           <td
                             class="ant-table-cell ant-table-selection-column"
@@ -686,7 +688,7 @@ exports[`workSpaceMenu renders with a single workspace and dashboard  1`] = `
                         </tr>
                         <tr
                           class="ant-table-row ant-table-row-level-0 data-table-row"
-                          data-row-key="tr_7"
+                          data-row-key="https://localhost:3000/nexus/v1/projects/nise/kerrien8"
                         >
                           <td
                             class="ant-table-cell ant-table-selection-column"
@@ -721,7 +723,7 @@ exports[`workSpaceMenu renders with a single workspace and dashboard  1`] = `
                         </tr>
                         <tr
                           class="ant-table-row ant-table-row-level-0 data-table-row"
-                          data-row-key="tr_8"
+                          data-row-key="https://localhost:3000/nexus/v1/projects/nise/kerrien9"
                         >
                           <td
                             class="ant-table-cell ant-table-selection-column"
@@ -756,7 +758,7 @@ exports[`workSpaceMenu renders with a single workspace and dashboard  1`] = `
                         </tr>
                         <tr
                           class="ant-table-row ant-table-row-level-0 data-table-row"
-                          data-row-key="tr_9"
+                          data-row-key="https://localhost:3000/nexus/v1/projects/nise/kerrien10"
                         >
                           <td
                             class="ant-table-cell ant-table-selection-column"

--- a/src/utils/contentTypes.ts
+++ b/src/utils/contentTypes.ts
@@ -5,6 +5,7 @@ import * as Sentry from '@sentry/browser';
  * Redacted list, adapted from - https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
  */
 export const MIME_TYPE_TO_EXTENSION: { [key: string]: string } = {
+  'application/asc': 'asc',
   'application/gzip': 'gz',
   'application/json': 'json',
   'application/ld+json': 'jsonld',

--- a/src/utils/contentTypes.ts
+++ b/src/utils/contentTypes.ts
@@ -1,0 +1,64 @@
+import * as Sentry from '@sentry/browser';
+
+/**
+ * Dictionary of important MIME Types for the Web.
+ * Redacted list, adapted from - https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
+ */
+export const MIME_TYPE_TO_EXTENSION: { [key: string]: string } = {
+  'application/gzip': 'gz',
+  'application/json': 'json',
+  'application/ld+json': 'jsonld',
+  'application/msword': 'doc',
+  'application/octet-stream': 'bin',
+  'application/pdf': 'pdf',
+  'application/vnd.ms-powerpoint': 'ppt',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation':
+    'pptx',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'xlsx',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document':
+    'docx',
+  'application/x-7z-compressed': '7z',
+  'application/x-tar': 'tar',
+  'application/xml': 'xml',
+  'application/zip': 'zip',
+  'audio/aac': 'aac',
+  'audio/midi,': 'mid',
+  'audio/mpeg': 'mp3',
+  'image/bmp': 'bmp',
+  'image/gif': 'gif',
+  'image/jpeg': 'jpeg',
+  'image/png': 'png',
+  'image/svg+xml': 'svg',
+  'image/webp': 'webp',
+  'text/css': 'css',
+  'text/csv': 'csv',
+  'text/html': 'htm',
+  'text/javascript': 'mjs',
+  'text/plain': 'txt',
+  'text/turtle': 'ttl',
+  'video/mp4': 'mp4',
+  'video/mpeg': 'mpeg',
+};
+
+/**
+ * @param encodingType - Should be one of:
+ *                       * undefined
+ *                       * A string containing only MIME types (e.g. -> 'text/html')
+ *                       * A stirng containing MIME type and character encoding, separated by semicolons (e.g. -> 'text/plain; charset=UTF-8')
+ * @returns File extension best supported for the given "encodedType" as listed in MDN (https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types).
+ * If no extension could be derived, the function returns an empty string.
+ */
+export const fileExtensionFromResourceEncoding = (encodingType?: string) => {
+  const mimeType = encodingType?.split(';')[0] ?? '';
+  const extension = MIME_TYPE_TO_EXTENSION[mimeType]
+    ? `${MIME_TYPE_TO_EXTENSION[mimeType]}`
+    : '';
+
+  if (extension === '') {
+    Sentry.captureMessage(
+      `Could not find extension for encoding format: ${encodingType}`
+    );
+  }
+
+  return extension;
+};

--- a/src/utils/validUrl.ts
+++ b/src/utils/validUrl.ts
@@ -14,5 +14,18 @@ function easyValidURL(url: string) {
     return false;
   }
 }
-export { easyValidURL };
+
+function isUrlCurieFormat(str: string) {
+  if (!str) {
+    return false;
+  }
+
+  // Regular expression pattern to match CURIE format
+  const curiePattern = /^[A-Za-z_][\w\-\.]*:?[\w\-\.]*$/;
+
+  // Test the string against the CURIE pattern
+  return curiePattern.test(str);
+}
+
+export { easyValidURL, isUrlCurieFormat };
 export default isValidUrl;

--- a/src/utils/validUrl.ts
+++ b/src/utils/validUrl.ts
@@ -1,16 +1,9 @@
 function isValidUrl(url: string) {
-  // Regular expression for validating URLs
-  const urlPattern = new RegExp(
-    '^(https?:\\/\\/)?' + // protocol
-    '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' + // domain name
-    '((\\d{1,3}\\.){3}\\d{1,3}))' + // IP address
-    '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' + // port and path
-    '(\\?[;&a-z\\d%_.~+=-]*)?' + // query string
-      '(\\#[-a-z\\d_]*)?$',
-    'i'
-  ); // fragment locator
-
-  return urlPattern.test(url);
+  try {
+    return Boolean(new URL(url));
+  } catch (e) {
+    return false;
+  }
 }
 
 function easyValidURL(url: string) {


### PR DESCRIPTION
Fixes #[3224](https://app.zenhub.com/workspaces/blue-brain-nexus-60ace035034cae00105c9307/issues/gh/bluebrain/nexus/3224)
<img width="1018" alt="Screenshot 2023-05-11 at 19 24 48" src="https://github.com/BlueBrain/nexus-web/assets/11242410/a905ba55-ae0a-41f4-a7c2-693cf05ee3b4">


## Description

Enable users to download metadata and files associated with rows in studios table.

## How to test
1. Open a dashboard in studios
2. Select a row to download
3. Click on download button in datapanel -> A tar file should be downloaded.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [X] I have added screenshots (if applicable), in the comment section.
