### PR TITLE
3937 // Display name or label of resource in my-data if present other…

### DIFF
--- a/src/shared/molecules/MyDataTable/MyDataTable.tsx
+++ b/src/shared/molecules/MyDataTable/MyDataTable.tsx
@@ -21,6 +21,7 @@ import {
   removeLocalStorageRows,
   toLocalStorageResources,
 } from '../../../shared/utils/datapanel';
+import { getResourceLabel } from '../../../shared/utils';
 
 export const MAX_DATA_SELECTED_SIZE__IN_BYTES = 1_073_741_824;
 export const MAX_LOCAL_STORAGE_ALLOWED_SIZE = 4.5;
@@ -189,6 +190,7 @@ const MyDataTable: React.FC<TProps> = ({
         ellipsis: true,
         render: (text, record) => {
           const showedText = isValidUrl(text) ? text.split('/').pop() : text;
+          const resourceId = record['@id'] ?? record._self;
           if (text && record._project) {
             const { org, project } = makeOrgProjectTuple(record._project);
             return (
@@ -196,7 +198,7 @@ const MyDataTable: React.FC<TProps> = ({
                 <Button
                   style={{ padding: 0 }}
                   type="link"
-                  onClick={() => goToResource(org, project, text)}
+                  onClick={() => goToResource(org, project, resourceId)}
                 >
                   {showedText}
                 </Button>
@@ -281,7 +283,7 @@ const MyDataTable: React.FC<TProps> = ({
     resources?._results?.map(resource => {
       return {
         ...resource,
-        name: resource['@id'] ?? resource._self,
+        name: getResourceLabel(resource),
         description: resource.discription ?? '',
       };
     }) || [];

--- a/src/shared/molecules/MyDataTable/MyDataTable.tsx
+++ b/src/shared/molecules/MyDataTable/MyDataTable.tsx
@@ -189,23 +189,22 @@ const MyDataTable: React.FC<TProps> = ({
         width: 250,
         ellipsis: true,
         render: (text, record) => {
-          const showedText = isValidUrl(text) ? text.split('/').pop() : text;
           const resourceId = record['@id'] ?? record._self;
           if (text && record._project) {
             const { org, project } = makeOrgProjectTuple(record._project);
             return (
-              <Tooltip title={text}>
+              <Tooltip title={resourceId}>
                 <Button
                   style={{ padding: 0 }}
                   type="link"
                   onClick={() => goToResource(org, project, resourceId)}
                 >
-                  {showedText}
+                  {text}
                 </Button>
               </Tooltip>
             );
           }
-          return <Tooltip title={text}>{showedText}</Tooltip>;
+          return <Tooltip title={resourceId}>{text}</Tooltip>;
         },
       },
       {


### PR DESCRIPTION
…wise id

When label, `preLabel`, or `name` of resource is present, display that, otherwise display id or self in my-data table.


![Screenshot from 2023-06-08 18-21-26](https://github.com/BlueBrain/nexus-web/assets/11242410/da0955f1-c8ed-40c8-bb5f-648b589b7ed4)

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
