### PR TITLE
3818 // Display views indexing errors

### DIFF
--- a/src/__mocks__/handlers/Settings/ViewsSubViewHandlers.ts
+++ b/src/__mocks__/handlers/Settings/ViewsSubViewHandlers.ts
@@ -1,0 +1,208 @@
+import { rest } from 'msw';
+import { deltaPath } from '__mocks__/handlers/handlers';
+
+export const identitiesHandler = () => {
+  return rest.get(deltaPath(`/identities`), (req, res, ctx) => {
+    const mockResponse = {
+      '@context': [
+        'https://bluebrain.github.io/nexus/contexts/metadata.json',
+        'https://bluebrain.github.io/nexus/contexts/identities.json',
+      ],
+      identities: [
+        {
+          '@id':
+            'https://dev.nise.bbp.epfl.ch/nexus/v1/realms/local/authenticated',
+          '@type': 'Authenticated',
+          realm: 'test',
+        },
+      ],
+    };
+    return res(ctx.status(200), ctx.json(mockResponse));
+  });
+};
+
+export const aclsHandler = (orgLabel: string, projectLabel: string) => {
+  return rest.get(
+    deltaPath(`/acls/${orgLabel}/${projectLabel}`),
+    (req, res, ctx) => {
+      const mockResponse = {
+        '@context': ['https://bluebrain.github.io/nexus/contexts/acls.json'],
+        _total: 1,
+        _results: [
+          {
+            '@id': 'https://dev.nise.bbp.epfl.ch/nexus/v1/acls',
+            '@type': 'AccessControlList',
+            acl: [
+              {
+                identity: {
+                  '@id':
+                    'https://dev.nise.bbp.epfl.ch/nexus/v1/realms/local/authenticated',
+                  '@type': 'Authenticated',
+                  realm: 'test',
+                },
+                permissions: [
+                  'realms/write',
+                  'files/write',
+                  'events/read',
+                  'organizations/write',
+                  'projects/delete',
+                  'projects/write',
+                  'views/write',
+                ],
+              },
+              {
+                identity: {
+                  '@id': 'https://dev.nise.bbp.epfl.ch/nexus/v1/anonymous',
+                  '@type': 'Anonymous',
+                },
+                permissions: [
+                  'realms/read',
+                  'permissions/read',
+                  'version/read',
+                ],
+              },
+            ],
+            _self: 'https://dev.nise.bbp.epfl.ch/nexus/v1/acls',
+          },
+        ],
+      };
+      return res(ctx.status(200), ctx.json(mockResponse));
+    }
+  );
+};
+
+export const viewWithIndexingErrors =
+  'https://bluebrain.github.io/nexus/vocabulary/defaultSparqlIndex';
+
+export const viewWithNoIndexingErrors =
+  'https://bluebrain.github.io/nexus/vocabulary/defaultElasticSearchIndex';
+
+export const viewsHandler = (orgLabel: string, projectLabel: string) => {
+  const baseViewObject = baseView(orgLabel, projectLabel);
+
+  return rest.get(
+    deltaPath(`/views/${orgLabel}/${projectLabel}`),
+    (req, res, ctx) => {
+      const mockResponse = {
+        '@context': [
+          'https://bluebrain.github.io/nexus/contexts/search.json',
+          'https://bluebrain.github.io/nexus/contexts/search-metadata.json',
+        ],
+        _total: 3,
+        _results: [
+          {
+            '@id': viewWithNoIndexingErrors,
+            '@type': ['ElasticSearchView', 'View'],
+            name: 'Default Elasticsearch view',
+            ...baseViewObject,
+          },
+          {
+            '@id': 'https://bluebrain.github.io/nexus/vocabulary/searchView',
+            '@type': ['View', 'CompositeView'],
+            ...baseViewObject,
+          },
+          {
+            '@id': viewWithIndexingErrors,
+            '@type': ['View', 'SparqlView'],
+            name: 'Default Sparql view',
+            ...baseViewObject,
+          },
+        ],
+      };
+      return res(ctx.status(200), ctx.json(mockResponse));
+    }
+  );
+};
+
+export const viewErrorsHandler = (orgLabel: string, projectLabel: string) => {
+  return rest.get(
+    deltaPath(`/views/${orgLabel}/${projectLabel}/:viewId/failures`),
+    (req, res, ctx) => {
+      const { viewId } = req.params;
+      const decodedId = decodeURIComponent(viewId as string);
+
+      const mockResponse = {
+        '@context': ['https://bluebrain.github.io/nexus/contexts/error.json'],
+        _total: decodedId === viewWithIndexingErrors ? 2 : 0,
+        _results:
+          decodedId === viewWithIndexingErrors
+            ? [
+                {
+                  ...baseIndexingError(
+                    orgLabel,
+                    projectLabel,
+                    `${decodedId}-1`
+                  ),
+                  message: 'Mock Error 1',
+                },
+                {
+                  ...baseIndexingError(
+                    orgLabel,
+                    projectLabel,
+                    `${decodedId}-2`
+                  ),
+                  message: 'Mock Error 2',
+                },
+              ]
+            : [],
+      };
+      return res(ctx.status(200), ctx.json(mockResponse));
+    }
+  );
+};
+
+export const viewStatsHandler = (orgLabel: string, projectLabel: string) => {
+  return rest.get(
+    deltaPath(`/views/${orgLabel}/${projectLabel}/:viewId/statistics`),
+    (req, res, ctx) => {
+      const mockResponse = {
+        '@context':
+          'https://bluebrain.github.io/nexus/contexts/statistics.json',
+        '@type': 'ViewStatistics',
+        delayInSeconds: 0,
+        discardedEvents: 0,
+        evaluatedEvents: 10489,
+        failedEvents: 0,
+        lastEventDateTime: '2023-08-24T13:53:01.884Z',
+        lastProcessedEventDateTime: '2023-08-24T13:53:01.884Z',
+        processedEvents: 10489,
+        remainingEvents: 0,
+        totalEvents: 10489,
+      };
+      return res(ctx.status(200), ctx.json(mockResponse));
+    }
+  );
+};
+
+const baseIndexingError = (
+  orgLabel: string,
+  projectLabel: string,
+  id: string
+) => ({
+  id,
+  errorType: 'epfl.indexing.ElasticSearchSink.BulkUpdateException',
+  message: 'Super dramatic error',
+  offset: {
+    '@type': 'At',
+    value: 264934,
+  },
+  project: `${orgLabel}/${projectLabel}`,
+  _rev: 1,
+});
+
+const baseView = (orgLabel: string, projectLabel: string) => ({
+  _constrainedBy: 'https://bluebrain.github.io/nexus/schemas/views.json',
+  _createdAt: '2022-04-01T08:27:55.583Z',
+  _createdBy:
+    'https://test.nise.bbp.epfl.ch/nexus/v1/realms/serviceaccounts/users/service-account-nexus-sa',
+  _deprecated: false,
+  _incoming: `https://test.nise.bbp.epfl.ch/nexus/v1/views/${orgLabel}/${projectLabel}/graph/incoming`,
+  _indexingRev: 1,
+  _outgoing: `https://test.nise.bbp.epfl.ch/nexus/v1/views/${orgLabel}/${projectLabel}/graph/outgoing`,
+  _project: `https://test.nise.bbp.epfl.ch/nexus/v1/projects/${orgLabel}/${projectLabel}`,
+  _rev: 1,
+  _self: `https://test.nise.bbp.epfl.ch/nexus/v1/views/${orgLabel}/${projectLabel}/graph`,
+  _updatedAt: '2022-04-01T08:27:55.583Z',
+  _updatedBy: `https://test.nise.bbp.epfl.ch/nexus/v1/realms/serviceaccounts/users/service-account-nexus-sa`,
+  _uuid: 'b48c6970-2e20-4a39-9180-574b5c656965',
+});

--- a/src/subapps/admin/components/Settings/ViewIndexingErrors.tsx
+++ b/src/subapps/admin/components/Settings/ViewIndexingErrors.tsx
@@ -1,0 +1,77 @@
+import { NexusClient } from '@bbp/nexus-sdk';
+import { Alert, Collapse, List } from 'antd';
+import React from 'react';
+import ReactJson from 'react-json-view';
+import './styles.less';
+
+interface Props {
+  indexingErrors: IndexingErrorResults;
+}
+
+export const ViewIndexingErrors: React.FC<Props> = ({
+  indexingErrors,
+}: Props) => {
+  return (
+    <div>
+      {<h3>{indexingErrors._total} Total errors</h3>}
+      {indexingErrors._total && (
+        <Alert
+          message="The list below shows all indexing errors - even the ones that are now resolved."
+          showIcon
+          style={{ margin: '20px' }}
+        />
+      )}
+      <List
+        itemLayout="horizontal"
+        dataSource={indexingErrors?._results}
+        data-testid="indexing-error-list"
+        renderItem={(indexingError: IndexingError) => (
+          <Collapse>
+            <Collapse.Panel
+              header={indexingError.message}
+              key={indexingError.id}
+              className="indexing-error-header"
+            >
+              <ReactJson src={indexingError} />
+            </Collapse.Panel>
+          </Collapse>
+        )}
+      />
+    </div>
+  );
+};
+
+export const fetchIndexingErrors = async ({
+  nexus,
+  apiEndpoint,
+  orgLabel,
+  projectLabel,
+  viewId,
+}: {
+  nexus: NexusClient;
+  apiEndpoint: string;
+  orgLabel: string;
+  projectLabel: string;
+  viewId: string;
+}): Promise<IndexingErrorResults> => {
+  const indexingErrors = await nexus.httpGet({
+    path: `${apiEndpoint}/views/${orgLabel}/${projectLabel}/${encodeURIComponent(
+      viewId
+    )}/failures`,
+    headers: { Accept: 'application/json' },
+  });
+  return indexingErrors;
+};
+
+export interface IndexingErrorResults {
+  '@context': string[] | string;
+  _next: string;
+  _results: IndexingError[];
+  _total: number;
+}
+
+interface IndexingError {
+  id: string;
+  message: string;
+  errorType: string;
+}

--- a/src/subapps/admin/components/Settings/ViewsSubView.spec.tsx
+++ b/src/subapps/admin/components/Settings/ViewsSubView.spec.tsx
@@ -1,0 +1,152 @@
+import { setupServer } from 'msw/node';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { deltaPath } from '__mocks__/handlers/handlers';
+import configureStore from '../../../../shared/store';
+import { createNexusClient } from '@bbp/nexus-sdk';
+import { createMemoryHistory } from 'history';
+import { Provider } from 'react-redux';
+import { Route, Router } from 'react-router-dom';
+import { NexusProvider } from '@bbp/react-nexus';
+import ViewsSubView from './ViewsSubView';
+import { render, screen, waitFor } from '../../../../utils/testUtil';
+import { UserEvent } from '@testing-library/user-event/dist/types/setup/setup';
+import userEvent from '@testing-library/user-event';
+import {
+  aclsHandler,
+  identitiesHandler,
+  viewErrorsHandler,
+  viewStatsHandler,
+  viewWithIndexingErrors,
+  viewWithNoIndexingErrors,
+  viewsHandler,
+} from '__mocks__/handlers/Settings/ViewsSubViewHandlers';
+
+describe('ViewsSubView', () => {
+  const mockOrganisation = 'copies';
+  const mockProject = 'hippocampus';
+
+  const server = setupServer(
+    identitiesHandler(),
+    viewsHandler(mockOrganisation, mockProject),
+    aclsHandler(mockOrganisation, mockProject),
+    viewErrorsHandler(mockOrganisation, mockProject),
+    viewStatsHandler(mockOrganisation, mockProject)
+  );
+
+  const history = createMemoryHistory({
+    initialEntries: [`/orgs/${mockOrganisation}/${mockProject}/settings`],
+  });
+
+  let user: UserEvent;
+  let container: HTMLElement;
+  let viewsSubViewComponent: JSX.Element;
+
+  beforeEach(async () => {
+    server.listen();
+    const queryClient = new QueryClient();
+    const nexus = createNexusClient({
+      fetch,
+      uri: deltaPath(),
+    });
+    const store = configureStore(
+      history,
+      { nexus },
+      { config: { apiEndpoint: 'https://localhost:3000' } }
+    );
+
+    viewsSubViewComponent = (
+      <Provider store={store}>
+        <QueryClientProvider client={queryClient}>
+          <Router history={history}>
+            <Route path="/orgs/:orgLabel/:projectLabel/settings">
+              <NexusProvider nexusClient={nexus}>
+                <ViewsSubView />
+              </NexusProvider>
+            </Route>
+          </Router>
+        </QueryClientProvider>
+      </Provider>
+    );
+
+    const component = render(viewsSubViewComponent);
+
+    container = component.container;
+    user = userEvent.setup();
+    await expectRowCountToBe(3);
+  });
+
+  it('shows a badge for views that have errors', async () => {
+    expect(getErrorBadgeContent(viewWithIndexingErrors)).toEqual('2');
+  });
+
+  it('does not show error badge for views that dont have errors', async () => {
+    expect(getErrorBadgeContent(viewWithNoIndexingErrors)).toBeUndefined();
+  });
+
+  it('shows indexing errors when view row is expanded', async () => {
+    await expandRow(viewWithIndexingErrors);
+
+    await screen.getByText(/2 Total errors/i, { selector: 'h3' });
+
+    const indexingErrorRows = await getErrorRows();
+    expect(indexingErrorRows.length).toEqual(2);
+
+    const errorRow1 = await getErrorRow('Mock Error 1');
+    expect(errorRow1).toBeTruthy();
+    const errorRow2 = await getErrorRow('Mock Error 2');
+    expect(errorRow2).toBeTruthy();
+  });
+
+  it('shows detailed error when error row is expanded', async () => {
+    await expandRow(viewWithIndexingErrors);
+
+    const errorRow1 = await getErrorRow('Mock Error 1');
+    await user.click(errorRow1);
+
+    const detailedErrorContainer = container.querySelector('.react-json-view');
+    expect(detailedErrorContainer).toBeTruthy();
+  });
+
+  const getErrorRow = async (errorMessage: string) => {
+    const row = await screen.getByText(new RegExp(errorMessage, 'i'), {
+      selector: '.ant-collapse-header-text',
+    });
+    return row;
+  };
+
+  const getErrorRows = () => {
+    const rowContainer = container.querySelector(
+      'div[data-testid="indexing-error-list"]'
+    )!;
+    return Array.from(rowContainer.querySelector('ul')!.children);
+  };
+
+  const expandRow = async (rowId: string) => {
+    const row = getViewRowById(rowId);
+    const expandButton = row.querySelector(
+      'span[data-testid="Expand indexing errors"]'
+    )!;
+    await user.click(expandButton);
+  };
+
+  const getViewRowById = (rowId: string) => {
+    return container.querySelector(`tr[data-row-key="${rowId}"`)!;
+  };
+
+  const expectRowCountToBe = async (expectedRowsCount: number) => {
+    return await waitFor(() => {
+      const rows = visibleTableRows();
+      expect(rows.length).toEqual(expectedRowsCount);
+      return rows;
+    });
+  };
+
+  const visibleTableRows = () => {
+    return container.querySelectorAll('table tbody tr.view-item-row');
+  };
+
+  const getErrorBadgeContent = (rowId: string) => {
+    const row = getViewRowById(rowId);
+    return row.querySelector('sup')?.textContent;
+  };
+});

--- a/src/subapps/admin/components/Settings/styles.less
+++ b/src/subapps/admin/components/Settings/styles.less
@@ -215,3 +215,11 @@
   align-items: center;
   justify-content: center;
 }
+
+.indexing-error-header {
+  .ant-collapse-header-text {
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+  }
+}

--- a/src/subapps/dataExplorer/DataExplorer.spec.tsx
+++ b/src/subapps/dataExplorer/DataExplorer.spec.tsx
@@ -1,14 +1,7 @@
 import { Resource, createNexusClient } from '@bbp/nexus-sdk';
 import { NexusProvider } from '@bbp/react-nexus';
 import '@testing-library/jest-dom';
-import {
-  RenderResult,
-  act,
-  fireEvent,
-  queryByRole,
-  waitForElementToBeRemoved,
-  within,
-} from '@testing-library/react';
+import { RenderResult, act, fireEvent, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { UserEvent } from '@testing-library/user-event/dist/types/setup/setup';
 import {


### PR DESCRIPTION
Fixes #[3818](https://github.com/BlueBrain/nexus/issues/3818)
Displays indexing errors in views:

A badge is displayed next to views that have indexing issues
![Screenshot from 2023-08-22 15-08-00](https://github.com/BlueBrain/nexus-web/assets/11242410/26b383a9-85d6-466d-afe5-2968b63020f6)

Error details are displayed on expansion
![Screenshot from 2023-08-22 15-14-37](https://github.com/BlueBrain/nexus-web/assets/11242410/1b5e3699-f70f-44bc-9f2d-a61a2701c070)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
