### PR TITLE
fix: reset selected types after clearing the local storage

### DIFF
--- a/src/shared/organisms/DataPanel/DataPanel.tsx
+++ b/src/shared/organisms/DataPanel/DataPanel.tsx
@@ -368,6 +368,7 @@ const DataPanel: React.FC<Props> = ({}) => {
   ];
 
   const handleClearSelectedItems = () => {
+    setTypes([]);
     updateDataPanel({
       resources: { selectedRowKeys: [], selectedRows: [] },
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #

## Description
If the user select some types to download an archive and then he clear the storage and then select others
then the previously selected types stay selected
The correct behavior is to reset the types selection 

<!--- Describe your changes in detail -->

https://github.com/BlueBrain/nexus-web/assets/2632473/3636fb63-4a2d-49d4-bc95-0b2b2e185ded


## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [X] I have added screenshots (if applicable), in the comment section.
