### PR TITLE
Hotfix // Fix antd autoscroll warning

### DIFF
--- a/src/subapps/dataExplorer/ProjectSelector.tsx
+++ b/src/subapps/dataExplorer/ProjectSelector.tsx
@@ -46,7 +46,6 @@ export const ProjectSelector: React.FC<Props> = ({ onSelect }: Props) => {
         allowClear={true}
         clearIcon={<CloseOutlined data-testid="reset-project-button" />}
         onClear={() => onSelect(undefined, undefined)}
-        placeholder={AllProjects}
         aria-label="project-filter"
         bordered={false}
         className="search-input"
@@ -56,6 +55,7 @@ export const ProjectSelector: React.FC<Props> = ({ onSelect }: Props) => {
         <Input
           size="middle"
           addonAfter={showClearIcon ? <CloseOutlined /> : <SearchOutlined />}
+          placeholder={AllProjects} // Antd doesn't like adding placeholder along with 'allowClear' in AutoComplete element, so it needs to be added to this Input element. (https://github.com/ant-design/ant-design/issues/26760).
         />
       </AutoComplete>
     </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes the following console warning. This is a known issue in the [antd](https://github.com/ant-design/ant-design/issues/26760).
![Screenshot from 2023-07-19 16-33-11](https://github.com/BlueBrain/nexus-web/assets/11242410/54379f9e-2789-4c18-8414-2e6eecf26e88)




## Description

<!--- Describe your changes in detail -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [X] I have added screenshots (if applicable), in the comment section.
