### PR TITLE
fix: filter by _self when click on remove for items in datapanel

### DIFF
--- a/src/shared/organisms/DataPanel/DataPanel.tsx
+++ b/src/shared/organisms/DataPanel/DataPanel.tsx
@@ -382,10 +382,10 @@ const DataPanel: React.FC<Props> = ({}) => {
   };
   const handleRemoveItemFromDataPanel = (record: TDataSource) => {
     const selectedRowKeys = resources.selectedRowKeys.filter(
-      t => t !== record.key
+      t => t !== record._self
     );
     const selectedRows = resources.selectedRows.filter(
-      t => t.key !== record.key
+      t => t._self !== record._self
     );
     localStorage.setItem(
       DATA_PANEL_STORAGE,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #

## Description
when the user try to remove item by item (with multiple binaries) from the data panel, it was just removing one of the resource type, but it must remove also the distributions from the localstorage

https://github.com/BlueBrain/nexus-web/assets/2632473/81ff421a-fcfd-40a2-b2d3-b42c57bf8d63



<!--- Describe your changes in detail -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [X] I have added screenshots (if applicable), in the comment section.
