### PR TITLE
3974 // Fix data download when name is array

### DIFF
--- a/src/shared/organisms/DataPanel/DataPanel.tsx
+++ b/src/shared/organisms/DataPanel/DataPanel.tsx
@@ -461,7 +461,7 @@ const DataPanel: React.FC<Props> = ({}) => {
               ? 'File'
               : 'Resource';
           const contentType =
-            resource.distribution?.label?.split('.').pop() ?? '';
+            resource.distribution?.label?.split('.')?.pop() ?? '';
           return {
             size,
             contentType: contentType?.toLowerCase(),

--- a/src/shared/organisms/DataPanel/DataPanel.tsx
+++ b/src/shared/organisms/DataPanel/DataPanel.tsx
@@ -560,7 +560,7 @@ const DataPanel: React.FC<Props> = ({}) => {
             link.parentNode?.removeChild(link);
             if (data.errors.length) {
               notification.warning({
-                duration: null,
+                duration: null, // Dont close the notification unless the user clicks it.
                 message: (
                   <span>
                     <strong>Archive: </strong>

--- a/src/shared/utils/__tests__/datapanel.spec.ts
+++ b/src/shared/utils/__tests__/datapanel.spec.ts
@@ -82,6 +82,18 @@ describe('datapanel utilities', () => {
     );
   });
 
+  it('serializes resources with arrays for name correctly', () => {
+    const resource = {
+      ...resourceWithDistributionArray,
+      label: undefined,
+      name: ['Sterling', 'Malory', 'Archer'],
+    };
+    const serializedItems = toLocalStorageResources(resource, 'studios');
+
+    expect(serializedItems.length).toEqual(5);
+    expect(serializedItems[0].name).toEqual('Sterling-Malory-Archer');
+  });
+
   it('serializes correct distribution value for each distribution item in array', () => {
     const resource = resourceWithDistributionArray;
     const serializedItems = toLocalStorageResources(resource, 'studios');

--- a/src/shared/utils/__tests__/index.spec.ts
+++ b/src/shared/utils/__tests__/index.spec.ts
@@ -19,8 +19,10 @@ import {
   deltaUrlToFusionUrl,
   getFriendlyTimeAgoString,
   getDateString,
+  getResourceLabel,
 } from '..';
 import * as moment from 'moment';
+import { getMockResource } from '../__mocks__/data_panel_download_resource';
 
 const identities: Identity[] = [
   {

--- a/src/shared/utils/__tests__/index.spec.ts
+++ b/src/shared/utils/__tests__/index.spec.ts
@@ -818,4 +818,64 @@ describe('utils functions', () => {
       expect(forceAsArray(undefined)).toEqual([]);
     });
   });
+
+  describe('getResourceLabel', () => {
+    it('uses prefLabel when availablae', () => {
+      const expectedLabel = 'ExpectedLabel';
+
+      const actualLabel = getResourceLabel({
+        prefLabel: expectedLabel,
+        name: 'foo',
+        label: 'bar',
+        '@id': 'https://abc.com/myid',
+        _self: 'https://abc.com/myself',
+      } as any);
+
+      expect(actualLabel).toEqual(expectedLabel);
+    });
+
+    it('appends name if it is an array', () => {
+      const expectedLabel = 'foo-bar';
+
+      const actualLabel = getResourceLabel({
+        name: ['foo', 'bar'],
+        '@id': 'https://abc.com/myid',
+        _self: 'https://abc.com/myself',
+      } as any);
+
+      expect(actualLabel).toEqual(expectedLabel);
+    });
+
+    it('takes first name if it is an array of one string', () => {
+      const expectedLabel = 'foo';
+
+      const actualLabel = getResourceLabel({
+        name: ['foo'],
+        '@id': 'https://abc.com/myid',
+        _self: 'https://abc.com/myself',
+      } as any);
+
+      expect(actualLabel).toEqual(expectedLabel);
+    });
+
+    it('uses self if id is not available', () => {
+      const expectedLabel = 'myself';
+
+      const actualLabel = getResourceLabel({
+        _self: 'https://abc.com/myself',
+      } as any);
+
+      expect(actualLabel).toEqual(expectedLabel);
+    });
+
+    it('gives last part of id after pound sign', () => {
+      const expectedLabel = 'myid';
+
+      const actualLabel = getResourceLabel({
+        '@id': 'https://abc.com#myid',
+      } as any);
+
+      expect(actualLabel).toEqual(expectedLabel);
+    });
+  });
 });

--- a/src/shared/utils/datapanel.ts
+++ b/src/shared/utils/datapanel.ts
@@ -9,7 +9,9 @@ import { getResourceLabel, uuidv4 } from '.';
 import { parseURL } from './nexusParse';
 
 const getResourceName = (resource: Resource) =>
-  resource.name ?? resource['@id'] ?? resource._self;
+  isArray(resource.name)
+    ? resource.name.join('')
+    : resource.name ?? resource['@id'] ?? resource._self;
 
 const baseLocalStorageObject = (
   resource: Resource,
@@ -37,6 +39,7 @@ export const toLocalStorageResources = (
   source: string
 ): TDataSource[] => {
   const resourceName = getResourceName(resource);
+
   try {
     // Case 1 - Resource has no distribution
     if (isNil(resource.distribution)) {

--- a/src/shared/utils/datapanel.ts
+++ b/src/shared/utils/datapanel.ts
@@ -8,11 +8,6 @@ import { ResourceObscured } from 'shared/organisms/DataPanel/DataPanel';
 import { getResourceLabel, uuidv4 } from '.';
 import { parseURL } from './nexusParse';
 
-const getResourceName = (resource: Resource) =>
-  isArray(resource.name)
-    ? resource.name.join('')
-    : resource.name ?? resource['@id'] ?? resource._self;
-
 const baseLocalStorageObject = (
   resource: Resource,
   source: string,
@@ -38,8 +33,7 @@ export const toLocalStorageResources = (
   resource: Resource,
   source: string
 ): TDataSource[] => {
-  const resourceName = getResourceName(resource);
-
+  const resourceName = getResourceLabel(resource);
   try {
     // Case 1 - Resource has no distribution
     if (isNil(resource.distribution)) {

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -5,6 +5,7 @@ import {
   isRegExp,
   isMatchWithCustomizer,
   pick,
+  isArray,
 } from 'lodash';
 import * as moment from 'moment';
 
@@ -140,8 +141,8 @@ export const stripBasename = (basename: string, path: string) => {
 
 // For getting the last part of a uri path as a title or label
 export const labelOf = (inputString: string) => {
-  const slash = inputString.substring(inputString.lastIndexOf('/') + 1);
-  const title = slash.substring(slash.lastIndexOf('#') + 1);
+  const slash = inputString?.substring(inputString?.lastIndexOf('/') + 1);
+  const title = slash?.substring(slash.lastIndexOf('#') + 1);
   return title;
 };
 
@@ -293,11 +294,14 @@ export function getResourceLabel(
     [key: string]: any;
   }
 ) {
+  const resourceName = isArray(resource.name)
+    ? resource.name.join('-')
+    : resource.name;
   return (
-    resource.prefLabel ||
-    resource.label ||
-    resource.name ||
-    labelOf(resource['@id']) ||
+    resource.prefLabel ??
+    resource.label ??
+    resourceName ??
+    labelOf(resource['@id']) ??
     labelOf(resource._self)
   );
 }


### PR DESCRIPTION
Fixes #3974

With fusion locally pointing to delta's production api, open the search page for Neuron Morphology. Go to the bottom of the row. You will find some rows with an array of names. Select those for download. The download should work without any errors in console. 

(The download was working previously too but the conosle had errors)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
