### PR TITLE
4155 // Fix jira plugin makes too many requests

### DIFF
--- a/src/shared/hooks/useJIRA.ts
+++ b/src/shared/hooks/useJIRA.ts
@@ -8,7 +8,6 @@ import useLocalStorage from './useLocalStorage';
 import useNotification from './useNotification';
 
 export function useJiraPlugin() {
-  console.log('JIRA Plugin Hook');
   const [
     jiraInaccessibleBecauseOfVPN,
     setJiraInaccessibleBecauseOfVPN,
@@ -32,7 +31,6 @@ export function useJiraPlugin() {
       return false;
     }
     try {
-      console.log('Fetch Project - Jira plugin');
       const response = await fetch(`${jiraAPIBaseUrl}/project`, {
         method: 'GET',
         headers: {
@@ -77,7 +75,6 @@ function useJIRA({
   projectLabel: string;
   resource?: Resource;
 }) {
-  console.log('Use Jira');
   const nexus = useNexusContext();
   const {
     jiraResourceCustomFieldName: nexusResourceFieldName,
@@ -157,7 +154,6 @@ function useJIRA({
   };
 
   const getProjects = () => {
-    console.log('Use Jira - Get projects');
     return nexus
       .httpGet({
         path: `${jiraAPIBaseUrl}/project`,
@@ -470,9 +466,14 @@ function useJIRA({
       getRequestToken();
       return;
     }
-    fetchProjects();
-    fetchLinkedIssues();
-  }, [isJiraConnected, projectSelf]);
+  }, [isJiraConnected]);
+
+  React.useEffect(() => {
+    if (projectSelf && isJiraConnected) {
+      fetchProjects();
+      fetchLinkedIssues();
+    }
+  }, [projectSelf, isJiraConnected]);
 
   return {
     isLoading,

--- a/src/shared/hooks/useJIRA.ts
+++ b/src/shared/hooks/useJIRA.ts
@@ -8,6 +8,7 @@ import useLocalStorage from './useLocalStorage';
 import useNotification from './useNotification';
 
 export function useJiraPlugin() {
+  console.log('JIRA Plugin Hook');
   const [
     jiraInaccessibleBecauseOfVPN,
     setJiraInaccessibleBecauseOfVPN,
@@ -31,6 +32,7 @@ export function useJiraPlugin() {
       return false;
     }
     try {
+      console.log('Fetch Project - Jira plugin');
       const response = await fetch(`${jiraAPIBaseUrl}/project`, {
         method: 'GET',
         headers: {
@@ -52,9 +54,11 @@ export function useJiraPlugin() {
     }
   };
 
-  isInaccessibleBecauseNotOnVPN().then(value => {
-    setJiraInaccessibleBecauseOfVPN(value);
-  });
+  React.useEffect(() => {
+    isInaccessibleBecauseNotOnVPN().then(value => {
+      setJiraInaccessibleBecauseOfVPN(value);
+    });
+  }, []);
 
   return { isUserInSupportedJiraRealm, jiraInaccessibleBecauseOfVPN };
 }
@@ -73,6 +77,7 @@ function useJIRA({
   projectLabel: string;
   resource?: Resource;
 }) {
+  console.log('Use Jira');
   const nexus = useNexusContext();
   const {
     jiraResourceCustomFieldName: nexusResourceFieldName,
@@ -152,6 +157,7 @@ function useJIRA({
   };
 
   const getProjects = () => {
+    console.log('Use Jira - Get projects');
     return nexus
       .httpGet({
         path: `${jiraAPIBaseUrl}/project`,


### PR DESCRIPTION
Number of requests fired by fusion are reduced by making following changes:

- The check for VPN only needs to be done once, when the `useJiraPlugin` is initialized because it depends on root state (like `apiEndpoint`) that does not change on every render.

For example, I was logging `Fetch project - Jira plugin` whenever a request was fired from fusion to delta endpoint `/jira/project`. These are the results before:

![Screenshot from 2023-08-21 11-05-18](https://github.com/BlueBrain/nexus-web/assets/11242410/94734113-336c-4ed8-8fee-7c65b8c16dc5)


These are the results after:
![Screenshot from 2023-08-21 11-03-31](https://github.com/BlueBrain/nexus-web/assets/11242410/51014f7d-28f7-43a0-89ef-3c37038b14f9)

- `getRequestToken` should only be called when the status of jira connection changes because it does not depend on `projectSelf`
- Finally, the jira projects and issues should be fetched only if we have the right request token and project self.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
