### PR TITLE
hotfix: workspaces menu studios

### DIFF
--- a/src/subapps/studioLegacy/containers/WorkspaceMenuContainer.tsx
+++ b/src/subapps/studioLegacy/containers/WorkspaceMenuContainer.tsx
@@ -405,14 +405,10 @@ const WorkspaceMenu: React.FC<WorkspaceMenuProps> = ({
           content={editWorkspaceWrapper}
           trigger="click"
         >
-          {/* <div
-            style={{ maxWidth: 'max-content', float: 'right', margin: '0 5px' }}
-          > */}
           <Button shape="round" type="default" role="button">
             <EditOutlined />
             Workspace
           </Button>
-          {/* </div> */}
         </Popover>
         {selectedWorkspace ? (
           <Popover

--- a/src/subapps/studioLegacy/containers/WorkspaceMenuContainer.tsx
+++ b/src/subapps/studioLegacy/containers/WorkspaceMenuContainer.tsx
@@ -8,6 +8,10 @@ import {
   EditOutlined,
   DownOutlined,
 } from '@ant-design/icons';
+import PromisePool from '@supercharge/promise-pool';
+import { ItemType } from 'antd/lib/menu/hooks/useItems';
+import { useQuery } from 'react-query';
+import { find, orderBy } from 'lodash';
 import useNotification from '../../../shared/hooks/useNotification';
 import EditTableForm from '../../../shared/components/EditTableForm';
 import DashboardEditorContainer from './DashBoardEditor/DashboardEditorContainer';
@@ -24,8 +28,8 @@ import DataTableContainer, {
 } from '../../../shared/containers/DataTableContainer';
 import STUDIO_CONTEXT from '../components/StudioContext';
 import { createTableContext } from '../../../subapps/projects/utils/workFlowMetadataUtils';
-import { find } from 'lodash';
 import { ErrorComponent } from '../../../shared/components/ErrorComponent';
+import '../studio.less';
 
 const DASHBOARD_TYPE = 'StudioDashboard';
 
@@ -346,7 +350,6 @@ const WorkspaceMenu: React.FC<WorkspaceMenuProps> = ({
         ) : null}
       </>
     );
-
     return resourcesWritePermissionsWrapper(editButton, permissionsPath);
   };
 
@@ -390,44 +393,44 @@ const WorkspaceMenu: React.FC<WorkspaceMenuProps> = ({
         ) : null}
       </>
     );
-
     return resourcesWritePermissionsWrapper(editButton, permissionsPath);
   };
 
   const actionButtons = () => {
     const actionsPopovers = (
-      <>
+      <div className='actions-menu'>
         <Popover
           style={{ background: 'none' }}
-          placement="rightTop"
+          placement='leftBottom'
           content={editWorkspaceWrapper}
           trigger="click"
         >
-          <Menu.Item
+          {/* <div
             style={{ maxWidth: 'max-content', float: 'right', margin: '0 5px' }}
-          >
-            <Button shape="round" type="default" role="button">
-              <EditOutlined />
-              Workspace
-            </Button>
-          </Menu.Item>
+          > */}
+          <Button shape="round" type="default" role="button">
+            <EditOutlined />
+            Workspace
+          </Button>
+          {/* </div> */}
         </Popover>
         {selectedWorkspace ? (
           <Popover
             style={{ background: 'none' }}
-            placement="rightTop"
+            placement="leftBottom"
             content={editDhashBoardspaceWrapper}
             trigger="click"
           >
-            <Menu.Item style={{ maxWidth: 'max-content', float: 'right' }}>
+            <div style={{ maxWidth: 'max-content', float: 'right' }}>
               <Button shape="round" type="default" role="button">
                 <EditOutlined />
                 Dashboard
               </Button>
-            </Menu.Item>
+            </div>
           </Popover>
         ) : null}
-      </>
+
+      </div>
     );
     return resourcesWritePermissionsWrapper(actionsPopovers, permissionsPath);
   };
@@ -538,7 +541,6 @@ const WorkspaceMenu: React.FC<WorkspaceMenuProps> = ({
       }
     }
   }, [selectedWorkspace, selectedDashboard]);
-
   React.useEffect(() => {
     if (workspaceIds.length > 0) {
       Promise.all(
@@ -679,51 +681,83 @@ const WorkspaceMenu: React.FC<WorkspaceMenuProps> = ({
     }
     return '';
   }
+  const { data: workspaceDashboards, isSuccess } = useQuery({
+    queryKey: ['workspace-dashboard-menu', { workspaces }],
+    enabled: !!workspaces && !!workspaces.length,
+    refetchOnWindowFocus: false,
+    retry: false,
+    queryFn: async () => {
+      const { results } = await PromisePool.for(workspaces)
+        .withConcurrency(5)
+        .process(async (item) => {
+          const { results } = await PromisePool.for(item.dashboards)
+            .withConcurrency(5)
+            .process(async (subitem) => {
+              return nexus.Resource.get(
+                orgLabel,
+                projectLabel,
+                encodeURIComponent((subitem as any).dashboard)
+              ) as Promise<
+                Resource<{
+                  label: string;
+                  description?: string;
+                  dataQuery: string;
+                  plugins: string[];
+                }>
+              >
+            })
+          return { workspace: item, dashboards: results };
+        })
+      return results;
+    }
+  })
+  const items: ItemType[] = isSuccess &&
+    workspaceDashboards &&
+    Boolean(workspaceDashboards.length) ?
+    orderBy(workspaceDashboards.map(item => {
+      return ({
+        key: item.workspace['@id'],
+        label: item.workspace.label,
+        title: item.workspace.label,
+        expandIcon: <DownOutlined />,
+        icon: <DownOutlined />,
+        className: selectKeysHighlight(item.workspace),
+        onTitleClick: () => setSelectedWorkspace(item.workspace),
+        popupClassName: 'workspace-popup-classname',
+        popupOffset: [0, 0],
+        createdAt: item.workspace._createdAt,
+        children: orderBy(item.dashboards.map(dash => {
+          return ({
+            label: dash.label,
+            updatedAt: dash._updatedAt,
+            key: `${item.workspace['@id']}*${dash['@id']}`,
+            onClick: () => {
+              setSelectedDashboard(dash);
+              setSelectedKeys([`${item.workspace['@id']}*${dash['@id']}`]);
+            }
+          })
+        }), ['label'], ['asc'])
+      })
+    }), ['createdAt'], ['asc']) : [];
+
   return (
     <div className="workspace-list-container">
-      <Menu
-        theme="dark"
-        mode="horizontal"
-        selectable={false}
-        triggerSubMenuAction="click"
-        selectedKeys={selectedKeys}
-        style={{
-          minHeight: '40px',
-        }}
-      >
-        {workspaces.map(w => (
-          <Menu.SubMenu
-            icon={<DownOutlined />}
-            title={w.label}
-            key={`workspace-${w['@id']}`}
-            popupOffset={[0, 0]}
-            className={selectKeysHighlight(w)}
-            onTitleClick={() => setSelectedWorkspace(w)}
-            popupClassName="workspace-popup-classname"
-          >
-            {dashboardSpinner ? (
-              <Menu.Item>
-                <Spin />
-              </Menu.Item>
-            ) : (
-              dashboards.map((d: Resource) => {
-                return (
-                  <Menu.Item
-                    key={`w${w['@id']}-d${d['@id']}`}
-                    onClick={() => {
-                      setSelectedKeys([`${w['@id']}*${d['@id']}`]);
-                      setSelectedDashboard(d);
-                    }}
-                  >
-                    {d.label}
-                  </Menu.Item>
-                );
-              })
-            )}
-          </Menu.SubMenu>
-        ))}
+      <div className='top-menu'>
+        {
+          isSuccess && Boolean(items.length) && <Menu
+            theme="dark"
+            mode="horizontal"
+            selectable={false}
+            triggerSubMenuAction="click"
+            selectedKeys={selectedKeys}
+            style={{
+              minHeight: '40px',
+            }}
+            items={items}
+          />
+        }
         {actionButtons()}
-      </Menu>
+      </div>
       <div>
         {renderResults()}
         {tableDataError && (
@@ -818,7 +852,8 @@ const WorkspaceMenu: React.FC<WorkspaceMenuProps> = ({
         )}
       </div>
     </div>
-  );
+  )
+
 };
 
 export default WorkspaceMenu;

--- a/src/subapps/studioLegacy/containers/WorkspaceMenuContainer.tsx
+++ b/src/subapps/studioLegacy/containers/WorkspaceMenuContainer.tsx
@@ -398,10 +398,10 @@ const WorkspaceMenu: React.FC<WorkspaceMenuProps> = ({
 
   const actionButtons = () => {
     const actionsPopovers = (
-      <div className='actions-menu'>
+      <div className="actions-menu">
         <Popover
           style={{ background: 'none' }}
-          placement='leftBottom'
+          placement="leftBottom"
           content={editWorkspaceWrapper}
           trigger="click"
         >
@@ -429,7 +429,6 @@ const WorkspaceMenu: React.FC<WorkspaceMenuProps> = ({
             </div>
           </Popover>
         ) : null}
-
       </div>
     );
     return resourcesWritePermissionsWrapper(actionsPopovers, permissionsPath);
@@ -689,10 +688,10 @@ const WorkspaceMenu: React.FC<WorkspaceMenuProps> = ({
     queryFn: async () => {
       const { results } = await PromisePool.for(workspaces)
         .withConcurrency(5)
-        .process(async (item) => {
+        .process(async item => {
           const { results } = await PromisePool.for(item.dashboards)
             .withConcurrency(5)
-            .process(async (subitem) => {
+            .process(async subitem => {
               return nexus.Resource.get(
                 orgLabel,
                 projectLabel,
@@ -704,47 +703,57 @@ const WorkspaceMenu: React.FC<WorkspaceMenuProps> = ({
                   dataQuery: string;
                   plugins: string[];
                 }>
-              >
-            })
+              >;
+            });
           return { workspace: item, dashboards: results };
-        })
+        });
       return results;
-    }
-  })
-  const items: ItemType[] = isSuccess &&
-    workspaceDashboards &&
-    Boolean(workspaceDashboards.length) ?
-    orderBy(workspaceDashboards.map(item => {
-      return ({
-        key: item.workspace['@id'],
-        label: item.workspace.label,
-        title: item.workspace.label,
-        expandIcon: <DownOutlined />,
-        icon: <DownOutlined />,
-        className: selectKeysHighlight(item.workspace),
-        onTitleClick: () => setSelectedWorkspace(item.workspace),
-        popupClassName: 'workspace-popup-classname',
-        popupOffset: [0, 0],
-        createdAt: item.workspace._createdAt,
-        children: orderBy(item.dashboards.map(dash => {
-          return ({
-            label: dash.label,
-            updatedAt: dash._updatedAt,
-            key: `${item.workspace['@id']}*${dash['@id']}`,
-            onClick: () => {
-              setSelectedDashboard(dash);
-              setSelectedKeys([`${item.workspace['@id']}*${dash['@id']}`]);
-            }
-          })
-        }), ['label'], ['asc'])
-      })
-    }), ['createdAt'], ['asc']) : [];
+    },
+  });
+  const items: ItemType[] =
+    isSuccess && workspaceDashboards && Boolean(workspaceDashboards.length)
+      ? orderBy(
+          workspaceDashboards.map(item => {
+            return {
+              key: item.workspace['@id'],
+              label: item.workspace.label,
+              title: item.workspace.label,
+              expandIcon: <DownOutlined />,
+              icon: <DownOutlined />,
+              className: selectKeysHighlight(item.workspace),
+              onTitleClick: () => setSelectedWorkspace(item.workspace),
+              popupClassName: 'workspace-popup-classname',
+              popupOffset: [0, 0],
+              createdAt: item.workspace._createdAt,
+              children: orderBy(
+                item.dashboards.map(dash => {
+                  return {
+                    label: dash.label,
+                    updatedAt: dash._updatedAt,
+                    key: `${item.workspace['@id']}*${dash['@id']}`,
+                    onClick: () => {
+                      setSelectedDashboard(dash);
+                      setSelectedKeys([
+                        `${item.workspace['@id']}*${dash['@id']}`,
+                      ]);
+                    },
+                  };
+                }),
+                ['label'],
+                ['asc']
+              ),
+            };
+          }),
+          ['createdAt'],
+          ['asc']
+        )
+      : [];
 
   return (
     <div className="workspace-list-container">
-      <div className='top-menu'>
-        {
-          isSuccess && Boolean(items.length) && <Menu
+      <div className="top-menu">
+        {isSuccess && Boolean(items.length) && (
+          <Menu
             theme="dark"
             mode="horizontal"
             selectable={false}
@@ -755,7 +764,7 @@ const WorkspaceMenu: React.FC<WorkspaceMenuProps> = ({
             }}
             items={items}
           />
-        }
+        )}
         {actionButtons()}
       </div>
       <div>
@@ -852,8 +861,7 @@ const WorkspaceMenu: React.FC<WorkspaceMenuProps> = ({
         )}
       </div>
     </div>
-  )
-
+  );
 };
 
 export default WorkspaceMenu;

--- a/src/subapps/studioLegacy/containers/__tests__/__snapshots__/WorkSpaceMenuContainer.spec.tsx.snap
+++ b/src/subapps/studioLegacy/containers/__tests__/__snapshots__/WorkSpaceMenuContainer.spec.tsx.snap
@@ -5,78 +5,38 @@ exports[`workSpaceMenu renders with a single workspace and dashboard  1`] = `
   <div
     class="workspace-list-container"
   >
-    <ul
-      class="ant-menu-overflow ant-menu ant-menu-root ant-menu-horizontal ant-menu-dark"
-      data-menu-list="true"
-      role="menu"
-      style="min-height: 40px;"
-      tabindex="0"
+    <div
+      class="top-menu"
     >
-      <li
-        class="ant-menu-overflow-item ant-menu-submenu ant-menu-submenu-horizontal menu-highlight-override"
-        role="none"
-        style="opacity: 1; order: 0;"
+      <ul
+        class="ant-menu-overflow ant-menu ant-menu-root ant-menu-horizontal ant-menu-dark"
+        data-menu-list="true"
+        role="menu"
+        style="min-height: 40px;"
+        tabindex="0"
       >
-        <div
-          aria-controls="rc-menu-uuid-test-workspace-w1-popup"
-          aria-expanded="false"
-          aria-haspopup="true"
-          class="ant-menu-submenu-title"
-          data-menu-id="rc-menu-uuid-test-workspace-w1"
-          role="menuitem"
-          tabindex="-1"
+        <li
+          class="ant-menu-overflow-item ant-menu-submenu ant-menu-submenu-horizontal menu-highlight-override ant-menu-submenu-selected"
+          role="none"
+          style="opacity: 1; order: 0;"
         >
-          <span
-            aria-label="down"
-            class="anticon anticon-down ant-menu-item-icon"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="down"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-              />
-            </svg>
-          </span>
-          <span
-            class="ant-menu-title-content"
-          >
-            w1
-          </span>
-          <i
-            class="ant-menu-submenu-arrow"
-          />
-        </div>
-      </li>
-      <li
-        class="ant-menu-overflow-item ant-menu-item ant-menu-item-active ant-menu-item-only-child"
-        role="menuitem"
-        style="opacity: 1; order: 1; max-width: max-content; float: right; margin: 0px 5px;"
-        tabindex="-1"
-      >
-        <span
-          class="ant-menu-title-content"
-        >
-          <button
-            class="ant-btn ant-btn-round ant-btn-default"
-            role="button"
-            type="button"
+          <div
+            aria-controls="rc-menu-uuid-test-w1-popup"
+            aria-expanded="false"
+            aria-haspopup="true"
+            class="ant-menu-submenu-title"
+            data-menu-id="rc-menu-uuid-test-w1"
+            role="menuitem"
+            tabindex="-1"
           >
             <span
-              aria-label="edit"
-              class="anticon anticon-edit"
+              aria-label="down"
+              class="anticon anticon-down ant-menu-item-icon"
               role="img"
             >
               <svg
                 aria-hidden="true"
-                data-icon="edit"
+                data-icon="down"
                 fill="currentColor"
                 focusable="false"
                 height="1em"
@@ -84,24 +44,97 @@ exports[`workSpaceMenu renders with a single workspace and dashboard  1`] = `
                 width="1em"
               >
                 <path
-                  d="M257.7 752c2 0 4-.2 6-.5L431.9 722c2-.4 3.9-1.3 5.3-2.8l423.9-423.9a9.96 9.96 0 000-14.1L694.9 114.9c-1.9-1.9-4.4-2.9-7.1-2.9s-5.2 1-7.1 2.9L256.8 538.8c-1.5 1.5-2.4 3.3-2.8 5.3l-29.5 168.2a33.5 33.5 0 009.4 29.8c6.6 6.4 14.9 9.9 23.8 9.9zm67.4-174.4L687.8 215l73.3 73.3-362.7 362.6-88.9 15.7 15.6-89zM880 836H144c-17.7 0-32 14.3-32 32v36c0 4.4 3.6 8 8 8h784c4.4 0 8-3.6 8-8v-36c0-17.7-14.3-32-32-32z"
+                  d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
                 />
               </svg>
             </span>
-            <span>
-              Workspace
+            <span
+              class="ant-menu-title-content"
+            >
+              w1
             </span>
-          </button>
-        </span>
-      </li>
-      <li
-        class="ant-menu-overflow-item ant-menu-item ant-menu-item-active ant-menu-item-only-child"
-        role="menuitem"
-        style="opacity: 1; order: 1; max-width: max-content; float: right;"
-        tabindex="-1"
+            <i
+              class="ant-menu-submenu-arrow"
+            />
+          </div>
+        </li>
+        <li
+          aria-hidden="true"
+          class="ant-menu-overflow-item ant-menu-overflow-item-rest ant-menu-submenu ant-menu-submenu-horizontal ant-menu-submenu-disabled"
+          role="none"
+          style="opacity: 0; height: 0px; overflow-y: hidden; order: 9007199254740991; pointer-events: none; position: absolute;"
+        >
+          <div
+            aria-controls="rc-menu-uuid-test-rc-menu-more-popup"
+            aria-disabled="true"
+            aria-expanded="false"
+            aria-haspopup="true"
+            class="ant-menu-submenu-title"
+            data-menu-id="rc-menu-uuid-test-rc-menu-more"
+            role="menuitem"
+          >
+            <span
+              aria-label="ellipsis"
+              class="anticon anticon-ellipsis"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="ellipsis"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+                />
+              </svg>
+            </span>
+            <i
+              class="ant-menu-submenu-arrow"
+            />
+          </div>
+        </li>
+      </ul>
+      <div
+        aria-hidden="true"
+        style="display: none;"
+      />
+      <div
+        class="actions-menu"
       >
-        <span
-          class="ant-menu-title-content"
+        <button
+          class="ant-btn ant-btn-round ant-btn-default"
+          role="button"
+          type="button"
+        >
+          <span
+            aria-label="edit"
+            class="anticon anticon-edit"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="edit"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M257.7 752c2 0 4-.2 6-.5L431.9 722c2-.4 3.9-1.3 5.3-2.8l423.9-423.9a9.96 9.96 0 000-14.1L694.9 114.9c-1.9-1.9-4.4-2.9-7.1-2.9s-5.2 1-7.1 2.9L256.8 538.8c-1.5 1.5-2.4 3.3-2.8 5.3l-29.5 168.2a33.5 33.5 0 009.4 29.8c6.6 6.4 14.9 9.9 23.8 9.9zm67.4-174.4L687.8 215l73.3 73.3-362.7 362.6-88.9 15.7 15.6-89zM880 836H144c-17.7 0-32 14.3-32 32v36c0 4.4 3.6 8 8 8h784c4.4 0 8-3.6 8-8v-36c0-17.7-14.3-32-32-32z"
+              />
+            </svg>
+          </span>
+          <span>
+            Workspace
+          </span>
+        </button>
+        <div
+          style="max-width: max-content; float: right;"
         >
           <button
             class="ant-btn ant-btn-round ant-btn-default"
@@ -131,52 +164,9 @@ exports[`workSpaceMenu renders with a single workspace and dashboard  1`] = `
               Dashboard
             </span>
           </button>
-        </span>
-      </li>
-      <li
-        aria-hidden="true"
-        class="ant-menu-overflow-item ant-menu-overflow-item-rest ant-menu-submenu ant-menu-submenu-horizontal"
-        role="none"
-        style="opacity: 0; height: 0px; overflow-y: hidden; order: 9007199254740991; pointer-events: none; position: absolute;"
-      >
-        <div
-          aria-controls="rc-menu-uuid-test-rc-menu-more-popup"
-          aria-expanded="false"
-          aria-haspopup="true"
-          class="ant-menu-submenu-title"
-          data-menu-id="rc-menu-uuid-test-rc-menu-more"
-          role="menuitem"
-          tabindex="-1"
-        >
-          <span
-            aria-label="ellipsis"
-            class="anticon anticon-ellipsis"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="ellipsis"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
-              />
-            </svg>
-          </span>
-          <i
-            class="ant-menu-submenu-arrow"
-          />
         </div>
-      </li>
-    </ul>
-    <div
-      aria-hidden="true"
-      style="display: none;"
-    />
+      </div>
+    </div>
     <div>
       <div
         class="studio-table-container"

--- a/src/subapps/studioLegacy/studio.less
+++ b/src/subapps/studioLegacy/studio.less
@@ -30,6 +30,27 @@ div.workspace-list-container {
     float: right;
     padding-right: 10px;
   }
+  div.top-menu{
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    background: #050A56;
+    height: 50px;
+    .ant-menu-item{
+      height: 50px;
+      width: 100%;
+    }
+    .actions-menu {
+      justify-self: flex-end;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 10px;
+      margin-right: 10px;
+      margin-left: auto;
+    }
+  } 
 }
 div.workspace {
   margin-top: 10px;

--- a/src/subapps/studioLegacy/studio.less
+++ b/src/subapps/studioLegacy/studio.less
@@ -30,14 +30,14 @@ div.workspace-list-container {
     float: right;
     padding-right: 10px;
   }
-  div.top-menu{
+  div.top-menu {
     display: flex;
     align-items: center;
     justify-content: space-between;
     width: 100%;
-    background: #050A56;
+    background: #050a56;
     height: 50px;
-    .ant-menu-item{
+    .ant-menu-item {
       height: 50px;
       width: 100%;
     }
@@ -50,7 +50,7 @@ div.workspace-list-container {
       margin-right: 10px;
       margin-left: auto;
     }
-  } 
+  }
 }
 div.workspace {
   margin-top: 10px;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #

## Description
In the studio details page, the workspaces are fetched then we build the menu, but the submenus will be build on every click on the parent menu, by requesting the api to list the items, and ANT will have problem to render the list because it's not already their (calculating the necessary space and dom elements)

we add a new fetch request for building the menu

https://github.com/BlueBrain/nexus-web/assets/2632473/742d8fd5-df72-4dc8-974a-95944d52fa41



## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [X] I have added screenshots (if applicable), in the comment section.
