### PR TITLE
fix: dateEnd must be greater than dateStart

### DIFF
--- a/src/shared/molecules/MyDataHeader/MyDataHeader.tsx
+++ b/src/shared/molecules/MyDataHeader/MyDataHeader.tsx
@@ -160,6 +160,10 @@ const Filters = ({
     !dateFilterType ||
     !dateField ||
     (dateFilterType === 'range' && (!dateStart || !dateEnd)) ||
+    (dateFilterType === 'range' &&
+      dateStart &&
+      dateEnd &&
+      moment(dateEnd).isBefore(dateStart, 'days')) ||
     (dateFilterType !== 'range' && !singleDate);
 
   const DatePickerContainer = (
@@ -188,13 +192,37 @@ const Filters = ({
             <DateSeparated
               name="dateStart"
               value={dateStart}
-              updateUpperDate={value => updateDate('dateStart', value)}
+              updateUpperDate={value => {
+                if (
+                  dateEnd &&
+                  moment(dateEnd).isValid() &&
+                  moment(dateEnd).isBefore(dateStart, 'days')
+                ) {
+                  return updateCurrentDates({
+                    dateStart: dateEnd,
+                    dateEnd: value,
+                  });
+                }
+                return updateDate('dateStart', value);
+              }}
             />
             <span className="range-born">To</span>
             <DateSeparated
               name="dateStart"
               value={dateEnd}
-              updateUpperDate={value => updateDate('dateEnd', value)}
+              updateUpperDate={value => {
+                if (
+                  dateStart &&
+                  moment(dateStart).isValid() &&
+                  moment(dateStart).isAfter(dateEnd, 'days')
+                ) {
+                  return updateCurrentDates({
+                    dateStart: value,
+                    dateEnd: dateStart,
+                  });
+                }
+                return updateDate('dateEnd', value);
+              }}
             />
           </Fragment>
         ) : (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #

## Description
The form validation, must detect if the dateEnd are greater than dateStart
if not the case, the UX must hande it, and switch between them

<!--- Describe your changes in detail -->

https://github.com/BlueBrain/nexus-web/assets/2632473/d682f272-5875-4aad-8d9f-18c65209ac28


## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [X] I have added screenshots (if applicable), in the comment section.
