### PR TITLE
4010 // Update query to retrieve non-deprecated resources by default

### DIFF
--- a/src/shared/containers/ResourceListBoardContainer.tsx
+++ b/src/shared/containers/ResourceListBoardContainer.tsx
@@ -19,7 +19,7 @@ export const DEFAULT_LIST: ResourceBoardList = {
   id: 'default',
   query: {
     size: 6,
-    deprecated: undefined,
+    deprecated: false, // Do not fetch deprecated resources by default.
     sort: '-_createdAt',
   },
 };

--- a/src/shared/containers/ResourceListContainer.tsx
+++ b/src/shared/containers/ResourceListContainer.tsx
@@ -248,7 +248,6 @@ const ResourceListContainer: React.FunctionComponent<{
       query: {
         ...list.query,
         type: !!value ? value : undefined,
-        deprecated: undefined,
         from: 0,
       },
     });


### PR DESCRIPTION
Fixes #[4010](https://app.zenhub.com/workspaces/blue-brain-nexus-60ace035034cae00105c9307/issues/gh/bluebrain/nexus/4010)
Shows non-deprecated resources by default

*Note*
Since the default query (which was faulty until now) is saved in the local storage the users will need to clear their local storage to see the fixed result. If needed, I can also update this PR to override the saved query retrieved from the LS, with `deprecated: false`. I'm open to suggestions. 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
