### PR TITLE
3939 // Fetch resources in my-data when they dont have distributions

### DIFF
--- a/src/shared/containers/DataTableContainer.tsx
+++ b/src/shared/containers/DataTableContainer.tsx
@@ -193,6 +193,9 @@ const DataTableContainer: React.FC<DataTableProps> = ({
 
   const [searchboxValue, setSearchboxValue] = useState<string>('');
   const [searchboxFocused, setSearchboxFocused] = useState<boolean>(false);
+  const [fetchingRowsForDownlaod, setFetchingRowsForDownload] = useState<
+    boolean
+  >(false);
   const nexus = useNexusContext();
   const history = useHistory();
   const location = useLocation();
@@ -465,7 +468,9 @@ const DataTableContainer: React.FC<DataTableProps> = ({
           <Table
             bordered
             loading={
-              tableData.dataResult.isLoading || tableData.tableResult.isLoading
+              tableData.dataResult.isLoading ||
+              tableData.tableResult.isLoading ||
+              fetchingRowsForDownlaod
             }
             rowClassName={'data-table-row'}
             title={() => renderTitle(options)}
@@ -487,7 +492,19 @@ const DataTableContainer: React.FC<DataTableProps> = ({
             rowSelection={{
               selectedRowKeys,
               onSelect: tableData.onSelectSingleRow,
-              onSelectAll: tableData.onSelectAll,
+              onSelectAll: async (
+                selected: boolean,
+                selectedRows: StudioTableRow[],
+                changedRows: StudioTableRow[]
+              ) => {
+                setFetchingRowsForDownload(true);
+                await tableData.onSelectAll(
+                  selected,
+                  selectedRows,
+                  changedRows
+                );
+                setFetchingRowsForDownload(false);
+              },
             }}
             rowKey={r => getStudioRowKey(r)}
             data-testid="dashboard-table"

--- a/src/shared/hooks/useAccessDataForTable.tsx
+++ b/src/shared/hooks/useAccessDataForTable.tsx
@@ -419,7 +419,7 @@ export const fetchResourceForDownload = async (
 
     const receivedExpandedId =
       isValidUrl(compactResource['@id']) &&
-      !isUrlCurieFormat(compactResource['@id']);
+      compactResource['@id']?.startsWith('http');
 
     if (receivedExpandedId) {
       return compactResource;
@@ -485,7 +485,7 @@ export const useAccessDataForTable = (
         .for(changedRows)
         .handleError(async err => {
           console.log(
-            '@@error in selecting multiple resources for download',
+            '@@error in selecting multiple resources for download in studios',
             err
           );
           return;

--- a/src/shared/molecules/MyDataTable/MyDataTable.tsx
+++ b/src/shared/molecules/MyDataTable/MyDataTable.tsx
@@ -1,8 +1,14 @@
-import React, { Fragment, useMemo, useReducer, useEffect } from 'react';
+import React, {
+  Fragment,
+  useMemo,
+  useReducer,
+  useEffect,
+  useState,
+} from 'react';
 import { Button, Table, Tag, Tooltip, notification } from 'antd';
 import { Link, useHistory, useLocation } from 'react-router-dom';
 import { PaginatedList, Resource } from '@bbp/nexus-sdk';
-import { isString, isArray } from 'lodash';
+import { isString, isArray, isNil } from 'lodash';
 import { clsx } from 'clsx';
 import { useSelector } from 'react-redux';
 import { ColumnsType, TablePaginationConfig } from 'antd/lib/table';
@@ -22,38 +28,11 @@ import {
   toLocalStorageResources,
 } from '../../../shared/utils/datapanel';
 import { getResourceLabel } from '../../../shared/utils';
+import { useNexusContext } from '@bbp/react-nexus';
+import { fetchResourceForDownload } from '../../../shared/hooks/useAccessDataForTable';
 
 export const MAX_DATA_SELECTED_SIZE__IN_BYTES = 1_073_741_824;
 export const MAX_LOCAL_STORAGE_ALLOWED_SIZE = 4.5;
-
-type TResource = {
-  [key: string]: any;
-} & {
-  '@context'?:
-    | string
-    | (
-        | string
-        | {
-            [key: string]: any;
-          }
-      )[]
-    | {
-        [key: string]: any;
-      };
-  '@type'?: string | string[];
-  '@id': string;
-  _incoming: string;
-  _outgoing: string;
-  _self: string;
-  _constrainedBy: string;
-  _project: string;
-  _rev: number;
-  _deprecated: boolean;
-  _createdAt: string;
-  _createdBy: string;
-  _updatedAt: string;
-  _updatedBy: string;
-};
 
 interface TMyDataTableRow extends Resource {
   name: string;
@@ -156,6 +135,7 @@ const MyDataTable: React.FC<TProps> = ({
   const { currentResourceView } = useSelector(
     (state: RootState) => state.uiSettings
   );
+  const nexus = useNexusContext();
   const [{ selectedRowKeys }, updateTableData] = useReducer(
     (
       previous: TResourceTableData,
@@ -169,6 +149,8 @@ const MyDataTable: React.FC<TProps> = ({
       selectedRows: [],
     }
   );
+
+  const [fetchingResourcesForDownload, setFetchingResources] = useState(false);
 
   const goToResource = (
     orgLabel: string,
@@ -298,16 +280,27 @@ const MyDataTable: React.FC<TProps> = ({
     showQuickJumper: true,
     showSizeChanger: true,
   };
-  const onSelectRowChange: SelectionSelectFn<TMyDataTableRow> = (
+  const onSelectRowChange: SelectionSelectFn<TMyDataTableRow> = async (
     record,
     selected
   ) => {
     const recordKey = record._self;
-
     const dataPanelLS: TResourceTableData = JSON.parse(
       localStorage.getItem(DATA_PANEL_STORAGE)!
     );
-    const localStorageRows = toLocalStorageResources(record, 'my-data');
+
+    let localStorageRows;
+    if (selected && isNil(record.distribution)) {
+      // Sometimes the distributions are not available in the response of the bulk fetch of resources. Delta is working on fixing this.
+      // In the mean time, fusion can retrieve this extra information by doing a separate request per resource that does not have `distribution`.
+      setFetchingResources(true);
+      const expandedResource = await fetchResourceForDownload(recordKey, nexus);
+      setFetchingResources(false);
+      localStorageRows = toLocalStorageResources(expandedResource, 'my-data');
+    } else {
+      localStorageRows = toLocalStorageResources(record, 'my-data');
+    }
+    toLocalStorageResources(record, 'my-data');
     let selectedRowKeys = dataPanelLS?.selectedRowKeys || [];
     let selectedRows = dataPanelLS?.selectedRows || [];
 
@@ -345,16 +338,30 @@ const MyDataTable: React.FC<TProps> = ({
     );
   };
 
-  const onSelectAllChange = (
+  const onSelectAllChange = async (
     selected: boolean,
     tSelectedRows: TMyDataTableRow[],
     changeRows: TMyDataTableRow[]
   ) => {
     const changedRowsLS: TDataSource[] = [];
-    changeRows.forEach(row => {
-      const localStorageRows = toLocalStorageResources(row, 'my-data');
-      changedRowsLS.push(...localStorageRows);
-    });
+
+    setFetchingResources(true);
+    for (const row of changeRows) {
+      if (selected && isNil(row.distribution)) {
+        // Sometimes the distributions are not available in the response of the bulk fetch of resources. Delta is working on fixing this.
+        // In the mean time, fusion can retrieve this extra information by doing a separate request per resource that does not have `distribution`.
+        const expandedRow = await fetchResourceForDownload(row._self, nexus);
+        const localStorageRows = toLocalStorageResources(
+          expandedRow,
+          'my-data'
+        );
+        changedRowsLS.push(...localStorageRows);
+      } else {
+        const localStorageRows = toLocalStorageResources(row, 'my-data');
+        changedRowsLS.push(...localStorageRows);
+      }
+    }
+    setFetchingResources(false);
 
     const dataPanelLS: TResourceTableData = JSON.parse(
       localStorage.getItem(DATA_PANEL_STORAGE)!
@@ -436,7 +443,7 @@ const MyDataTable: React.FC<TProps> = ({
         getContainer: () => window,
       }}
       rowKey={record => record._self}
-      loading={isLoading}
+      loading={isLoading || fetchingResourcesForDownload}
       columns={columns}
       dataSource={dataSource}
       pagination={tablePaginationConfig}


### PR DESCRIPTION
Fixes #3939

## Description

In 'my-data' resources rendered inside the table can sometimes not have `distribution` property (either because the user never added distribution to that resource or because delta didn't send the distribution when we did the request to load all resources for a given page (using the pagination queries)). In this case, we need to fetch a given resource again, so that we can display correct information about it's distributions (if any) in the datapanel bar.

Since the resources can take a while to load (especially when the user clicks "select all" checkbox), I have added a loader. In addition to giving user a feedback, it also disallows checking boxes in the table while the resources are loading.
 
## How has this been tested?

With fusion pointing to delta's dev api, go to page 72 of my data and select any file. This should show multiple extensions in the data panel, not just json.
When using the staging api of delta go to page 91 of my-data to test this.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
