### PR TITLE
3978 // Dont show json extension for metadata files in datapanel

### DIFF
--- a/src/shared/organisms/DataPanel/DataPanel.tsx
+++ b/src/shared/organisms/DataPanel/DataPanel.tsx
@@ -498,12 +498,25 @@ const DataPanel: React.FC<Props> = ({}) => {
     }
   };
 
-  const typesCounter = compact(
-    Object.entries(resourcesGrouped).map(([key, value]) =>
-      isEmpty(key) || isNil(key) || key === 'undefined' || key === ''
-        ? null
-        : { [key]: value.length }
-    )
+  const typesCounter: { [key: string]: number }[] = compact(
+    Object.entries(resourcesGrouped).map(([key, value]) => {
+      if (isEmpty(key) || isNil(key) || key === 'undefined' || key === '') {
+        return null;
+      }
+
+      if (key === 'json') {
+        const metadataFiles = value.filter(
+          v => v?.localStorageType === 'resource' && v['@type'] !== 'File'
+        ).length;
+
+        // We don't want to display `json` for metadata files since they are always downloaded.
+        return metadataFiles === value.length
+          ? null
+          : { [key]: value.length - metadataFiles };
+      }
+
+      return { [key]: value.length };
+    })
   );
   const displayedTypes = slice(typesCounter, 0, 3);
   const dropdownTypes = slice(typesCounter, 3);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #3978

JSON extension is not shown for metadata files but still shown for other files.
For example:
In the screenshot I selected a resource that has a json distribution. Therefore the JSON extensionis shown in DataPanel:

![Screenshot from 2023-06-16 10-33-25](https://github.com/BlueBrain/nexus-web/assets/11242410/a1b6392d-1fc6-4129-94c1-de828ccdcc7b)

However in the following case the Json extension is not shown because only the metadata will be downloaded

![Screenshot from 2023-06-16 10-33-38](https://github.com/BlueBrain/nexus-web/assets/11242410/5a480848-a5b7-4129-af4f-017de6e4babb)

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
