### PR TITLE
US 4038 // Show only user data by default

### DIFF
--- a/src/subapps/dataExplorer/DataExplorer-utils.spec.tsx
+++ b/src/subapps/dataExplorer/DataExplorer-utils.spec.tsx
@@ -36,8 +36,8 @@ describe('DataExplorerSpec-Utils', () => {
         },
       },
     ];
+    const actual = getAllPaths(resources);
     const expectedPaths = [
-      '@id',
       'contributors',
       'contributors.name',
       'contributors.name.firstname',
@@ -50,8 +50,9 @@ describe('DataExplorerSpec-Utils', () => {
       'distribution.filename',
       'distribution.label',
       'distribution.name',
+      '@id',
     ];
-    expect(getAllPaths(resources)).toEqual(expectedPaths);
+    expect(actual).toEqual(expectedPaths);
   });
 
   it('sorts path starting with underscore at the end of the list', () => {
@@ -65,17 +66,18 @@ describe('DataExplorerSpec-Utils', () => {
         _updatedAt: 'some time ago',
         name: 'anotherNameValue',
         _createdAt: '12 September 2020',
-        project: 'secret project',
+        _project: 'secret project',
       },
     ];
     const expectedPaths = [
       'name',
-      'project',
+      '_createdAt',
+      '_project',
+      '_updatedAt',
+
       '_author',
       '_author.designation',
       '_author.name',
-      '_createdAt',
-      '_updatedAt',
     ];
     const receivedPaths = getAllPaths(resources);
 
@@ -625,6 +627,57 @@ describe('DataExplorerSpec-Utils', () => {
         'value5',
         'does-not-contain'
       )
+    ).toEqual(true);
+  });
+
+  it('does not throw when checking for non existence on a path when resource has primitve value', () => {
+    const resource = {
+      '@context': [
+        'https://bluebrain.github.io/nexus/contexts/metadata.json',
+        {
+          '1Point': {
+            '@id': 'nsg:1Point',
+          },
+          '2DContour': {
+            '@id': 'nsg:2DContour',
+          },
+          '3DContour': {
+            '@id': 'nsg:3DContour',
+          },
+          '3Point': {
+            '@id': 'nsg:3Point',
+          },
+          '@vocab':
+            'https://bbp-nexus.epfl.ch/vocabs/bbp/neurosciencegraph/core/v0.1.0/',
+          Derivation: {
+            '@id': 'prov:Derivation',
+          },
+          xsd: 'http://www.w3.org/2001/XMLSchema#',
+        },
+      ],
+      '@id': 'https://bbp.epfl.ch/nexus/search/neuroshapes',
+      _constrainedBy:
+        'https://bluebrain.github.io/nexus/schemas/unconstrained.json',
+      _createdAt: '2019-02-11T14:15:14.020Z',
+      _createdBy: 'https://bbp.epfl.ch/nexus/v1/realms/bbp/users/pirman',
+      _deprecated: false,
+      _incoming:
+        'https://bbp.epfl.ch/nexus/v1/resources/webapps/search-app-prod-public/_/neuroshapes/incoming',
+      _outgoing:
+        'https://bbp.epfl.ch/nexus/v1/resources/webapps/search-app-prod-public/_/neuroshapes/outgoing',
+      _project:
+        'https://bbp.epfl.ch/nexus/v1/projects/webapps/search-app-prod-public',
+      _rev: 1,
+      _schemaProject:
+        'https://bbp.epfl.ch/nexus/v1/projects/webapps/search-app-prod-public',
+      _self:
+        'https://bbp.epfl.ch/nexus/v1/resources/webapps/search-app-prod-public/_/neuroshapes',
+      _updatedAt: '2019-02-11T14:15:14.020Z',
+      _updatedBy: 'https://bbp.epfl.ch/nexus/v1/realms/bbp/users/pirman',
+    };
+
+    expect(
+      checkPathExistence(resource, '@context.@vocab', 'does-not-exist')
     ).toEqual(true);
   });
 });

--- a/src/subapps/dataExplorer/DataExplorer.spec.tsx
+++ b/src/subapps/dataExplorer/DataExplorer.spec.tsx
@@ -6,9 +6,10 @@ import userEvent from '@testing-library/user-event';
 import { UserEvent } from '@testing-library/user-event/dist/types/setup/setup';
 import {
   dataExplorerPageHandler,
-  defaultMockResult,
   filterByProjectHandler,
+  getCompleteResources,
   getMockResource,
+  sourceResourceHandler,
 } from '__mocks__/handlers/DataExplorer/handlers';
 import { deltaPath } from '__mocks__/handlers/handlers';
 import { setupServer } from 'msw/node';
@@ -19,7 +20,6 @@ import { AllProjects } from './ProjectSelector';
 import { getColumnTitle } from './DataExplorerTable';
 import {
   CONTAINS,
-  DEFAULT_OPTION,
   DOES_NOT_CONTAIN,
   DOES_NOT_EXIST,
   EXISTS,
@@ -29,13 +29,16 @@ import { createMemoryHistory } from 'history';
 import { Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import configureStore from '../../shared/store';
+import { ALWAYS_DISPLAYED_COLUMNS, isNexusMetadata } from './DataExplorerUtils';
 
 describe('DataExplorer', () => {
   const defaultTotalResults = 500_123;
+  const mockResourcesOnPage1: Resource[] = getCompleteResources();
 
   const server = setupServer(
-    dataExplorerPageHandler(defaultMockResult, defaultTotalResults),
-    filterByProjectHandler(defaultMockResult)
+    dataExplorerPageHandler(undefined, defaultTotalResults),
+    sourceResourceHandler(),
+    filterByProjectHandler()
   );
   const history = createMemoryHistory({});
 
@@ -83,7 +86,7 @@ describe('DataExplorer', () => {
 
   const DropdownSelector = '.ant-select-dropdown';
   const DropdownOptionSelector = 'div.ant-select-item-option-content';
-  const TypeOptionSelector = 'div.ant-select-item-option-content > span';
+  const CustomOptionSelector = 'div.ant-select-item-option-content > span';
 
   const PathMenuLabel = 'path-selector';
   const PredicateMenuLabel = 'predicate-selector';
@@ -108,15 +111,18 @@ describe('DataExplorer', () => {
     return header;
   };
 
-  const getTextForColumn = async (resource: Resource, colName: string) => {
-    const selfCell = await screen.getAllByText(
-      new RegExp(resource._self, 'i'),
-      {
-        selector: 'td',
-      }
-    );
+  const getTotalColumns = () => {
+    return Array.from(container.querySelectorAll('th'));
+  };
 
-    const allCellsForRow = Array.from(selfCell[0].parentElement!.childNodes);
+  const expectColumHeaderToNotExist = async (name: string) => {
+    expect(expectColumHeaderToExist(name)).rejects.toThrow();
+  };
+
+  const getTextForColumn = async (resource: Resource, colName: string) => {
+    const row = await screen.getByTestId(resource._self);
+
+    const allCellsForRow = Array.from(row.childNodes);
     const colIndex = Array.from(
       container.querySelectorAll('th')
     ).findIndex(header =>
@@ -126,13 +132,7 @@ describe('DataExplorer', () => {
   };
 
   const getRowForResource = async (resource: Resource) => {
-    const selfCell = await screen.getAllByText(
-      new RegExp(resource._self, 'i'),
-      {
-        selector: 'td',
-      }
-    );
-    const row = selfCell[0].parentElement;
+    const row = await screen.getByTestId(resource._self);
     expect(row).toBeInTheDocument();
     return row!;
   };
@@ -190,7 +190,10 @@ describe('DataExplorer', () => {
     resources: Resource[],
     total: number = 300
   ) => {
-    server.use(dataExplorerPageHandler(resources, total));
+    server.use(
+      sourceResourceHandler(resources),
+      dataExplorerPageHandler(resources, total)
+    );
 
     const pageInput = await screen.getByRole('listitem', { name: '2' });
     expect(pageInput).toBeInTheDocument();
@@ -213,12 +216,17 @@ describe('DataExplorer', () => {
     return menuDropdown;
   };
 
+  const selectPath = async (path: string) => {
+    selectOptionFromMenu(PathMenuLabel, path, CustomOptionSelector);
+  };
+
   const selectOptionFromMenu = async (
     menuAriaLabel: string,
     optionLabel: string,
     optionSelector?: string
   ) => {
     await openMenuFor(menuAriaLabel);
+    const allOptions = getVisibleOptionsFromMenu();
     const option = await getDropdownOption(optionLabel, optionSelector);
     await userEvent.click(option, { pointerEventsCheck: 0 });
   };
@@ -228,11 +236,11 @@ describe('DataExplorer', () => {
    * NOTE: Since antd menus use virtual scroll, not all options inside the menu are visible.
    * This function only returns those options that are visible.
    */
-  const getVisibleOptionsFromMenu = () => {
+  const getVisibleOptionsFromMenu = (
+    selector: string = DropdownOptionSelector
+  ) => {
     const menuDropdown = document.querySelector(DropdownSelector);
-    return Array.from(
-      menuDropdown?.querySelectorAll(DropdownOptionSelector) ?? []
-    );
+    return Array.from(menuDropdown?.querySelectorAll(selector) ?? []);
   };
 
   const getTotalSizeOfDataset = async (expectedCount: string) => {
@@ -274,20 +282,56 @@ describe('DataExplorer', () => {
     return await screen.getByTestId('reset-project-button');
   };
 
+  const showMetadataSwitch = async () =>
+    await screen.getByLabelText('Show metadata');
+
+  it('shows columns for fields that are only in source data', async () => {
+    await expectRowCountToBe(10);
+    const column = await expectColumHeaderToExist('userProperty1');
+    expect(column).toBeInTheDocument();
+  });
+
   it('shows rows for all fetched resources', async () => {
     await expectRowCountToBe(10);
   });
 
-  it('shows columns for each top level property in resources', async () => {
+  it('shows only user columns for each top level property by default', async () => {
     await expectRowCountToBe(10);
     const seenColumns = new Set();
 
-    for (const mockResource of defaultMockResult) {
+    for (const mockResource of mockResourcesOnPage1) {
       for (const topLevelProperty of Object.keys(mockResource)) {
         if (!seenColumns.has(topLevelProperty)) {
           seenColumns.add(topLevelProperty);
-          const header = getColumnTitle(topLevelProperty);
-          await expectColumHeaderToExist(header);
+
+          if (ALWAYS_DISPLAYED_COLUMNS.has(topLevelProperty)) {
+            await expectColumHeaderToExist(getColumnTitle(topLevelProperty));
+          } else if (isNexusMetadata(topLevelProperty)) {
+            expect(
+              expectColumHeaderToExist(getColumnTitle(topLevelProperty))
+            ).rejects.toThrow();
+          } else {
+            await expectColumHeaderToExist(getColumnTitle(topLevelProperty));
+          }
+        }
+      }
+    }
+
+    expect(seenColumns.size).toBeGreaterThan(1);
+  });
+
+  it('shows user columns for all top level properties when show user metadata clicked', async () => {
+    await expectRowCountToBe(10);
+    const showMetadataButton = await showMetadataSwitch();
+    await userEvent.click(showMetadataButton);
+
+    const seenColumns = new Set();
+
+    for (const mockResource of mockResourcesOnPage1) {
+      for (const topLevelProperty of Object.keys(mockResource)) {
+        if (!seenColumns.has(topLevelProperty)) {
+          seenColumns.add(topLevelProperty);
+          await expectColumHeaderToExist(getColumnTitle(topLevelProperty));
         }
       }
     }
@@ -343,7 +387,7 @@ describe('DataExplorer', () => {
 
   it('shows No data text when values are missing for a column', async () => {
     await expectRowCountToBe(10);
-    const resourceWithMissingProperty = defaultMockResult.find(
+    const resourceWithMissingProperty = mockResourcesOnPage1.find(
       res => !('specialProperty' in res)
     )!;
     const textForSpecialProperty = await getTextForColumn(
@@ -355,7 +399,7 @@ describe('DataExplorer', () => {
 
   it('shows No data text when values is undefined', async () => {
     await expectRowCountToBe(10);
-    const resourceWithUndefinedProperty = defaultMockResult.find(
+    const resourceWithUndefinedProperty = mockResourcesOnPage1.find(
       res => res.specialProperty === undefined
     )!;
     const textForSpecialProperty = await getTextForColumn(
@@ -367,7 +411,7 @@ describe('DataExplorer', () => {
 
   it('does not show No data text when values is null', async () => {
     await expectRowCountToBe(10);
-    const resourceWithUndefinedProperty = defaultMockResult.find(
+    const resourceWithUndefinedProperty = mockResourcesOnPage1.find(
       res => res.specialProperty === null
     )!;
     const textForSpecialProperty = await getTextForColumn(
@@ -380,7 +424,7 @@ describe('DataExplorer', () => {
 
   it('does not show No data when value is empty string', async () => {
     await expectRowCountToBe(10);
-    const resourceWithEmptyString = defaultMockResult.find(
+    const resourceWithEmptyString = mockResourcesOnPage1.find(
       res => res.specialProperty === ''
     )!;
 
@@ -394,7 +438,7 @@ describe('DataExplorer', () => {
 
   it('does not show No data when value is empty array', async () => {
     await expectRowCountToBe(10);
-    const resourceWithEmptyArray = defaultMockResult.find(
+    const resourceWithEmptyArray = mockResourcesOnPage1.find(
       res =>
         Array.isArray(res.specialProperty) && res.specialProperty.length === 0
     )!;
@@ -409,7 +453,7 @@ describe('DataExplorer', () => {
 
   it('does not show No data when value is empty object', async () => {
     await expectRowCountToBe(10);
-    const resourceWithEmptyObject = defaultMockResult.find(
+    const resourceWithEmptyObject = mockResourcesOnPage1.find(
       res =>
         typeof res.specialProperty === 'object' &&
         res.specialProperty !== null &&
@@ -469,7 +513,7 @@ describe('DataExplorer', () => {
 
   it('shows resources filtered by the selected type', async () => {
     await expectRowCountToBe(10);
-    await selectOptionFromMenu(TypeMenuLabel, 'file', TypeOptionSelector);
+    await selectOptionFromMenu(TypeMenuLabel, 'file', CustomOptionSelector);
 
     visibleTableRows().forEach(row =>
       expect(typeFromRow(row)).toMatch(/file/i)
@@ -478,29 +522,32 @@ describe('DataExplorer', () => {
 
   it('only shows types that exist in selected project in type autocomplete', async () => {
     await openMenuFor(TypeMenuLabel);
-    const optionBefore = await getDropdownOption('Dataset', TypeOptionSelector);
+    const optionBefore = await getDropdownOption(
+      'Dataset',
+      CustomOptionSelector
+    );
     expect(optionBefore).toBeInTheDocument();
 
     await selectOptionFromMenu(ProjectMenuLabel, 'unhcr');
 
     await openMenuFor(TypeMenuLabel);
     expect(
-      getDropdownOption('Dataset', TypeOptionSelector)
+      getDropdownOption('Dataset', CustomOptionSelector)
     ).rejects.toThrowError();
   });
 
   it('shows paths as options in a select menu of path selector', async () => {
+    await expectRowCountToBe(10);
     await openMenuFor('path-selector');
 
-    const pathOptions = getVisibleOptionsFromMenu();
+    const pathOptions = getVisibleOptionsFromMenu(CustomOptionSelector);
 
-    const expectedPaths = getAllPaths(defaultMockResult);
+    const expectedPaths = getAllPaths(mockResourcesOnPage1);
     expect(expectedPaths.length).toBeGreaterThanOrEqual(
-      Object.keys(defaultMockResult[0]).length
+      Object.keys(mockResourcesOnPage1[0]).length
     );
-    expect(pathOptions[0].innerHTML).toMatch(DEFAULT_OPTION);
 
-    pathOptions.slice(1).forEach((path, index) => {
+    pathOptions.forEach((path, index) => {
       expect(path.innerHTML).toMatch(
         new RegExp(`${expectedPaths[index]}$`, 'i')
       );
@@ -516,11 +563,11 @@ describe('DataExplorer', () => {
       getMockResource('self3', { year: 2013 }),
     ]);
 
-    await selectOptionFromMenu(PathMenuLabel, 'author');
+    await selectPath('author');
     await selectOptionFromMenu(PredicateMenuLabel, DOES_NOT_EXIST);
     await expectRowCountToBe(1);
 
-    await selectOptionFromMenu(PathMenuLabel, 'edition');
+    await selectPath('edition');
     await selectOptionFromMenu(PredicateMenuLabel, DOES_NOT_EXIST);
     await expectRowCountToBe(2);
   });
@@ -532,7 +579,7 @@ describe('DataExplorer', () => {
       getMockResource('self3', { year: 2013 }),
     ]);
 
-    await selectOptionFromMenu(PathMenuLabel, 'author');
+    await selectPath('author');
     await userEvent.click(container);
     await selectOptionFromMenu(PredicateMenuLabel, CONTAINS);
     const valueInput = await screen.getByPlaceholderText('type the value...');
@@ -552,7 +599,7 @@ describe('DataExplorer', () => {
       getMockResource('self3', { year: 2013 }),
     ]);
 
-    await selectOptionFromMenu(PathMenuLabel, 'author');
+    await selectPath('author');
     await userEvent.click(container);
     await selectOptionFromMenu(PredicateMenuLabel, CONTAINS);
     await expectRowCountToBe(3);
@@ -565,7 +612,7 @@ describe('DataExplorer', () => {
       getMockResource('self3', { year: 2013 }),
     ]);
 
-    await selectOptionFromMenu(PathMenuLabel, 'author');
+    await selectPath('author');
     await userEvent.click(container);
     await selectOptionFromMenu(PredicateMenuLabel, EXISTS);
     await expectRowCountToBe(2);
@@ -578,7 +625,7 @@ describe('DataExplorer', () => {
       getMockResource('self3', { year: 2013 }),
     ]);
 
-    await selectOptionFromMenu(PathMenuLabel, 'author');
+    await selectPath('author');
     await userEvent.click(container);
     await selectOptionFromMenu(PredicateMenuLabel, DOES_NOT_CONTAIN);
     const valueInput = await screen.getByPlaceholderText('type the value...');
@@ -603,7 +650,7 @@ describe('DataExplorer', () => {
 
     expect(history.location.pathname).not.toContain('self1');
 
-    const firstDataRow = await getRowForResource(defaultMockResult[0]);
+    const firstDataRow = await getRowForResource(mockResourcesOnPage1[0]);
     await userEvent.click(firstDataRow);
 
     expect(history.location.pathname).toContain('self1');
@@ -650,12 +697,31 @@ describe('DataExplorer', () => {
       getMockResource('self3', { year: 2013 }),
     ]);
 
-    await selectOptionFromMenu(PathMenuLabel, 'author');
+    await selectPath('author');
     await userEvent.click(container);
     await selectOptionFromMenu(PredicateMenuLabel, EXISTS);
     await expectRowCountToBe(2);
 
     const totalFromFrontendAfter = await getFilteredResultsCount(2);
     expect(totalFromFrontendAfter).toBeVisible();
+  });
+
+  it('shows column for metadata path even if toggle for show metadata is off', async () => {
+    const metadataProperty = '_createdBy';
+    await expectRowCountToBe(10);
+
+    await expectColumHeaderToNotExist(metadataProperty);
+
+    const originalColumns = getTotalColumns().length;
+
+    await selectOptionFromMenu(
+      PathMenuLabel,
+      metadataProperty,
+      CustomOptionSelector
+    );
+    await selectOptionFromMenu(PredicateMenuLabel, EXISTS);
+
+    await expectColumHeaderToExist(metadataProperty);
+    expect(getTotalColumns().length).toEqual(originalColumns + 1);
   });
 });

--- a/src/subapps/dataExplorer/DataExplorer.tsx
+++ b/src/subapps/dataExplorer/DataExplorer.tsx
@@ -1,15 +1,18 @@
 import { Resource } from '@bbp/nexus-sdk';
-import { useNexusContext } from '@bbp/react-nexus';
-import { notification } from 'antd';
-import { isString } from 'lodash';
-import React, { useReducer } from 'react';
-import { useQuery } from 'react-query';
+import { Switch } from 'antd';
+import React, { useReducer, useState } from 'react';
 import { DataExplorerTable } from './DataExplorerTable';
-import './styles.less';
+import {
+  columnFromPath,
+  isUserColumn,
+  sortColumns,
+  usePaginatedExpandedResources,
+} from './DataExplorerUtils';
 import { ProjectSelector } from './ProjectSelector';
 import { PredicateSelector } from './PredicateSelector';
 import { DatasetCount } from './DatasetCount';
 import { TypeSelector } from './TypeSelector';
+import './styles.less';
 
 export interface DataExplorerConfiguration {
   pageSize: number;
@@ -17,13 +20,14 @@ export interface DataExplorerConfiguration {
   orgAndProject?: [string, string];
   type: string | undefined;
   predicateFilter: ((resource: Resource) => boolean) | null;
+  selectedPath: string | null;
 }
 
 export const DataExplorer: React.FC<{}> = () => {
-  const nexus = useNexusContext();
+  const [showMetadataColumns, setShowMetadataColumns] = useState(false);
 
   const [
-    { pageSize, offset, orgAndProject, predicateFilter, type },
+    { pageSize, offset, orgAndProject, predicateFilter, type, selectedPath },
     updateTableConfiguration,
   ] = useReducer(
     (
@@ -36,34 +40,15 @@ export const DataExplorer: React.FC<{}> = () => {
       orgAndProject: undefined,
       type: undefined,
       predicateFilter: null,
+      selectedPath: null,
     }
   );
 
-  const { data: resources, isLoading } = useQuery({
-    queryKey: ['data-explorer', { pageSize, offset, orgAndProject, type }],
-    retry: false,
-    queryFn: () => {
-      return nexus.Resource.list(orgAndProject?.[0], orgAndProject?.[1], {
-        type,
-        from: offset,
-        size: pageSize,
-      });
-    },
-    onError: error => {
-      notification.error({
-        message: 'Error loading data from the server',
-        description: isString(error) ? (
-          error
-        ) : isObject(error) ? (
-          <div>
-            <strong>{(error as any)['@type']}</strong>
-            <div>{(error as any)['details']}</div>
-          </div>
-        ) : (
-          ''
-        ),
-      });
-    },
+  const { data: resources, isLoading } = usePaginatedExpandedResources({
+    pageSize,
+    offset,
+    orgAndProject,
+    type,
   });
 
   const currentPageDataSource: Resource[] = resources?._results || [];
@@ -101,19 +86,35 @@ export const DataExplorer: React.FC<{}> = () => {
       </div>
 
       {!isLoading && (
-        <DatasetCount
-          nexusTotal={resources?._total ?? 0}
-          totalOnPage={resources?._results?.length ?? 0}
-          totalFiltered={
-            predicateFilter ? displayedDataSource.length : undefined
-          }
-        />
+        <div className="flex-container">
+          <DatasetCount
+            nexusTotal={resources?._total ?? 0}
+            totalOnPage={resources?._results?.length ?? 0}
+            totalFiltered={
+              predicateFilter ? displayedDataSource.length : undefined
+            }
+          />
+          <div className="data-explorer-toggles">
+            <Switch
+              defaultChecked={false}
+              checked={showMetadataColumns}
+              onClick={isChecked => setShowMetadataColumns(isChecked)}
+              id="show-metadata-columns"
+              className="data-explorer-toggle"
+            />
+            <label htmlFor="show-metadata-columns">Show metadata</label>
+          </div>
+        </div>
       )}
 
       <DataExplorerTable
         isLoading={isLoading}
         dataSource={displayedDataSource}
-        columns={columnsFromDataSource(currentPageDataSource)}
+        columns={columnsFromDataSource(
+          currentPageDataSource,
+          showMetadataColumns,
+          selectedPath
+        )}
         total={resources?._total}
         pageSize={pageSize}
         offset={offset}
@@ -123,16 +124,25 @@ export const DataExplorer: React.FC<{}> = () => {
   );
 };
 
-export const isObject = (value: any) => {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-};
-
-export const columnsFromDataSource = (resources: Resource[]): string[] => {
+export const columnsFromDataSource = (
+  resources: Resource[],
+  showMetadataColumns: boolean,
+  selectedPath: string | null
+): string[] => {
   const columnNames = new Set<string>();
 
   resources.forEach(resource => {
     Object.keys(resource).forEach(key => columnNames.add(key));
   });
 
-  return Array.from(columnNames);
+  if (showMetadataColumns) {
+    return Array.from(columnNames).sort(sortColumns);
+  }
+
+  const selectedMetadataColumn = columnFromPath(selectedPath);
+  return Array.from(columnNames)
+    .filter(
+      colName => isUserColumn(colName) || colName === selectedMetadataColumn
+    )
+    .sort(sortColumns);
 };

--- a/src/subapps/dataExplorer/DataExplorerTable.tsx
+++ b/src/subapps/dataExplorer/DataExplorerTable.tsx
@@ -40,6 +40,7 @@ export const DataExplorerTable: React.FC<TDataExplorerTable> = ({
   const tablePaginationConfig: TablePaginationConfig = {
     pageSize,
     total: allowedTotal,
+    pageSizeOptions: [10, 20, 50],
     position: ['bottomLeft'],
     defaultPageSize: 50,
     defaultCurrent: 0,
@@ -69,6 +70,7 @@ export const DataExplorerTable: React.FC<TDataExplorerTable> = ({
       rowKey={record => record._self}
       onRow={resource => ({
         onClick: _ => goToResource(resource),
+        'data-testid': resource._self,
       })}
       loading={isLoading}
       bordered={false}

--- a/src/subapps/dataExplorer/DataExplorerUtils.tsx
+++ b/src/subapps/dataExplorer/DataExplorerUtils.tsx
@@ -1,6 +1,86 @@
+import { Resource } from '@bbp/nexus-sdk';
 import { useNexusContext } from '@bbp/react-nexus';
+import PromisePool from '@supercharge/promise-pool';
 import { notification } from 'antd';
 import { useQuery } from 'react-query';
+import { makeOrgProjectTuple } from '../../shared/molecules/MyDataTable/MyDataTable';
+import { isString } from 'lodash';
+
+export const usePaginatedExpandedResources = ({
+  pageSize,
+  offset,
+  orgAndProject,
+  type,
+}: PaginatedResourcesParams) => {
+  const nexus = useNexusContext();
+
+  return useQuery({
+    queryKey: ['data-explorer', { pageSize, offset, orgAndProject, type }],
+    retry: false,
+    queryFn: async () => {
+      const resultWithPartialResources = await nexus.Resource.list(
+        orgAndProject?.[0],
+        orgAndProject?.[1],
+        {
+          type,
+          from: offset,
+          size: pageSize,
+        }
+      );
+
+      // If we failed to fetch the expanded source for some resources, we can use the compact/partial resource as a fallback.
+      const fallbackResources: Resource[] = [];
+      const { results: expandedResources } = await PromisePool.withConcurrency(
+        4
+      )
+        .for(resultWithPartialResources._results)
+        .handleError(async (err, partialResource) => {
+          console.log(
+            `@@error in fetching resource with id: ${partialResource['@id']}`,
+            err
+          );
+          fallbackResources.push(partialResource);
+          return;
+        })
+        .process(async partialResource => {
+          if (partialResource._project) {
+            const { org, project } = makeOrgProjectTuple(
+              partialResource._project
+            );
+
+            return (await nexus.Resource.get(
+              org,
+              project,
+              encodeURIComponent(partialResource['@id']),
+              { annotate: true }
+            )) as Resource;
+          }
+
+          return partialResource;
+        });
+      return {
+        ...resultWithPartialResources,
+        _results: [...expandedResources, ...fallbackResources],
+      };
+    },
+    onError: error => {
+      notification.error({
+        message: 'Error loading data from the server',
+        description: isString(error) ? (
+          error
+        ) : isObject(error) ? (
+          <div>
+            <strong>{(error as any)['@type']}</strong>
+            <div>{(error as any)['details']}</div>
+          </div>
+        ) : (
+          ''
+        ),
+      });
+    },
+    staleTime: Infinity,
+  });
+};
 
 export const useAggregations = (
   bucketName: 'projects' | 'types',
@@ -27,6 +107,57 @@ export const useAggregations = (
   });
 };
 
+export const sortColumns = (a: string, b: string) => {
+  // Sorts paths alphabetically. Additionally all paths starting with an underscore are sorted at the end of the list (because they represent metadata).
+  const columnA = columnFromPath(a);
+  const columnB = columnFromPath(b);
+
+  if (!isUserColumn(columnA) && !isUserColumn(columnB)) {
+    return a.localeCompare(b);
+  }
+  if (!isUserColumn(columnA)) {
+    return 1;
+  }
+  if (!isUserColumn(columnB)) {
+    return -1;
+  }
+  // Neither a, nor b are userColumns. Now, we want to "ALWAYS_SORTED_COLUMNS" to appear below other user defined columns like "contributions"
+  if (ALWAYS_DISPLAYED_COLUMNS.has(a) && ALWAYS_DISPLAYED_COLUMNS.has(b)) {
+    return a.localeCompare(b);
+  }
+  if (ALWAYS_DISPLAYED_COLUMNS.has(a)) {
+    return 1;
+  }
+  if (ALWAYS_DISPLAYED_COLUMNS.has(b)) {
+    return -1;
+  }
+  return a.localeCompare(b);
+};
+
+export const columnFromPath = (path: string | null) =>
+  path?.split('.')[0] ?? '';
+
+export const isUserColumn = (colName: string) => {
+  return ALWAYS_DISPLAYED_COLUMNS.has(colName) || !isNexusMetadata(colName);
+};
+
+export const ALWAYS_DISPLAYED_COLUMNS = new Set([
+  '_project',
+  '_createdAt',
+  '_updatedAt',
+]);
+
+const UNDERSCORE = '_';
+
+const METADATA_COLUMNS = new Set(['@id', '@context']);
+
+export const isNexusMetadata = (colName: string) =>
+  METADATA_COLUMNS.has(colName) || colName.startsWith(UNDERSCORE);
+
+export const isObject = (value: any) => {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+};
+
 export interface AggregationsResult {
   '@context': string;
   total: number;
@@ -43,3 +174,10 @@ export type AggregatedProperty = {
 };
 
 export type AggregatedBucket = { key: string; doc_count: number };
+
+interface PaginatedResourcesParams {
+  pageSize: number;
+  offset: number;
+  orgAndProject?: string[];
+  type?: string;
+}

--- a/src/subapps/dataExplorer/styles.less
+++ b/src/subapps/dataExplorer/styles.less
@@ -12,6 +12,13 @@
     margin-bottom: 28px;
   }
 
+  .flex-container {
+    display: flex;
+    max-width: 90vw;
+    justify-content: space-between;
+    align-items: center;
+  }
+
   .data-explorer-count {
     color: @fusion-neutral-7;
     margin-left: 20px;
@@ -19,6 +26,30 @@
 
     span {
       margin-right: 24px;
+    }
+  }
+
+  .data-explorer-toggles {
+    label {
+      margin-left: 6px;
+      color: @fusion-blue-8;
+    }
+    .data-explorer-toggle {
+      border: 1px solid @fusion-blue-8;
+      box-sizing: content-box;
+
+      &[aria-checked='true'] {
+        background-color: @fusion-blue-8;
+        .ant-switch-handle::before {
+          background-color: white;
+        }
+      }
+      &[aria-checked='false'] {
+        background-color: transparent;
+        .ant-switch-handle::before {
+          background-color: @fusion-blue-8;
+        }
+      }
     }
   }
 
@@ -54,6 +85,15 @@
         &::placeholder {
           color: @fusion-neutral-7;
           font-weight: 400;
+        }
+      }
+
+      .ant-select-selection-item {
+        span {
+          color: @fusion-blue-8 !important;
+          border: none;
+          background: @fusion-main-bg;
+          font-weight: 700;
         }
       }
 
@@ -132,7 +172,10 @@
 .data-explorer-table {
   table {
     width: auto;
-    min-width: unset !important;
+    min-width: 90vw;
+  }
+  .ant-table {
+    background: #f5f5f5;
   }
   .ant-table-thead > tr > th.data-explorer-column {
     background-color: #f5f5f5 !important;
@@ -170,5 +213,12 @@
 .search-menu {
   .ant-select-item-option-content {
     color: @fusion-blue-8;
+    width: 100%;
+    .first-metadata-path {
+      width: 100%;
+      display: block;
+      border-top: 1px solid @medium-gray;
+      padding-top: 4px;
+    }
   }
 }


### PR DESCRIPTION
Fixes #4038

1. Adds a toggle button that can be used to show or hide nexus metadata columns
2. Sorts columns and paths such that user columns appear before metadata columns
3. Gets expanded resource for data explorer

![Screenshot from 2023-07-13 11-57-54](https://github.com/BlueBrain/nexus-web/assets/11242410/0bcaf97d-086e-4b55-94ab-3dd94735ec37)

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added necessary unit and integration tests.
- [X] I have added screenshots (if applicable), in the comment section.
