### PR TITLE
Hotfix: use key download url

### DIFF
--- a/src/shared/components/ResourceEditor/ResourceEditor.less
+++ b/src/shared/components/ResourceEditor/ResourceEditor.less
@@ -213,6 +213,10 @@
       margin-left: 10px;
       color: @fusion-primary-color;
     }
+    .key-binding {
+      margin-left: 10px;
+      color: @fusion-primary-color;
+    }
   }
 }
 

--- a/src/shared/components/ResourceEditor/useEditorTooltip.tsx
+++ b/src/shared/components/ResourceEditor/useEditorTooltip.tsx
@@ -56,12 +56,21 @@ function createTooltipNode({
   nodeTitle.className = 'title';
   nodeTitle.appendChild(document.createTextNode(title));
   tooltipItemContent.appendChild(nodeTitle);
-
-  const nodeDownload = isDownloadable && document.createElement('img');
-  nodeDownload && nodeDownload.setAttribute('src', downloadImg);
-  nodeDownload && nodeDownload.classList.add('download-icon');
-  nodeDownload && tooltipItemContent.appendChild(nodeDownload);
-
+  if (isDownloadable) {
+    const nodeDownload = document.createElement('img');
+    nodeDownload.setAttribute('src', downloadImg);
+    nodeDownload.classList.add('download-icon');
+    tooltipItemContent.appendChild(nodeDownload);
+    const keyBinding = document.createElement('span');
+    keyBinding.className = 'key-binding';
+    // the user has to click and press option key on mac or alt key on windows
+    const userAgent = navigator.userAgent;
+    const isMac = userAgent.indexOf('Mac') !== -1;
+    keyBinding.appendChild(
+      document.createTextNode(isMac ? '⌥ + Click' : 'Alt + Click')
+    );
+    tooltipItemContent.appendChild(keyBinding);
+  }
   return tooltipItemContent;
 }
 function createTooltipContent({ resolvedAs, error, results }: TTooltipCreator) {
@@ -363,7 +372,9 @@ function useEditorPopover({
               }
               case 'resource': {
                 const result = results as TDELink;
-                if (result.isDownloadable) {
+                // this alt for windows, and option for mac
+                const optionClick = ev.altKey;
+                if (result.isDownloadable && optionClick) {
                   return downloadBinaryAsyncHandler({
                     orgLabel: result.resource?.[0]!,
                     projectLabel: result.resource?.[1]!,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #

## Description
downloadable links can be navigate to same as simple links, 
to download a binary, the user has to use the combination of `⌥ + Click` (on mac) or `Alt + Click` (on windows)
<!--- Describe your changes in detail -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
