### PR TITLE
Fix: add referer to data explorer to allow return back to origin DEGF

### DIFF
--- a/src/shared/canvas/DataExplorerGraphFlow/styles.less
+++ b/src/shared/canvas/DataExplorerGraphFlow/styles.less
@@ -37,7 +37,6 @@
     align-items: flex-start;
     justify-content: space-between;
     gap: 10px;
-    margin-top: 52px;
   }
 
   &.no-current {

--- a/src/shared/containers/ResourceEditor.tsx
+++ b/src/shared/containers/ResourceEditor.tsx
@@ -19,6 +19,7 @@ import {
   InitNewVisitDataExplorerGraphView,
 } from '../store/reducers/data-explorer';
 import { getOrgAndProjectFromResourceObject, getResourceLabel } from '../utils';
+import { pick } from 'lodash';
 
 const ResourceEditorContainer: React.FunctionComponent<{
   resourceId: string;
@@ -131,6 +132,7 @@ const ResourceEditorContainer: React.FunctionComponent<{
     } else {
       dispatch(
         InitNewVisitDataExplorerGraphView({
+          referer: pick(location, ['pathname', 'search', 'state']),
           current: {
             _self: data._self,
             types: getNormalizedTypes(data['@type']),

--- a/src/shared/molecules/DataExplorerGraphFlowMolecules/NavigationBackButton.tsx
+++ b/src/shared/molecules/DataExplorerGraphFlowMolecules/NavigationBackButton.tsx
@@ -2,7 +2,12 @@ import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useHistory, useLocation } from 'react-router';
 import { ArrowLeftOutlined } from '@ant-design/icons';
-import { ReturnBackDataExplorerGraphFlow } from '../../store/reducers/data-explorer';
+import { clsx } from 'clsx';
+import {
+  DATA_EXPLORER_GRAPH_FLOW_DIGEST,
+  ResetDataExplorerGraphFlow,
+  ReturnBackDataExplorerGraphFlow,
+} from '../../store/reducers/data-explorer';
 import { RootState } from '../../store/reducers';
 import './styles.less';
 
@@ -10,13 +15,31 @@ const NavigationBack = () => {
   const dispatch = useDispatch();
   const history = useHistory();
   const location = useLocation();
-  const { links } = useSelector((state: RootState) => state.dataExplorer);
+  const { links, referer } = useSelector(
+    (state: RootState) => state.dataExplorer
+  );
+
   const onBack = () => {
+    if (referer?.pathname && !links.length) {
+      dispatch(ResetDataExplorerGraphFlow({ initialState: null }));
+      localStorage.removeItem(DATA_EXPLORER_GRAPH_FLOW_DIGEST);
+      history.push(`${referer.pathname}${referer.search}`, {
+        ...referer.state,
+      });
+      return;
+    }
     history.replace(location.pathname);
     dispatch(ReturnBackDataExplorerGraphFlow());
   };
-  return links.length ? (
-    <button className="navigation-back-btn" onClick={onBack}>
+
+  return links.length || !!referer?.pathname ? (
+    <button
+      className={clsx(
+        'navigation-back-btn',
+        referer?.pathname && !links.length && 'go-back-to-referer'
+      )}
+      onClick={onBack}
+    >
       <ArrowLeftOutlined />
       <span>Back</span>
     </button>

--- a/src/shared/molecules/DataExplorerGraphFlowMolecules/styles.less
+++ b/src/shared/molecules/DataExplorerGraphFlowMolecules/styles.less
@@ -130,6 +130,9 @@
       color: @fusion-daybreak-7;
     }
   }
+  &.go-back-to-referer {
+    margin-left: 40px;
+  }
 }
 
 .degf-content__haeder {

--- a/src/shared/molecules/ResolvedLinkEditorPopover/ResolvedLinkEditorPopover.tsx
+++ b/src/shared/molecules/ResolvedLinkEditorPopover/ResolvedLinkEditorPopover.tsx
@@ -5,7 +5,8 @@ import { useHistory, useLocation, useRouteMatch } from 'react-router';
 import { useNexusContext } from '@bbp/react-nexus';
 import { NexusClient, Resource } from '@bbp/nexus-sdk';
 import { clsx } from 'clsx';
-import { Button, Tag } from 'antd';
+import { Tag } from 'antd';
+import { pick } from 'lodash';
 import { DownloadOutlined, LoadingOutlined } from '@ant-design/icons';
 import { match as pmatch } from 'ts-pattern';
 import { UISettingsActionTypes } from '../../store/actions/ui-settings';
@@ -90,7 +91,7 @@ const ResolvedLinkEditorPopover = () => {
   const navigate = useHistory();
   const dispatch = useDispatch();
   const nexus = useNexusContext();
-  const { pathname } = useLocation();
+  const { pathname, search, state } = useLocation();
   const routeMatch = useRouteMatch<{
     orgLabel: string;
     projectLabel: string;
@@ -120,6 +121,7 @@ const ResolvedLinkEditorPopover = () => {
       const orgProject = getOrgAndProjectFromProjectId(data._project);
       dispatch(
         InitNewVisitDataExplorerGraphView({
+          referer: { pathname, search, state },
           source: {
             _self: data._self,
             title: getResourceLabel(data),

--- a/src/shared/store/reducers/data-explorer.ts
+++ b/src/shared/store/reducers/data-explorer.ts
@@ -21,6 +21,11 @@ export type TDELink = {
 export type TDataExplorerState = {
   links: TDELink[];
   current: TDELink | null;
+  referer?: {
+    pathname: string;
+    search: string;
+    state: Record<string, any>;
+  } | null;
   shrinked: boolean;
   limited: boolean;
   highlightIndex: number;
@@ -29,6 +34,7 @@ export type TDataExplorerState = {
 const initialState: TDataExplorerState = {
   links: [],
   current: null,
+  referer: null,
   shrinked: false,
   limited: false,
   highlightIndex: -1,
@@ -70,10 +76,11 @@ export const dataExplorerSlice = createSlice({
     },
     InitNewVisitDataExplorerGraphView: (
       state,
-      { payload: { source, current, limited } }
+      { payload: { source, current, limited, referer } }
     ) => {
       const newState = {
         ...state,
+        referer,
         current,
         limited,
         links:


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->


## Description
1. Allow the user to return back to the origin of the data explorer graph flow experience
2. Add the `referer` to data explorer state
<!--- Describe your changes in detail -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
