### PR TITLE
3996 // Studio rows should include index in Key because they can have same self

### DIFF
--- a/src/__mocks__/handlers/DataTableContainer/handlers.ts
+++ b/src/__mocks__/handlers/DataTableContainer/handlers.ts
@@ -263,3 +263,62 @@ export const sparqlViewSingleResult = rest.post(
     return res(ctx.status(200), ctx.json(mockResponse));
   }
 );
+
+export const getMockStudioResource = (givenName: string, self: string) => ({
+  familyName: {
+    type: 'literal',
+    value: 'Archer',
+  },
+  givenName: {
+    type: 'literal',
+    value: givenName,
+  },
+  id: {
+    type: 'uri',
+    value: self,
+  },
+  self: {
+    type: 'uri',
+    value: self,
+  },
+});
+
+export const sparqlViewResultHandler = (
+  studioRows: ReturnType<typeof getMockStudioResource>[]
+) => {
+  return rest.post(
+    deltaPath('/views/bbp/agents/graph/sparql'),
+    (req, res, ctx) => {
+      const mockResponse = {
+        head: {
+          vars: ['self', 'givenName', 'familyName', 'id'],
+        },
+        results: {
+          bindings: [...studioRows],
+        },
+      };
+
+      return res(ctx.status(200), ctx.json(mockResponse));
+    }
+  );
+};
+
+export const fetchResourceForDownload = rest.get(
+  deltaPath(
+    `/resources/bbp/agents/_/persons%2Fc3358e61-7650-4954-99b7-f7572cbf5d5g`
+  ),
+  (req, res, ctx) => {
+    const self = req.url.pathname.slice(req.url.pathname.lastIndexOf('/') + 1);
+    const mockResponse = {
+      '@context': [
+        'https://bluebrain.github.io/nexus/contexts/metadata.json',
+        'https://bluebrainnexus.io/workflowStep/table-context',
+      ],
+      '@id': `https://bbp.epfl.ch/neurosciencegraph/data/${self}`,
+      '@type': 'Resource',
+      _self: `https://localhost:3000/resources/bbp/agents/_/${self}`,
+    };
+
+    return res(ctx.status(200), ctx.json(mockResponse));
+  }
+);

--- a/src/subapps/studioLegacy/containers/__tests__/__snapshots__/WorkSpaceMenuContainer.spec.tsx.snap
+++ b/src/subapps/studioLegacy/containers/__tests__/__snapshots__/WorkSpaceMenuContainer.spec.tsx.snap
@@ -450,7 +450,7 @@ exports[`workSpaceMenu renders with a single workspace and dashboard  1`] = `
                         </tr>
                         <tr
                           class="ant-table-row ant-table-row-level-0 data-table-row"
-                          data-row-key="https://localhost:3000/nexus/v1/projects/nise/kerrien1"
+                          data-row-key="https://localhost:3000/nexus/v1/projects/nise/kerrien1-index0"
                         >
                           <td
                             class="ant-table-cell ant-table-selection-column"
@@ -485,7 +485,7 @@ exports[`workSpaceMenu renders with a single workspace and dashboard  1`] = `
                         </tr>
                         <tr
                           class="ant-table-row ant-table-row-level-0 data-table-row"
-                          data-row-key="https://localhost:3000/nexus/v1/projects/nise/kerrien2"
+                          data-row-key="https://localhost:3000/nexus/v1/projects/nise/kerrien2-index1"
                         >
                           <td
                             class="ant-table-cell ant-table-selection-column"
@@ -520,7 +520,7 @@ exports[`workSpaceMenu renders with a single workspace and dashboard  1`] = `
                         </tr>
                         <tr
                           class="ant-table-row ant-table-row-level-0 data-table-row"
-                          data-row-key="https://localhost:3000/nexus/v1/projects/nise/kerrien3"
+                          data-row-key="https://localhost:3000/nexus/v1/projects/nise/kerrien3-index2"
                         >
                           <td
                             class="ant-table-cell ant-table-selection-column"
@@ -555,7 +555,7 @@ exports[`workSpaceMenu renders with a single workspace and dashboard  1`] = `
                         </tr>
                         <tr
                           class="ant-table-row ant-table-row-level-0 data-table-row"
-                          data-row-key="https://localhost:3000/nexus/v1/projects/nise/kerrien4"
+                          data-row-key="https://localhost:3000/nexus/v1/projects/nise/kerrien4-index3"
                         >
                           <td
                             class="ant-table-cell ant-table-selection-column"
@@ -590,7 +590,7 @@ exports[`workSpaceMenu renders with a single workspace and dashboard  1`] = `
                         </tr>
                         <tr
                           class="ant-table-row ant-table-row-level-0 data-table-row"
-                          data-row-key="https://localhost:3000/nexus/v1/projects/nise/kerrien5"
+                          data-row-key="https://localhost:3000/nexus/v1/projects/nise/kerrien5-index4"
                         >
                           <td
                             class="ant-table-cell ant-table-selection-column"
@@ -625,7 +625,7 @@ exports[`workSpaceMenu renders with a single workspace and dashboard  1`] = `
                         </tr>
                         <tr
                           class="ant-table-row ant-table-row-level-0 data-table-row"
-                          data-row-key="https://localhost:3000/nexus/v1/projects/nise/kerrien6"
+                          data-row-key="https://localhost:3000/nexus/v1/projects/nise/kerrien6-index5"
                         >
                           <td
                             class="ant-table-cell ant-table-selection-column"
@@ -660,7 +660,7 @@ exports[`workSpaceMenu renders with a single workspace and dashboard  1`] = `
                         </tr>
                         <tr
                           class="ant-table-row ant-table-row-level-0 data-table-row"
-                          data-row-key="https://localhost:3000/nexus/v1/projects/nise/kerrien7"
+                          data-row-key="https://localhost:3000/nexus/v1/projects/nise/kerrien7-index6"
                         >
                           <td
                             class="ant-table-cell ant-table-selection-column"
@@ -695,7 +695,7 @@ exports[`workSpaceMenu renders with a single workspace and dashboard  1`] = `
                         </tr>
                         <tr
                           class="ant-table-row ant-table-row-level-0 data-table-row"
-                          data-row-key="https://localhost:3000/nexus/v1/projects/nise/kerrien8"
+                          data-row-key="https://localhost:3000/nexus/v1/projects/nise/kerrien8-index7"
                         >
                           <td
                             class="ant-table-cell ant-table-selection-column"
@@ -730,7 +730,7 @@ exports[`workSpaceMenu renders with a single workspace and dashboard  1`] = `
                         </tr>
                         <tr
                           class="ant-table-row ant-table-row-level-0 data-table-row"
-                          data-row-key="https://localhost:3000/nexus/v1/projects/nise/kerrien9"
+                          data-row-key="https://localhost:3000/nexus/v1/projects/nise/kerrien9-index8"
                         >
                           <td
                             class="ant-table-cell ant-table-selection-column"
@@ -765,7 +765,7 @@ exports[`workSpaceMenu renders with a single workspace and dashboard  1`] = `
                         </tr>
                         <tr
                           class="ant-table-row ant-table-row-level-0 data-table-row"
-                          data-row-key="https://localhost:3000/nexus/v1/projects/nise/kerrien10"
+                          data-row-key="https://localhost:3000/nexus/v1/projects/nise/kerrien10-index9"
                         >
                           <td
                             class="ant-table-cell ant-table-selection-column"


### PR DESCRIPTION
Sometimes different rows in Studio table can have same self. (Example, "[Cell Types](http://localhost:8000/studios/neurosciencegraph/datamodels/studios/https%3A%2F%2Fbbp-nexus.epfl.ch%2Fstaging%2Fv1%2Fresources%2Fneurosciencegraph%2Fdatamodels%2F_%2F11b6317f-dd9f-41b7-a4ab-228e86eab2df?workspaceId=https%3A%2F%2Fbbp-nexus.epfl.ch%2Fstaging%2Fv1%2Fresources%2Fneurosciencegraph%2Fdatamodels%2F_%2F8b810fa0-d924-49f0-80f1-7e6735370f56&dashboardId=https%3A%2F%2Fbbp-nexus.epfl.ch%2Fstaging%2Fv1%2Fresources%2Fneurosciencegraph%2Fdatamodels%2F_%2F0774ce60-bca9-4618-9093-b8f695bc5703)" Studio in neuroscience organization in staging env). In these cases, we still need to have a unique React.Key for each row. However, self should still be used to fetch resources for download.

That's why a row in studio needs two keys:

tableKey: to help react render each row in table correctly. This is unique for every row
localStorageKey: usually the value of `self.value`. This is used to retrieve a row to display it in the resources panel or to fetch it for downloading it through the data panel.

<!--- Provide a general summary of your changes in the Title above -->

Fixes #

## Description

<!--- Describe your changes in detail -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
