### PR TITLE
Hotfix // Reset predicate when search term is empty

### DIFF
--- a/src/subapps/dataExplorer/PredicateSelector.tsx
+++ b/src/subapps/dataExplorer/PredicateSelector.tsx
@@ -62,6 +62,8 @@ export const PredicateSelector: React.FC<Props> = ({
             predicateFilter: (resource: Resource) =>
               doesResourceContain(resource, path, searchTerm, 'contains'),
           });
+        } else {
+          onPredicateChange({ predicateFilter: null });
         }
         break;
       case DOES_NOT_CONTAIN:
@@ -75,7 +77,10 @@ export const PredicateSelector: React.FC<Props> = ({
                 'does-not-contain'
               ),
           });
+        } else {
+          onPredicateChange({ predicateFilter: null });
         }
+
         break;
       default:
         onPredicateChange({ predicateFilter: null });


### PR DESCRIPTION
Bug description - if user selects a "contains" (or "does not contain") predicate, enters a value like "search", then removes the value, and enters another value, then the predicate does not run on the full 50 rows, but only the ones that were filtered after first value was entered. This PR fixes this bug.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
