### PR TITLE
fix: file extenstion from json files

### DIFF
--- a/src/shared/molecules/MyDataTable/MyDataTable.tsx
+++ b/src/shared/molecules/MyDataTable/MyDataTable.tsx
@@ -70,7 +70,7 @@ export type TDataSource = {
   resource?: any; // TODO: Remove
   localStorageType?: 'resource' | 'distribution';
   distributionItemsLength?: number;
-  distribution?: {
+  distribution: {
     contentSize: number;
     encodingFormat: string | string[];
     label: string;

--- a/src/shared/organisms/DataPanel/DataPanel.tsx
+++ b/src/shared/organisms/DataPanel/DataPanel.tsx
@@ -466,7 +466,6 @@ const DataPanel: React.FC<Props> = ({}) => {
               ? resource.distribution?.encodingFormat[0]
               : resource.distribution?.encodingFormat
           );
-
           return {
             size,
             contentType: contentType?.toLowerCase(),
@@ -490,7 +489,6 @@ const DataPanel: React.FC<Props> = ({}) => {
 
     return groupBy(newDataSource, 'contentType');
   }, [dataSource]);
-
   const existedTypes = compact(Object.keys(resourcesGrouped)).filter(
     i => i !== 'undefined'
   );
@@ -511,7 +509,10 @@ const DataPanel: React.FC<Props> = ({}) => {
 
       if (key === 'json') {
         const metadataFiles = value.filter(
-          v => v?.localStorageType === 'resource' && v['@type'] !== 'File'
+          v =>
+            v?.localStorageType === 'resource' &&
+            v['@type'] !== 'File' &&
+            v['@type'].includes('File')
         ).length;
 
         // We don't want to display `json` for metadata files since they are always downloaded.

--- a/src/shared/organisms/DataPanel/DataPanel.tsx
+++ b/src/shared/organisms/DataPanel/DataPanel.tsx
@@ -463,8 +463,8 @@ const DataPanel: React.FC<Props> = ({}) => {
           const contentType = getCorrectFileExtension(
             resource.distribution?.label ?? '',
             isArray(resource.distribution?.encodingFormat)
-              ? resource.distribution?.encodingFormat[0] ?? ''
-              : resource.distribution?.encodingFormat ?? ''
+              ? resource.distribution?.encodingFormat[0]
+              : resource.distribution?.encodingFormat
           );
 
           return {

--- a/src/shared/organisms/DataPanel/DataPanel.tsx
+++ b/src/shared/organisms/DataPanel/DataPanel.tsx
@@ -69,7 +69,7 @@ import {
   pathForChildDistributions,
   pathForTopLevelResources,
 } from '../../../shared/utils/datapanel';
-import { getCorrectFileExtension } from '../../../utils/contentTypes';
+import { getNormalizedFileExtension } from '../../../utils/contentTypes';
 import './styles.less';
 
 type Props = {
@@ -460,8 +460,8 @@ const DataPanel: React.FC<Props> = ({}) => {
             Boolean(resource.distribution?.contentSize)
               ? 'File'
               : 'Resource';
-          const contentType = getCorrectFileExtension(
-            resource.distribution?.label ?? '',
+          const contentType = getNormalizedFileExtension(
+            resource.distribution.label,
             isArray(resource.distribution?.encodingFormat)
               ? resource.distribution?.encodingFormat[0]
               : resource.distribution?.encodingFormat

--- a/src/shared/organisms/DataPanel/DataPanel.tsx
+++ b/src/shared/organisms/DataPanel/DataPanel.tsx
@@ -52,6 +52,7 @@ import {
   FileZipOutlined,
   PlusOutlined,
 } from '@ant-design/icons';
+import * as pluralize from 'pluralize';
 import useOnClickOutside from '../../../shared/hooks/useClickOutside';
 import { parseProjectUrl, uuidv4 } from '../../../shared/utils';
 import { ParsedNexusUrl, parseURL } from '../../../shared/utils/nexusParse';
@@ -62,15 +63,14 @@ import {
   TResourceTableData,
   makeOrgProjectTuple,
 } from '../../molecules/MyDataTable/MyDataTable';
-
-import './styles.less';
 import {
   distributionMatchesTypes,
   getSizeOfResourcesToDownload,
   pathForChildDistributions,
   pathForTopLevelResources,
 } from '../../../shared/utils/datapanel';
-import * as pluralize from 'pluralize';
+import { getCorrectFileExtension } from '../../../utils/contentTypes';
+import './styles.less';
 
 type Props = {
   authenticated?: boolean;
@@ -460,8 +460,13 @@ const DataPanel: React.FC<Props> = ({}) => {
             Boolean(resource.distribution?.contentSize)
               ? 'File'
               : 'Resource';
-          const contentType =
-            resource.distribution?.label?.split('.')?.pop() ?? '';
+          const contentType = getCorrectFileExtension(
+            resource.distribution?.label ?? '',
+            isArray(resource.distribution?.encodingFormat)
+              ? resource.distribution?.encodingFormat[0] ?? ''
+              : resource.distribution?.encodingFormat ?? ''
+          );
+
           return {
             size,
             contentType: contentType?.toLowerCase(),

--- a/src/shared/utils/__tests__/contentTypes.spec.ts
+++ b/src/shared/utils/__tests__/contentTypes.spec.ts
@@ -1,0 +1,49 @@
+import {
+  fileExtensionFromResourceEncoding,
+  getCorrectFileExtension,
+} from '../../../utils/contentTypes';
+
+describe('fileExtensionFromResourceEncoding', () => {
+  it('should return the file extension for a valid encoding type', () => {
+    const encodingType = 'image/jpeg';
+    const extension = fileExtensionFromResourceEncoding(encodingType);
+    expect(extension).toBe('jpeg');
+  });
+
+  it('should return an empty string for an unknown encoding type', () => {
+    const encodingType = 'unknown/type';
+    const extension = fileExtensionFromResourceEncoding(encodingType);
+    expect(extension).toBe('');
+  });
+
+  it('should handle encoding types with additional parameters', () => {
+    const encodingType = 'audio/aac; bitrate=320kbps';
+    const extension = fileExtensionFromResourceEncoding(encodingType);
+    expect(extension).toBe('aac');
+  });
+});
+describe('getCorrectFileExtension', () => {
+  it('should return the file name extension if the file has extension', () => {
+    const item = {
+      filename: 'first-image.png',
+      encodingFormat: 'image/jpeg',
+    };
+    const extension = getCorrectFileExtension(
+      item.filename,
+      item.encodingFormat
+    );
+    expect(extension).toBe('png');
+  });
+
+  it('should return the file encoding format if the file do not has extension', () => {
+    const item = {
+      filename: 'first-image',
+      encodingFormat: 'image/jpeg',
+    };
+    const extension = getCorrectFileExtension(
+      item.filename,
+      item.encodingFormat
+    );
+    expect(extension).toBe('jpeg');
+  });
+});

--- a/src/shared/utils/__tests__/contentTypes.spec.ts
+++ b/src/shared/utils/__tests__/contentTypes.spec.ts
@@ -1,6 +1,6 @@
 import {
   fileExtensionFromResourceEncoding,
-  getCorrectFileExtension,
+  getNormalizedFileExtension,
 } from '../../../utils/contentTypes';
 
 describe('fileExtensionFromResourceEncoding', () => {
@@ -28,7 +28,7 @@ describe('getCorrectFileExtension', () => {
       filename: 'first-image.png',
       encodingFormat: 'image/jpeg',
     };
-    const extension = getCorrectFileExtension(
+    const extension = getNormalizedFileExtension(
       item.filename,
       item.encodingFormat
     );
@@ -40,7 +40,7 @@ describe('getCorrectFileExtension', () => {
       filename: 'first-image',
       encodingFormat: 'image/jpeg',
     };
-    const extension = getCorrectFileExtension(
+    const extension = getNormalizedFileExtension(
       item.filename,
       item.encodingFormat
     );

--- a/src/utils/contentTypes.ts
+++ b/src/utils/contentTypes.ts
@@ -64,17 +64,14 @@ export const fileExtensionFromResourceEncoding = (encodingType?: string) => {
   return extension;
 };
 
-export const getCorrectFileExtension = (
-  filename?: string,
+export const getNormalizedFileExtension = (
+  filename: string,
   encodingFormat?: string
 ) => {
-  if (filename) {
-    const lastDotIndex = filename.lastIndexOf('.');
-    if (lastDotIndex !== -1 && lastDotIndex !== 0) {
-      const extension = filename.slice(lastDotIndex + 1);
-      return extension;
-    }
-    return fileExtensionFromResourceEncoding(encodingFormat);
+  const lastDotIndex = filename.lastIndexOf('.');
+  if (lastDotIndex !== -1 && lastDotIndex !== 0) {
+    const extension = filename.slice(lastDotIndex + 1);
+    return extension;
   }
   return fileExtensionFromResourceEncoding(encodingFormat) ?? '';
 };

--- a/src/utils/contentTypes.ts
+++ b/src/utils/contentTypes.ts
@@ -65,15 +65,16 @@ export const fileExtensionFromResourceEncoding = (encodingType?: string) => {
 };
 
 export const getCorrectFileExtension = (
-  filename: string,
-  encodingFormat: string
+  filename?: string,
+  encodingFormat?: string
 ) => {
-  const lastDotIndex = filename.lastIndexOf('.');
-  if (lastDotIndex !== -1 && lastDotIndex !== 0) {
-    const extension = filename.slice(lastDotIndex + 1);
-    return extension;
-  } else if (encodingFormat) {
+  if (filename) {
+    const lastDotIndex = filename.lastIndexOf('.');
+    if (lastDotIndex !== -1 && lastDotIndex !== 0) {
+      const extension = filename.slice(lastDotIndex + 1);
+      return extension;
+    }
     return fileExtensionFromResourceEncoding(encodingFormat);
   }
-  return '';
+  return fileExtensionFromResourceEncoding(encodingFormat) ?? '';
 };

--- a/src/utils/contentTypes.ts
+++ b/src/utils/contentTypes.ts
@@ -50,7 +50,7 @@ export const MIME_TYPE_TO_EXTENSION: { [key: string]: string } = {
  * If no extension could be derived, the function returns an empty string.
  */
 export const fileExtensionFromResourceEncoding = (encodingType?: string) => {
-  const mimeType = encodingType?.split(';')[0] ?? '';
+  const mimeType = encodingType?.split(';')[0] ?? encodingType ?? '';
   const extension = MIME_TYPE_TO_EXTENSION[mimeType]
     ? `${MIME_TYPE_TO_EXTENSION[mimeType]}`
     : '';
@@ -62,4 +62,18 @@ export const fileExtensionFromResourceEncoding = (encodingType?: string) => {
   }
 
   return extension;
+};
+
+export const getCorrectFileExtension = (
+  filename: string,
+  encodingFormat: string
+) => {
+  const lastDotIndex = filename.lastIndexOf('.');
+  if (lastDotIndex !== -1 && lastDotIndex !== 0) {
+    const extension = filename.slice(lastDotIndex + 1);
+    return extension;
+  } else if (encodingFormat) {
+    return fileExtensionFromResourceEncoding(encodingFormat);
+  }
+  return '';
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #

## Description
1- Get the correct extension of a file (first check the `filename` then the `encodingFormat`)
2- when filtering the `json` resource from the `json` files, the @type could be an array so filtering the by array must be added

<!--- Describe your changes in detail -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
