### PR TITLE
Feature 3365 // Show total rows in studio dashboard

### DIFF
--- a/src/shared/containers/DataTableContainer.tsx
+++ b/src/shared/containers/DataTableContainer.tsx
@@ -440,11 +440,15 @@ const DataTableContainer: React.FC<DataTableProps> = ({
             <div className="table-options__inner">
               {tableResource?.enableSearch && search}
               <span className="table-row-count">
+                {/* If the user filters a column (i.e. updates) or enters a serch term (i.e. update dataResult), show the total rows in format <rows shown to user>/<total rows>, otherwise only show total rows. */}
                 {displayedRows &&
                 displayedRows !== tableData.dataResult.data?.items?.length
                   ? `${displayedRows} / `
+                  : tableData.dataResult?.data?.items.length !==
+                    tableData.dataResult.data?.total
+                  ? `${tableData.dataResult.data?.items?.length} /`
                   : ''}
-                {`${tableData.dataResult.data?.items?.length ?? 0} `}
+                {`${tableData.dataResult?.data?.total ?? 0} `}
                 RESULTS
               </span>
               {(!disableEdit ||

--- a/src/shared/containers/DataTableContainer.tsx
+++ b/src/shared/containers/DataTableContainer.tsx
@@ -134,6 +134,8 @@ const DataTableContainer: React.FC<DataTableProps> = ({
     useSelector((state: RootState) => state.config.basePath) || '';
   const [showEditForm, setShowEditForm] = useState<boolean>(showEdit || false);
   const [tableDataError, setTableDataError] = useState<null | Error>(null);
+  const [displayedRows, setDisplayedRows] = useState(0);
+
   useEffect(() => {
     setShowEditForm(showEdit || false);
   }, [showEdit]);
@@ -437,6 +439,14 @@ const DataTableContainer: React.FC<DataTableProps> = ({
           <Col span={8} className="table-options">
             <div className="table-options__inner">
               {tableResource?.enableSearch && search}
+              <span className="table-row-count">
+                {displayedRows &&
+                displayedRows !== tableData.dataResult.data?.items?.length
+                  ? `${displayedRows} / `
+                  : ''}
+                {`${tableData.dataResult.data?.items?.length ?? 0} `}
+                RESULTS
+              </span>
               {(!disableEdit ||
                 !disableAddFromCart ||
                 tableResource.enableDownload ||
@@ -449,10 +459,6 @@ const DataTableContainer: React.FC<DataTableProps> = ({
       </div>
     );
   };
-
-  // const [preparingDataDownload, setPreparingDataDownload] = React.useState(
-  //   false
-  // );
 
   return (
     <div className="studio-table-container">
@@ -495,6 +501,9 @@ const DataTableContainer: React.FC<DataTableProps> = ({
             }}
             rowKey={r => getStudioRowKey(r)}
             data-testid="dashboard-table"
+            onChange={(page, fileter, sorter, extra) => {
+              setDisplayedRows(extra.currentDataSource?.length ?? 0);
+            }}
           />
           <Modal
             open={showEditForm}

--- a/src/shared/styles/data-table.less
+++ b/src/shared/styles/data-table.less
@@ -19,7 +19,12 @@ h3.ant-typography.table-title {
   display: flex !important;
   &__inner {
     margin-left: auto;
+    margin-right: 10px;
   }
+}
+
+.table-row-count {
+  margin: 0 20px;
 }
 
 .ant-pagination-options .ant-pagination-options-size-changer {

--- a/src/subapps/studioLegacy/containers/__tests__/__snapshots__/WorkSpaceMenuContainer.spec.tsx.snap
+++ b/src/subapps/studioLegacy/containers/__tests__/__snapshots__/WorkSpaceMenuContainer.spec.tsx.snap
@@ -320,6 +320,13 @@ exports[`workSpaceMenu renders with a single workspace and dashboard  1`] = `
                               </span>
                             </span>
                           </span>
+                          <span
+                            class="table-row-count"
+                          >
+                            
+                            10 
+                            RESULTS
+                          </span>
                           <button
                             class="ant-btn ant-btn-round ant-btn-default ant-btn-icon-only"
                             type="button"


### PR DESCRIPTION
Fixes #[3365](https://app.zenhub.com/workspaces/blue-brain-nexus-60ace035034cae00105c9307/issues/gh/bluebrain/nexus/3365)

## Description
If no filter is set, show total number of rows in user's table. If filter is set, show count in this format `${rows_displayed}/${total_rows}`

<img width="1258" alt="Screenshot 2023-05-11 at 19 52 57" src="https://github.com/BlueBrain/nexus-web/assets/11242410/42a2f8a6-9428-4755-9ceb-c13ce242bb19">

Count when no filter is set

<img width="1258" alt="Screenshot 2023-05-11 at 19 52 33" src="https://github.com/BlueBrain/nexus-web/assets/11242410/bdf98d2b-42f2-4aa8-941b-9f17def19311">

Count when filter is set


## How to test
1. Navigate to any studio dashboard -> Count of all rows in table should be displayed
2. Set a filter in any column -> Along with total, a count of filtered rows should be displayed


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [x] I have added screenshots (if applicable), in the comment section.
