### PR TITLE
3980 // Use zip format for archive instead of tar

### DIFF
--- a/src/shared/containers/ResourceViewActionsContainer.tsx
+++ b/src/shared/containers/ResourceViewActionsContainer.tsx
@@ -99,7 +99,6 @@ const ResourceViewActionsContainer: React.FC<{
     }
   };
   const basePath = useSelector((state: RootState) => state.config.basePath);
-
   const [tags, setTags] = React.useState<{
     '@context'?: Context;
     tags: {

--- a/src/shared/organisms/DataPanel/DataPanel.spec.ts
+++ b/src/shared/organisms/DataPanel/DataPanel.spec.ts
@@ -105,7 +105,7 @@ describe('DataPanel', () => {
       .fn()
       .mockResolvedValue('Archive create passed');
     const mockEndpointError = new Error('However, Archive get failed');
-    mockNexus.Archive.get = jest.fn().mockRejectedValue(mockEndpointError);
+    mockNexus.httpGet = jest.fn().mockRejectedValue(mockEndpointError);
 
     try {
       await downloadArchive({
@@ -139,7 +139,7 @@ describe('DataPanel', () => {
       .fn()
       .mockResolvedValue('Archive create passed');
     const mockEndpointError = new Error('However, Archive get failed');
-    mockNexus.Archive.get = jest.fn().mockRejectedValue(mockEndpointError);
+    mockNexus.httpGet = jest.fn().mockRejectedValue(mockEndpointError);
 
     try {
       await downloadArchive({
@@ -170,7 +170,7 @@ describe('DataPanel', () => {
     mockNexus.Archive.create = jest
       .fn()
       .mockResolvedValue('Archive create passed');
-    mockNexus.Archive.get = jest.fn().mockResolvedValue(new Blob());
+    mockNexus.httpGet = jest.fn().mockResolvedValue(new Blob());
 
     const result = await downloadArchive({
       nexus: mockNexus,
@@ -199,7 +199,7 @@ describe('DataPanel', () => {
     mockNexus.Archive.create = jest
       .fn()
       .mockResolvedValue('Archive create passed');
-    mockNexus.Archive.get = jest.fn().mockResolvedValue(new Blob());
+    mockNexus.httpGet = jest.fn().mockResolvedValue(new Blob());
 
     const result = await downloadArchive({
       nexus: mockNexus,
@@ -225,14 +225,15 @@ describe('DataPanel', () => {
     mockNexus.httpGet = jest
       .fn()
       // Out of 4 distributions, 2 were not fetched
-      .mockRejectedValueOnce(new Error('Distribution 1 could not be found'))
-      .mockRejectedValueOnce(new Error('Distribution 2 could not be found'))
-      .mockReturnValue(getMockDistribution('mockfilename'));
+      .mockRejectedValueOnce(new Error('Distribution 1 could not be found')) // Error for 1st distribution
+      .mockRejectedValueOnce(new Error('Distribution 2 could not be found')) // Error for 2nd distribution
+      .mockReturnValueOnce(getMockDistribution('mockfilename')) // Successful response for 3rd distribution
+      .mockReturnValueOnce(getMockDistribution('mockfilename')) // Successful response for 4th distribution
+      .mockResolvedValueOnce(new Blob()); // Successful response for get archive
 
     mockNexus.Archive.create = jest
       .fn()
       .mockResolvedValue('Archive create passed');
-    mockNexus.Archive.get = jest.fn().mockResolvedValue(new Blob());
 
     const result = await downloadArchive({
       nexus: mockNexus,

--- a/src/shared/organisms/DataPanel/DataPanel.tsx
+++ b/src/shared/organisms/DataPanel/DataPanel.tsx
@@ -245,7 +245,7 @@ export async function downloadArchive({
   try {
     const archive = await nexus.httpGet({
       path: `${apiEndpoint}/archives/${parsedData.org}/${parsedData.project}/${archiveId}?ignoreNotFound=true`,
-      headers: { accept: 'application/zip' },
+      headers: { accept: 'application/zip, application/json' },
       context: {
         parseAs: 'blob',
       },

--- a/src/shared/utils/__tests__/datapanel.spec.ts
+++ b/src/shared/utils/__tests__/datapanel.spec.ts
@@ -239,7 +239,7 @@ describe('datapanel utilities', () => {
     expect(actualPathProps).toEqual(expectPathProps);
   });
 
-  it('trims path for top level resource when its name is too long', () => {
+  it('does not trim path for top level resource even if it is long', () => {
     const namePrefix = Array(20)
       .fill('A')
       .join('');
@@ -257,7 +257,7 @@ describe('datapanel utilities', () => {
     const actualPathProps = pathForTopLevelResources(mockResource, new Map());
 
     const expectPathProps: FilePath = {
-      path: `/${orgName}/${projectName}/${nameSuffix}`,
+      path: `/${orgName}/${projectName}/${resourceName}`,
       filename: 'metadata',
       extension: 'json',
     };
@@ -364,8 +364,8 @@ describe('datapanel utilities', () => {
     );
 
     const expectPathProps = {
-      path: `${parentPath}/${nameSuffix}`,
-      fileName: `${nameSuffix}.asc`,
+      path: `${parentPath}/${namePrefix}${nameSuffix}`,
+      fileName: `${namePrefix}${nameSuffix}.asc`,
     };
 
     expect(actualPathProps).toEqual(expectPathProps);

--- a/src/shared/utils/datapanel.ts
+++ b/src/shared/utils/datapanel.ts
@@ -241,19 +241,18 @@ export function pathForTopLevelResources(
 ): FilePath {
   const self = isArray(resource._self) ? resource._self[0] : resource._self;
   const parsedSelf = parseURL(self);
-  const encodedName = encodeURIComponent(resource.name).slice(-20);
+  const encodedName = encodeURIComponent(resource.name);
 
   const fullPath = `/${parsedSelf.org}/${parsedSelf.project}/${encodedName}`;
-  const trimmedPath = fullPath.length > 60 ? `/${uuidv4()}` : fullPath;
 
   let uniquePath: string;
-  if (existingPaths.has(trimmedPath)) {
-    const count = existingPaths.get(trimmedPath)!;
-    uniquePath = `${trimmedPath}-${count}`;
-    existingPaths.set(trimmedPath, count + 1);
+  if (existingPaths.has(fullPath)) {
+    const count = existingPaths.get(fullPath)!;
+    uniquePath = `${fullPath}-${count}`;
+    existingPaths.set(fullPath, count + 1);
   } else {
-    uniquePath = trimmedPath;
-    existingPaths.set(trimmedPath, 1);
+    uniquePath = fullPath;
+    existingPaths.set(fullPath, 1);
   }
 
   return {
@@ -274,15 +273,13 @@ export function pathForChildDistributions(
   const defaultUniqueName = uuidv4().substring(0, 10); // TODO use last part of child self or id
 
   const fullFileName = fileNameForDistributionItem(distItem, defaultUniqueName);
-  const nameWithoutExtension = fullFileName.slice(
+  const fileNameWithoutExtension = fullFileName.slice(
     0,
     fullFileName.lastIndexOf('.')
   );
   const extension = fullFileName.slice(fullFileName.lastIndexOf('.') + 1);
 
-  const fileName = nameWithoutExtension.slice(-20);
-
-  const childDir = fileName; // Max Length 20
+  const childDir = fileNameWithoutExtension; // Max Length 20
   const pathToChildFile = `${parentPath}/${childDir}`; // Max Length 60 + 1 + 20 = 80
   let uniquePath: string; // TODO de-deuplicate
   if (existingPaths.has(pathToChildFile)) {
@@ -296,6 +293,6 @@ export function pathForChildDistributions(
 
   return {
     path: uniquePath,
-    fileName: `${fileName}.${extension}`,
+    fileName: `${fileNameWithoutExtension}.${extension}`,
   };
 }


### PR DESCRIPTION
### Needs delta's support for zip format in production

This PR is only tested using delta's staging and dev environments at the moment.

Fixes #3980

1. Uses zip format to download archive 
2. Removes the limit on names of files since we are now using zip format:

Tree before with trimming:

![Screenshot from 2023-06-16 15-26-46](https://github.com/BlueBrain/nexus-web/assets/11242410/3a99c399-6b1d-4724-9c34-2eab89700985)

Tree after without trimming the path:

![Screenshot from 2023-06-16 15-28-41](https://github.com/BlueBrain/nexus-web/assets/11242410/180f2e9e-a0c6-4fb0-88df-a74eafa4cf95)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added necessary unit and integration tests.
- [x] I have added screenshots (if applicable), in the comment section.
