### PR TITLE
Bug // When distribution has no label, use empty string instead of fa…

### DIFF
--- a/src/shared/organisms/DataPanel/DataPanel.tsx
+++ b/src/shared/organisms/DataPanel/DataPanel.tsx
@@ -453,7 +453,7 @@ const DataPanel: React.FC<Props> = ({}) => {
           const contentType = resource.distribution
             ? isArray(resource.distribution?.label)
               ? resource.distribution?.label[0].split('.').pop()
-              : resource.distribution?.label.split('.').pop() ?? ''
+              : resource.distribution?.label?.split('.').pop() ?? ''
             : '';
           return {
             size,


### PR DESCRIPTION
If the distribution.label is undefined the "adding to cart" fails and throws this error. The PR fixes it.

```
@@error https://bbp.epfl.ch/neurosciencegraph/data/morphologies/9a26d448-8cf1-4561-b5fc-ec51c9a4aaf4 TypeError: Cannot read properties of undefined (reading 'split')
    at DataPanel.tsx:456:46
    at Array.map (<anonymous>)
    at DataPanel.tsx:436:8
    at Object.pa [as useMemo] (react-dom.production.min.js:162:119)
    at t.useMemo (react.production.min.js:25:113)
    at S (DataPanel.tsx:433:28)
    at Go (react-dom.production.min.js:153:146)
    at Na (react-dom.production.min.js:175:309)
    at vs (react-dom.production.min.js:263:406)
    at cu (react-dom.production.min.js:246:265)
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
