### PR TITLE
3939 // improve file size indication

### DIFF
--- a/src/shared/molecules/MyDataTable/MyDataTable.tsx
+++ b/src/shared/molecules/MyDataTable/MyDataTable.tsx
@@ -68,8 +68,8 @@ export type TDataSource = {
   distribution?: {
     contentSize: number;
     encodingFormat: string | string[];
-    label: string | string[];
-    hasDistribution?: boolean;
+    label: string;
+    hasDistribution: boolean;
   };
 };
 type TProps = {

--- a/src/shared/utils/__mocks__/data_panel_download_resource.ts
+++ b/src/shared/utils/__mocks__/data_panel_download_resource.ts
@@ -44,6 +44,46 @@ export const resourceWithoutDistrition = {
     'https://staging.nise.bbp.epfl.ch/nexus/v1/realms/serviceaccounts/users/service-account-nexus-sa',
 };
 
+export const fileResourceWithNoDistribution = {
+  '@context': [
+    'https://bluebrain.github.io/nexus/contexts/files.json',
+    'https://bluebrain.github.io/nexus/contexts/metadata.json',
+  ],
+  '@id':
+    'https://bbp.epfl.ch/neurosciencegraph/data/938fb28f-6e5c-434f-8d12-572e5c005f73',
+  '@type': 'File',
+  _bytes: 318076,
+  _constrainedBy: 'https://bluebrain.github.io/nexus/schemas/files.json',
+  _createdAt: '2022-03-31T16:54:52.580Z',
+  _createdBy:
+    'https://dev.nise.bbp.epfl.ch/nexus/v1/realms/serviceaccounts/users/service-account-nexus-sa',
+  _deprecated: false,
+  _digest: {
+    _algorithm: 'SHA-256',
+    _value: '84da895fdc949ae7b7bd55192a8fef3b1cd5721c06b0993339e0cc42997bd3a4',
+  },
+  _filename: 'C120501B1-MT-C1_IDRest.zip',
+  _incoming:
+    'https://dev.nise.bbp.epfl.ch/nexus/v1/files/copies/sscx/https:%2F%2Fbbp.epfl.ch%2Fneurosciencegraph%2Fdata%2F938fb28f-6e5c-434f-8d12-572e5c005f73/incoming',
+  _mediaType: 'application/zip',
+  _origin: 'Client',
+  _outgoing:
+    'https://dev.nise.bbp.epfl.ch/nexus/v1/files/copies/sscx/https:%2F%2Fbbp.epfl.ch%2Fneurosciencegraph%2Fdata%2F938fb28f-6e5c-434f-8d12-572e5c005f73/outgoing',
+  _project: 'https://dev.nise.bbp.epfl.ch/nexus/v1/projects/copies/sscx',
+  _rev: 1,
+  _self:
+    'https://dev.nise.bbp.epfl.ch/nexus/v1/files/copies/sscx/https:%2F%2Fbbp.epfl.ch%2Fneurosciencegraph%2Fdata%2F938fb28f-6e5c-434f-8d12-572e5c005f73',
+  _storage: {
+    '@id': 'https://bluebrain.github.io/nexus/vocabulary/diskStorageDefault',
+    '@type': 'DiskStorage',
+    _rev: 1,
+  },
+  _updatedAt: '2022-03-31T16:54:52.580Z',
+  _updatedBy:
+    'https://dev.nise.bbp.epfl.ch/nexus/v1/realms/serviceaccounts/users/service-account-nexus-sa',
+  _uuid: '5673b3ae-bdd6-43b4-a3ca-aa6c771edbfa',
+};
+
 export const resourceWithDistributionArray = {
   '@context': [
     'https://bluebrain.github.io/nexus/contexts/metadata.json',


### PR DESCRIPTION
File size of the archive is only show when either of the 2 conditions is true:

1. The user adds a resource of type `File`, then the size of the file is shown:

![Screenshot from 2023-06-09 17-58-45](https://github.com/BlueBrain/nexus-web/assets/11242410/229e8bb3-ce9f-468d-99bf-26c247be5567)

2. The user checks an extension in the datapanel. Size of the files of that extension is shown:
![Screenshot from 2023-06-09 18-00-36](https://github.com/BlueBrain/nexus-web/assets/11242410/3c59172c-4b9d-4282-b4ed-45b3dfbf1479)


In the following case no file size is shown because the user did not select a resource of type `File` and also did not check any boxes for specific extensions:
![Screenshot from 2023-06-09 18-01-55](https://github.com/BlueBrain/nexus-web/assets/11242410/a5e51d6a-44ed-4925-9b6d-98dc168d5927)


## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added necessary unit and integration tests.
- [x] I have added screenshots (if applicable), in the comment section.
