### PR TITLE
Fix: back btn use react router location

### DIFF
--- a/src/shared/canvas/DataExplorerGraphFlow/DateExplorerGraphFlow.tsx
+++ b/src/shared/canvas/DataExplorerGraphFlow/DateExplorerGraphFlow.tsx
@@ -9,7 +9,7 @@ import {
   ResetDataExplorerGraphFlow,
 } from '../../store/reducers/data-explorer';
 import {
-  NavigationBack,
+  NavigationBackButton,
   NavigationCollapseButton,
 } from '../../molecules/DataExplorerGraphFlowMolecules';
 import NavigationStack from '../../organisms/DataExplorerGraphFlowNavigationStack/NavigationStack';
@@ -81,7 +81,7 @@ const DataExplorerGraphFlow = () => {
       </div>
       <div className="degf__navigation-back">
         <NavigationCollapseButton />
-        <NavigationBack />
+        <NavigationBackButton />
       </div>
       <div className="degf__content">
         <DataExplorerContentPage />

--- a/src/shared/molecules/DataExplorerGraphFlowMolecules/NavigationBackButton.tsx
+++ b/src/shared/molecules/DataExplorerGraphFlowMolecules/NavigationBackButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { useHistory } from 'react-router';
+import { useHistory, useLocation } from 'react-router';
 import { ArrowLeftOutlined } from '@ant-design/icons';
 import { ReturnBackDataExplorerGraphFlow } from '../../store/reducers/data-explorer';
 import { RootState } from '../../store/reducers';
@@ -9,6 +9,7 @@ import './styles.less';
 const NavigationBack = () => {
   const dispatch = useDispatch();
   const history = useHistory();
+  const location = useLocation();
   const { links } = useSelector((state: RootState) => state.dataExplorer);
   const onBack = () => {
     history.replace(location.pathname);

--- a/src/shared/molecules/DataExplorerGraphFlowMolecules/index.ts
+++ b/src/shared/molecules/DataExplorerGraphFlowMolecules/index.ts
@@ -1,5 +1,5 @@
 export { default as DataExplorerGraphFlowContentLimitedHeader } from './ContentLimitedHeader';
-export { default as NavigationBack } from './NavigationBack';
+export { default as NavigationBackButton } from './NavigationBackButton';
 export { default as NavigationStackItem } from './NavigationStackItem';
 export { default as NavigationStackShrinkedItem } from './NavigationStackShrinkedItem';
 export { default as NavigationCollapseButton } from './NavigationCollapseButton';

--- a/src/shared/organisms/DataExplorerGraphFlowNavigationStack/NavigationStack.spec.tsx
+++ b/src/shared/organisms/DataExplorerGraphFlowNavigationStack/NavigationStack.spec.tsx
@@ -12,7 +12,7 @@ import { NexusProvider } from '@bbp/react-nexus';
 import { deltaPath } from '../../../__mocks__/handlers/handlers';
 import NavigationStack from './NavigationStack';
 import {
-  NavigationBack,
+  NavigationBackButton,
   NavigationCollapseButton,
 } from '../../molecules/DataExplorerGraphFlowMolecules';
 import configureStore from '../../store';
@@ -108,7 +108,7 @@ describe('NavigationStack', () => {
             <>
               <NavigationStack />
               <NavigationCollapseButton />
-              <NavigationBack />
+              <NavigationBackButton />
             </>
           </NexusProvider>
         </Router>
@@ -403,7 +403,7 @@ describe('NavigationStack', () => {
   it('should decode the navigation digest at first render', () => {
     store.dispatch(ResetDataExplorerGraphFlow({ initialState: null }));
     store.dispatch(PopulateDataExplorerGraphFlow(sampleDigest));
-    render(app);
+    rerender(app);
     const dataExplorerState = store.getState().dataExplorer;
     expect(dataExplorerState.links.length).toBe(2);
     expect(dataExplorerState.current._self).toBe(digestCurrentSelf);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description

- Use react router `useLocation` hook instead using window location to get the right pathname when navigating

<!--- Describe your changes in detail -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
