### PR TITLE
US 7 // Filter resource that dont contain value

### DIFF
--- a/src/shared/components/ResourceEditor/CodeEditor.tsx
+++ b/src/shared/components/ResourceEditor/CodeEditor.tsx
@@ -35,7 +35,7 @@ const CodeEditor = forwardRef<codemiror.Editor | undefined, TCodeEditor>(
     return (
       <Spin spinning={busy}>
         <CodeMirror
-          data-testId="code-mirror-editor"
+          data-testid="code-mirror-editor"
           value={value}
           autoCursor={false}
           detach={false}

--- a/src/shared/components/ResourceEditor/ResourceEditor.spec.tsx
+++ b/src/shared/components/ResourceEditor/ResourceEditor.spec.tsx
@@ -26,7 +26,7 @@ describe('ResourceEditor', () => {
     const onLinksFound = jest.fn();
     const { queryByText, container, getByTestId } = render(
       <CodeEditor
-        data-testId="code-mirror-editor"
+        data-testid="code-mirror-editor"
         value={JSON.stringify(resourceResolverApi)}
         editable={false}
         onLinkClick={() => {}}

--- a/src/shared/components/ResourceEditor/index.tsx
+++ b/src/shared/components/ResourceEditor/index.tsx
@@ -185,7 +185,7 @@ const ResourceEditor: React.FunctionComponent<ResourceEditorProps> = props => {
 
   return (
     <div
-      data-testId="resource-editor"
+      data-testid="resource-editor"
       className={valid ? 'resource-editor' : 'resource-editor _invalid'}
     >
       {showControlPanel && (

--- a/src/subapps/dataExplorer/DataExplorer-utils.spec.tsx
+++ b/src/subapps/dataExplorer/DataExplorer-utils.spec.tsx
@@ -504,4 +504,127 @@ describe('DataExplorerSpec-Utils', () => {
     };
     expect(checkPathExistence(resource, 'topLevelNotExisting')).toEqual(false);
   });
+
+  it('checks if resource does not contain value in path', () => {
+    const resource = {
+      distribution: [
+        {
+          name: 'sally',
+          filename: 'billy',
+          label: ['ChiPmunK'],
+        },
+        {
+          name: 'sally',
+          sillyname: 'soliloquy',
+          filename: 'bolly',
+          label: { foo: 'foovalut', bar: 'barvalue' },
+        },
+      ],
+    };
+
+    expect(
+      doesResourceContain(resource, 'distribution', 'sally', 'does-not-contain')
+    ).toEqual(true);
+
+    expect(
+      doesResourceContain(
+        resource,
+        'distribution.name',
+        'sally',
+        'does-not-contain'
+      )
+    ).toEqual(false);
+
+    expect(
+      doesResourceContain(
+        resource,
+        'distribution.filename',
+        'billy',
+        'does-not-contain'
+      )
+    ).toEqual(true);
+
+    expect(
+      doesResourceContain(
+        resource,
+        'distribution.filename',
+        'popeye',
+        'does-not-contain'
+      )
+    ).toEqual(true);
+  });
+
+  it('checks if resource does not contain value for nested paths', () => {
+    const resource = {
+      distribution: [
+        {
+          name: 'sally',
+          filename: 'billy',
+          label: ['ChiPmunK'],
+          nested: [{ prop1: 'value1', prop2: ['value2', 'value3'] }],
+        },
+        {
+          name: 'sally',
+          sillyname: 'soliloquy',
+          filename: 'bolly',
+          label: { foo: 'foovalut', bar: 'barvalue' },
+          nested: [{ prop1: 'value1', prop2: ['value2', 'value5'] }],
+        },
+      ],
+    };
+
+    expect(
+      doesResourceContain(
+        resource,
+        'distribution.label',
+        'chipmunk',
+        'does-not-contain'
+      )
+    ).toEqual(true);
+
+    expect(
+      doesResourceContain(
+        resource,
+        'distribution.label',
+        'crazy',
+        'does-not-contain'
+      )
+    ).toEqual(true);
+
+    expect(
+      doesResourceContain(
+        resource,
+        'distribution.nested',
+        'crazy',
+        'does-not-contain'
+      )
+    ).toEqual(true);
+
+    expect(
+      doesResourceContain(
+        resource,
+        'distribution.nested.prop2',
+        'value2',
+        'does-not-contain'
+      )
+    ).toEqual(true);
+
+    expect(
+      doesResourceContain(
+        resource,
+        'distribution.nested.prop2',
+        'value',
+        'does-not-contain'
+      )
+    ).toEqual(false);
+
+    expect(
+      doesResourceContain(
+        resource,
+        'distribution.nested.prop2',
+        'value5',
+        'does-not-contain'
+      )
+    ).toEqual(true);
+  });
 });

--- a/src/subapps/dataExplorer/DataExplorer.spec.tsx
+++ b/src/subapps/dataExplorer/DataExplorer.spec.tsx
@@ -21,6 +21,7 @@ import { getColumnTitle } from './DataExplorerTable';
 import {
   CONTAINS,
   DEFAULT_OPTION,
+  DOES_NOT_CONTAIN,
   DOES_NOT_EXIST,
   EXISTS,
   getAllPaths,
@@ -466,5 +467,36 @@ describe('DataExplorer', () => {
     await userEvent.click(container);
     await selectOptionFromMenu(PredicateMenuLabel, EXISTS);
     await expectRowCountToBe(2);
+  });
+
+  it('filters by resources that do not contain value provided by user', async () => {
+    await expectRowCountToBe(10);
+    const mockResourcesForNextPage = [
+      getMockResource('self1', { author: 'piggy', edition: 1 }),
+      getMockResource('self2', { author: ['iggy', 'twinky'] }),
+      getMockResource('self3', { year: 2013 }),
+    ];
+
+    await getRowsForNextPage(mockResourcesForNextPage);
+    await expectRowCountToBe(3);
+
+    await selectOptionFromMenu(PathMenuLabel, 'author');
+    await userEvent.click(container);
+    await selectOptionFromMenu(PredicateMenuLabel, DOES_NOT_CONTAIN);
+    const valueInput = await screen.getByPlaceholderText('type the value...');
+    await userEvent.type(valueInput, 'iggy');
+    await expectRowCountToBe(2);
+
+    await userEvent.clear(valueInput);
+    await userEvent.type(valueInput, 'goldilocks');
+    await expectRowCountToBe(3);
+
+    await userEvent.clear(valueInput);
+    await userEvent.type(valueInput, 'piggy');
+    await expectRowCountToBe(2);
+
+    await userEvent.clear(valueInput);
+    await userEvent.type(valueInput, 'arch');
+    await expectRowCountToBe(3);
   });
 });

--- a/src/subapps/dataExplorer/DataExplorer.spec.tsx
+++ b/src/subapps/dataExplorer/DataExplorer.spec.tsx
@@ -26,6 +26,10 @@ import {
   EXISTS,
   getAllPaths,
 } from './PredicateSelector';
+import { createMemoryHistory } from 'history';
+import { Router } from 'react-router-dom';
+import { Provider } from 'react-redux';
+import configureStore from '../../shared/store';
 
 describe('DataExplorer', () => {
   const server = setupServer(
@@ -33,6 +37,7 @@ describe('DataExplorer', () => {
     filterByProjectHandler(defaultMockResult),
     getProjectHandler()
   );
+  const history = createMemoryHistory({});
 
   let container: HTMLElement;
   let user: UserEvent;
@@ -46,13 +51,18 @@ describe('DataExplorer', () => {
       fetch,
       uri: deltaPath(),
     });
+    const store = configureStore(history, { nexus }, {});
 
     dataExplorerPage = (
-      <QueryClientProvider client={queryClient}>
-        <NexusProvider nexusClient={nexus}>
-          <DataExplorer />
-        </NexusProvider>
-      </QueryClientProvider>
+      <Provider store={store}>
+        <QueryClientProvider client={queryClient}>
+          <Router history={history}>
+            <NexusProvider nexusClient={nexus}>
+              <DataExplorer />
+            </NexusProvider>
+          </Router>
+        </QueryClientProvider>
+      </Provider>
     );
 
     component = render(dataExplorerPage);
@@ -110,6 +120,18 @@ describe('DataExplorer', () => {
       header.innerHTML.match(new RegExp(getColumnTitle(colName), 'i'))
     );
     return allCellsForRow[colIndex].textContent;
+  };
+
+  const getRowForResource = async (resource: Resource) => {
+    const selfCell = await screen.getAllByText(
+      new RegExp(resource._self, 'i'),
+      {
+        selector: 'td',
+      }
+    );
+    const row = selfCell[0].parentElement;
+    expect(row).toBeInTheDocument();
+    return row!;
   };
 
   const openProjectAutocomplete = async () => {
@@ -498,5 +520,16 @@ describe('DataExplorer', () => {
     await userEvent.clear(valueInput);
     await userEvent.type(valueInput, 'arch');
     await expectRowCountToBe(3);
+  });
+
+  it('navigates to resource view when user clicks on row', async () => {
+    await expectRowCountToBe(10);
+
+    expect(history.location.pathname).not.toContain('self1');
+
+    const firstDataRow = await getRowForResource(defaultMockResult[0]);
+    await userEvent.click(firstDataRow);
+
+    expect(history.location.pathname).toContain('self1');
   });
 });

--- a/src/subapps/dataExplorer/DataExplorerTable.tsx
+++ b/src/subapps/dataExplorer/DataExplorerTable.tsx
@@ -8,6 +8,8 @@ import isValidUrl from '../../utils/validUrl';
 import { NoDataCell } from './NoDataCell';
 import './styles.less';
 import { DataExplorerConfiguration } from './DataExplorer';
+import { useHistory, useLocation } from 'react-router-dom';
+import { makeResourceUri, parseProjectUrl } from '../../shared/utils';
 
 interface TDataExplorerTable {
   isLoading: boolean;
@@ -30,6 +32,9 @@ export const DataExplorerTable: React.FC<TDataExplorerTable> = ({
   offset,
   updateTableConfiguration,
 }: TDataExplorerTable) => {
+  const history = useHistory();
+  const location = useLocation();
+
   const allowedTotal = total ? (total > 10000 ? 10000 : total) : undefined;
 
   const tablePaginationConfig: TablePaginationConfig = {
@@ -48,11 +53,23 @@ export const DataExplorerTable: React.FC<TDataExplorerTable> = ({
     showSizeChanger: true,
   };
 
+  const goToResource = (resource: Resource) => {
+    const resourceId = resource['@id'] ?? resource._self;
+    const [orgLabel, projectLabel] = parseProjectUrl(resource._project);
+
+    history.push(makeResourceUri(orgLabel, projectLabel, resourceId), {
+      background: location,
+    });
+  };
+
   return (
     <Table<Resource>
       columns={columnsConfig(columns)}
       dataSource={dataSource}
       rowKey={record => record._self}
+      onRow={resource => ({
+        onClick: _ => goToResource(resource),
+      })}
       loading={isLoading}
       bordered={false}
       className="data-explorer-table"


### PR DESCRIPTION
In case of arrays, if any one element does not contain the value, then the resource row is said is displayed.


![Screenshot from 2023-07-04 16-45-47](https://github.com/BlueBrain/nexus-web/assets/11242410/6d6f785e-c8c9-4f78-918f-ffe8de94a602)



## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added necessary unit and integration tests.
- [X] I have added screenshots (if applicable), in the comment section.
