### PR TITLE
fix: add realm to identities to differntiate similair names and singu…

### DIFF
--- a/src/subapps/admin/components/Settings/PermissionsAclsSubView.tsx
+++ b/src/subapps/admin/components/Settings/PermissionsAclsSubView.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import { groupBy, sortBy } from 'lodash';
-import { Table, Collapse, Checkbox, Empty, Spin } from 'antd';
+import { Table, Collapse, Checkbox, Empty, Spin, Tag } from 'antd';
 import { ColumnsType } from 'antd/es/table';
 import { useRouteMatch } from 'react-router';
 import { useQuery } from 'react-query';
@@ -21,6 +21,7 @@ type DataType = {
   create?: boolean;
   query?: boolean;
   children?: DataType[];
+  realm?: string;
 };
 type GroupedPermission = {
   name: string;
@@ -87,7 +88,6 @@ const PermissionsAclsSubView = (props: Props) => {
     refetchOnWindowFocus: false,
     retry: false,
   });
-
   const columns: ColumnsType<DataType> = useMemo(
     () => [
       {
@@ -97,7 +97,10 @@ const PermissionsAclsSubView = (props: Props) => {
         width: 200,
         ellipsis: true,
         render: (text, record) => (
-          <span className={record.parent ? 'row-as-head' : ''}>{text}</span>
+          <span className={record.parent ? 'row-as-head' : ''}>
+            {record.realm && <Tag>{record.realm}</Tag>}
+            {text}
+          </span>
         ),
       },
       {
@@ -158,13 +161,14 @@ const PermissionsAclsSubView = (props: Props) => {
       const iden = identity.subject ?? (identity.group || '');
       const name = iden ? `: ${iden}` : '';
       return {
-        key: identity['@id'],
+        key: `${identity.realm}/${identity['@id']}`,
         name: `${identity['@type']}${name}`,
+        realm: identity.realm,
         parent: true,
         // @ts-ignore
         children: permissions.map(({ name, permissions }) => ({
           name,
-          key: `${identity['@type']}:${identity.subject}:${name}`,
+          key: `${identity.realm}/${identity['@type']}/${identity.subject}:${name}`,
           read: permissions.includes('read'),
           write: permissions.includes('write'),
           create: permissions.includes('create'),


### PR DESCRIPTION
…larity of reactKeys

<!--- Provide a general summary of your changes in the Title above -->

Fixes #

## Description
In the ACLs & Permissions Tab, there might be multiple entities with the same name but they are in different realms,
We should enable the user to differentiate between user by their realms

<img width="1512" alt="Screenshot 2023-06-26 at 10 38 52" src="https://github.com/BlueBrain/nexus-web/assets/2632473/b874f430-a4a2-486d-b452-1fdf708eec83">

<!--- Describe your changes in detail -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [X] I have added screenshots (if applicable), in the comment section.
