### PR TITLE
fix: show full types in multiple lines in tooltip

### DIFF
--- a/src/shared/molecules/MyDataTable/MyDataTable.tsx
+++ b/src/shared/molecules/MyDataTable/MyDataTable.tsx
@@ -130,6 +130,24 @@ export const notifyTotalSizeExeeced = () => {
     key: 'data-panel-size-exceeded',
   });
 };
+const getTypesTrancated = (text: string | string[]) => {
+  let types = '';
+  let typesWithUrl = text;
+  if (isArray(text)) {
+    types = text
+      .map(item => (isValidUrl(item) ? item.split('/').pop() : item))
+      .join('\n');
+    typesWithUrl = text.join('\n');
+  } else if (isString(text) && isValidUrl(text)) {
+    types = text.split('/').pop() ?? '';
+  } else {
+    types = text;
+  }
+  return {
+    types,
+    typesWithUrl,
+  };
+};
 type TSorterProps = {
   order?: string;
   name: string;
@@ -281,19 +299,12 @@ const MyDataTable: React.FC<TProps> = ({
         dataIndex: '@type',
         sorter: false,
         render: text => {
-          let types = '';
-          if (isArray(text)) {
-            types = text
-              .map(item => (isValidUrl(item) ? item.split('/').pop() : item))
-              .join('\n');
-          } else if (isString(text) && isValidUrl(text)) {
-            types = text.split('/').pop() ?? '';
-          } else {
-            types = text;
-          }
+          const { types, typesWithUrl } = getTypesTrancated(text);
           return (
             <Tooltip
-              title={() => <div style={{ whiteSpace: 'pre-wrap' }}>{text}</div>}
+              title={() => (
+                <div style={{ whiteSpace: 'pre-wrap' }}>{typesWithUrl}</div>
+              )}
             >
               <div style={{ whiteSpace: 'pre-wrap' }}>{types}</div>
             </Tooltip>

--- a/src/shared/molecules/MyDataTable/MyDataTable.tsx
+++ b/src/shared/molecules/MyDataTable/MyDataTable.tsx
@@ -139,7 +139,7 @@ const getTypesTrancated = (text: string | string[]) => {
       .join('\n');
     typesWithUrl = text.join('\n');
   } else if (isString(text) && isValidUrl(text)) {
-    types = text.split('/').pop() ?? '';
+    types = text.split('/').pop()!;
   } else {
     types = text;
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #

## Description
In the resources listing in my data page, the types of each resource might be an array, in the relative row, we show only the label of the type, in the tooltip we show the whole URI of the type so we should present them in a better way so each type will have a new line in the tooltip

<img width="1509" alt="Screenshot 2023-06-26 at 10 42 37" src="https://github.com/BlueBrain/nexus-web/assets/2632473/89d01632-9bd9-41f5-8071-244245d99099">

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [X] I have added screenshots (if applicable), in the comment section.
