### PR TITLE
Show organization name in studio listing page

### DIFF
--- a/src/pages/StudiosPage/StudiosPage.tsx
+++ b/src/pages/StudiosPage/StudiosPage.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useNexusContext } from '@bbp/react-nexus';
-import { Spin, List, Input, Alert } from 'antd';
+import { Spin, List, Input, Alert, Tag } from 'antd';
 import { Link, useParams } from 'react-router-dom';
 import { useInfiniteQuery } from 'react-query';
 import { useDispatch, useSelector } from 'react-redux';
@@ -56,6 +56,7 @@ type TStudioItem = {
   to: string;
   title: string;
   project: string;
+  organization: string;
   deprected: boolean;
   description?: string;
   datasets?: string;
@@ -102,6 +103,7 @@ const StudioItem = ({
   description,
   deprected,
   project,
+  organization,
   createdAt,
   datasets,
   access,
@@ -125,7 +127,10 @@ const StudioItem = ({
         <div className="statistics">
           <div className="statistics_item">
             <div>Project</div>
-            <div>{project}</div>
+            <Tag className="org-project-tag" color="blue">
+              {organization}
+            </Tag>
+            <span>{project}</span>
           </div>
           <div className="statistics_item">
             <div>Created</div>
@@ -312,17 +317,6 @@ const FusionStudiosPage: React.FC = () => {
                   placeholder="Search studio"
                 />
               </div>
-              {/* <div className="action-sort">
-                <span>Sort:</span>
-                <SortAscendingOutlined
-                  style={{ backgroundColor: sortBackgroundColor(sort, 'asc') }}
-                  onClick={() => handleUpdateSorting('asc')}
-                />
-                <SortDescendingOutlined
-                  style={{ backgroundColor: sortBackgroundColor(sort, 'desc') }}
-                  onClick={() => handleUpdateSorting('desc')}
-                />
-              </div> */}
             </div>
             <div className="route-data-container" ref={dataContainerRef}>
               {pmatch(status)
@@ -351,6 +345,7 @@ const FusionStudiosPage: React.FC = () => {
                             {...{
                               to,
                               project: projectLabel,
+                              organization: orgLabel,
                               title: item.label,
                               deprected: item.deprecated,
                               createdAt: new Date(item.createdAt),

--- a/src/pages/StudiosPage/StudiosPage.tsx
+++ b/src/pages/StudiosPage/StudiosPage.tsx
@@ -62,6 +62,7 @@ type TStudioItem = {
   datasets?: string;
   createdAt: Date;
   access?: string;
+  index: number;
 };
 type TFetchStudiosListProps = TStudiosOptions & {
   nexus: NexusClient;
@@ -107,6 +108,7 @@ const StudioItem = ({
   createdAt,
   datasets,
   access,
+  index,
 }: TStudioItem) => {
   return (
     <List.Item className="route-result-list_item" role="routeitem-studio">
@@ -124,16 +126,16 @@ const StudioItem = ({
           </Link>
           <p>{description}</p>
         </div>
-        <div className="statistics">
+        <div className="statistics studios-list-item">
           <div className="statistics_item">
-            <div>Project</div>
+            {index === 0 && <div>Organization / Project</div>}
             <Tag className="org-project-tag" color="blue">
               {organization}
             </Tag>
             <span>{project}</span>
           </div>
           <div className="statistics_item">
-            <div>Created</div>
+            {index === 0 && <div>Created</div>}
             <div>{timeago(createdAt)}</div>
           </div>
         </div>
@@ -337,13 +339,14 @@ const FusionStudiosPage: React.FC = () => {
                       itemLayout="horizontal"
                       loadMore={LoadMore}
                       dataSource={dataSource}
-                      renderItem={item => {
+                      renderItem={(item, index) => {
                         const { orgLabel, projectLabel, id } = item;
                         const to = makeStudioUri(orgLabel, projectLabel, id);
                         return (
                           <StudioItem
                             {...{
                               to,
+                              index,
                               project: projectLabel,
                               organization: orgLabel,
                               title: item.label,

--- a/src/shared/molecules/MyDataTable/MyDataTable.tsx
+++ b/src/shared/molecules/MyDataTable/MyDataTable.tsx
@@ -206,7 +206,7 @@ const MyDataTable: React.FC<TProps> = ({
       },
       {
         key: 'project',
-        title: 'project',
+        title: 'organization / project',
         dataIndex: 'project',
         sorter: false,
         render: (text, record) => {

--- a/src/shared/styles/route-layout.less
+++ b/src/shared/styles/route-layout.less
@@ -148,6 +148,13 @@
               grid-template-rows: max-content max-content;
               gap: 5px;
 
+              &.studios-list-item {
+                grid-template-rows: none;
+                gap: 5px;
+                align-items: center;
+                height: 100%;
+              }
+
               &_item {
                 div:first-child {
                   font-family: 'Titillium Web';

--- a/src/shared/styles/route-layout.less
+++ b/src/shared/styles/route-layout.less
@@ -105,7 +105,7 @@
           &_wrapper {
             width: 100%;
             display: grid;
-            grid-template-columns: 2fr 1fr 1fr;
+            grid-template-columns: 2fr 2fr 1fr;
             gap: 10px;
             align-items: start;
             justify-content: space-between;
@@ -167,6 +167,11 @@
                   line-height: 136%;
                   color: @fusion-daybreak-9;
                 }
+              }
+
+              .org-project-tag {
+                color: @fusion-main-color !important;
+                border: none;
               }
             }
 


### PR DESCRIPTION
Based on the [issue](https://www.notion.so/Fusion-Tests-17-May-2023-b8dc3a00e06d40fb87f1ec6ed1969e16?pvs=4#9361af8127894eca837bb44f8775da93) that came up during testing for version 1.8, this PR shows organization name for a project next to it , in the studio listing page:

<img width="1512" alt="Screenshot 2023-05-22 at 10 08 36" src="https://github.com/BlueBrain/nexus-web/assets/11242410/3adda2df-da08-464e-a3da-afcd34a3e8fe">



- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
