### PR TITLE
US 4022 / Show count in a clearer format

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "NODE_ENV=development  DEBUG=* webpack --mode development --config-name server && node dist/server.js",
     "build": "NODE_ENV=production NODE_OPTIONS=--max_old_space_size=8192  webpack --mode production",
     "test": "jest",
-    "test:watch": "jest --watch",
+    "test:watch": "jest --watch --maxWorkers=4",
     "cy:open": "cypress open",
     "cy:run": "cypress run",
     "test-ui": "API_ENDPOINT=http://test start-server-and-test start http://localhost:8000 cy:run",
@@ -210,7 +210,10 @@
     ],
     "globals": {
       "FUSION_VERSION": "1.0.0",
-      "COMMIT_HASH": "9013fa343"
+      "COMMIT_HASH": "9013fa343",
+      "ts-jest": {
+        "isolatedModules": true
+      }
     },
     "watchPathIgnorePatterns": [
       "node_modules"

--- a/src/subapps/dataExplorer/DataExplorer.tsx
+++ b/src/subapps/dataExplorer/DataExplorer.tsx
@@ -8,7 +8,7 @@ import { DataExplorerTable } from './DataExplorerTable';
 import './styles.less';
 import { ProjectSelector } from './ProjectSelector';
 import { PredicateSelector } from './PredicateSelector';
-import * as pluralize from 'pluralize';
+import { DatasetCount } from './DatasetCount';
 
 export interface DataExplorerConfiguration {
   pageSize: number;
@@ -91,25 +91,13 @@ export const DataExplorer: React.FC<{}> = () => {
       </div>
 
       {!isLoading && (
-        <div className="data-explorer-count">
-          <span>
-            Total from backend:{' '}
-            <b>
-              {resources?._total ?? 0}{' '}
-              {pluralize('dataset', resources?._total ?? 0)}
-            </b>{' '}
-          </span>
-
-          {predicateFilter !== null && (
-            <span>
-              Total from frontend:{' '}
-              <b>
-                {displayedDataSource.length}{' '}
-                {pluralize('dataset', displayedDataSource.length ?? 0)}
-              </b>{' '}
-            </span>
-          )}
-        </div>
+        <DatasetCount
+          nexusTotal={resources?._total ?? 0}
+          totalOnPage={resources?._results?.length ?? 0}
+          totalFiltered={
+            predicateFilter ? displayedDataSource.length : undefined
+          }
+        />
       )}
 
       <DataExplorerTable

--- a/src/subapps/dataExplorer/DatasetCount.tsx
+++ b/src/subapps/dataExplorer/DatasetCount.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import * as pluralize from 'pluralize';
+import { isNil } from 'lodash';
+import './styles.less';
+
+interface Props {
+  nexusTotal: number;
+  totalFiltered?: number;
+  totalOnPage: number;
+}
+
+export const DatasetCount: React.FC<Props> = ({
+  nexusTotal,
+  totalOnPage,
+  totalFiltered,
+}: Props) => {
+  return (
+    <div className="data-explorer-count">
+      <span>
+        Total:{' '}
+        <b>
+          {nexusTotal.toLocaleString(`en-US`)}{' '}
+          {pluralize('dataset', nexusTotal ?? 0)}
+        </b>{' '}
+      </span>
+
+      <span>
+        Sample loaded for review: <b>{totalOnPage}</b>
+      </span>
+
+      {!isNil(totalFiltered) && (
+        <span>
+          Filtered: <b>{totalFiltered}</b>
+        </span>
+      )}
+    </div>
+  );
+};

--- a/src/subapps/dataExplorer/styles.less
+++ b/src/subapps/dataExplorer/styles.less
@@ -13,7 +13,7 @@
   }
 
   .data-explorer-count {
-    color: @fusion-blue-8;
+    color: @fusion-neutral-7;
     margin-left: 20px;
     margin-bottom: 28px;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #US 4022

Shows large numbers in the count of data explorer, as a comma separated value. For example the number 911899 will be shown as "911,899". Also makes the wording of count clearer.


![Screenshot from 2023-07-11 13-15-35](https://github.com/BlueBrain/nexus-web/assets/11242410/29159949-6852-418e-a735-979f0fbbecf6)


## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
