### PR TITLE
F4048: Acl check actions

### DIFF
--- a/src/shared/App.less
+++ b/src/shared/App.less
@@ -237,7 +237,7 @@
   justify-content: center;
   gap: 10px;
   span {
-    color: #003a8c;
+    color: @fusion-blue-8;
   }
   .full-screen-switch {
     border-color: #2e76bf !important;
@@ -251,7 +251,7 @@
     .ant-switch-handle {
       top: 1px;
       &::before {
-        background: #002766;
+        background: @fusion-daybreak-10;
       }
     }
   }

--- a/src/shared/components/ResourceEditor/index.tsx
+++ b/src/shared/components/ResourceEditor/index.tsx
@@ -7,7 +7,7 @@ import {
   SaveOutlined,
 } from '@ant-design/icons';
 import { useSelector } from 'react-redux';
-import { useNexusContext } from '@bbp/react-nexus';
+import { AccessControl } from '@bbp/react-nexus';
 import codemiror from 'codemirror';
 
 import 'codemirror/mode/javascript/javascript';
@@ -261,7 +261,11 @@ const ResourceEditor: React.FunctionComponent<ResourceEditorProps> = props => {
                   style={switchMarginRight}
                 />
               )}
-              {userAuthenticated && (
+              <AccessControl
+                path={[`${orgLabel}/${projectLabel}`]}
+                permissions={['resources/write']}
+                noAccessComponent={() => <></>}
+              >
                 <Button
                   role="submit"
                   icon={<SaveOutlined />}
@@ -272,7 +276,7 @@ const ResourceEditor: React.FunctionComponent<ResourceEditorProps> = props => {
                 >
                   Save
                 </Button>
-              )}{' '}
+              </AccessControl>
               {editable && isEditing && (
                 <Button danger size="small" onClick={handleCancel}>
                   Cancel


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #https://github.com/BlueBrain/nexus/issues/4048

## Description
In the JSON editor in resource view page, the save button was dependent on the user login state to show the button, 
the right way is the wrap the button with the permission config so the user will have the right to update the resource depends on his/her permissions.

<!--- Describe your changes in detail -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
