### PR TITLE
fix: when there is no query don't render the sorter

### DIFF
--- a/src/shared/molecules/MyDataTable/MyDataTable.tsx
+++ b/src/shared/molecules/MyDataTable/MyDataTable.tsx
@@ -264,15 +264,14 @@ const MyDataTable: React.FC<TProps> = ({
           return (
             <div>
               organization / project
-              {query ||
-                (query.trim() !== '' && (
-                  <Sorter
-                    name="name"
-                    order={orderDirection}
-                    onSortAscend={() => updateSort(['_project'])}
-                    onSortDescend={() => updateSort(['-_project'])}
-                  />
-                ))}
+              {(!query || query.trim() === '') && (
+                <Sorter
+                  name="name"
+                  order={orderDirection}
+                  onSortAscend={() => updateSort(['_project'])}
+                  onSortDescend={() => updateSort(['-_project'])}
+                />
+              )}
             </div>
           );
         },
@@ -331,15 +330,14 @@ const MyDataTable: React.FC<TProps> = ({
           return (
             <div>
               updated date
-              {query ||
-                (query.trim() !== '' && (
-                  <Sorter
-                    name="name"
-                    order={orderDirection}
-                    onSortAscend={() => updateSort(['_updatedAt', '@id'])}
-                    onSortDescend={() => updateSort(['-_updatedAt', '@id'])}
-                  />
-                ))}
+              {(!query || query.trim() === '') && (
+                <Sorter
+                  name="name"
+                  order={orderDirection}
+                  onSortAscend={() => updateSort(['_updatedAt', '@id'])}
+                  onSortDescend={() => updateSort(['-_updatedAt', '@id'])}
+                />
+              )}
             </div>
           );
         },
@@ -360,15 +358,14 @@ const MyDataTable: React.FC<TProps> = ({
           return (
             <div>
               created date
-              {query ||
-                (query.trim() !== '' && (
-                  <Sorter
-                    name="name"
-                    order={orderDirection}
-                    onSortAscend={() => updateSort(['_createdAt', '@id'])}
-                    onSortDescend={() => updateSort(['-_createdAt', '@id'])}
-                  />
-                ))}
+              {(!query || query.trim() === '') && (
+                <Sorter
+                  name="name"
+                  order={orderDirection}
+                  onSortAscend={() => updateSort(['_createdAt', '@id'])}
+                  onSortDescend={() => updateSort(['-_createdAt', '@id'])}
+                />
+              )}
             </div>
           );
         },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #

## Description
When the user start typing a query in the search box; the sorter must be hidden due the delta API  do not support the query and the sorter to be in one query

<!--- Describe your changes in detail -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
