### PR TITLE
4083 // Run "exists" and "does not exists" predicates in backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "NODE_ENV=development  DEBUG=* webpack --mode development --config-name server && node dist/server.js",
     "build": "NODE_ENV=production NODE_OPTIONS=--max_old_space_size=8192  webpack --mode production",
     "test": "jest",
-    "test:watch": "jest --watch",
+    "test:watch": "jest --watch --maxWorkers=4",
     "cy:open": "cypress open",
     "cy:run": "cypress run",
     "cy:ci": "echo | sudo docker exec --user=$UID -t cypress cypress run --config-file cypress.config.ts --browser chrome",
@@ -212,7 +212,10 @@
     ],
     "globals": {
       "FUSION_VERSION": "1.0.0",
-      "COMMIT_HASH": "9013fa343"
+      "COMMIT_HASH": "9013fa343",
+      "ts-jest": {
+        "isolatedModules": true
+      }
     },
     "watchPathIgnorePatterns": [
       "node_modules"

--- a/src/__mocks__/handlers/DataExplorer/handlers.ts
+++ b/src/__mocks__/handlers/DataExplorer/handlers.ts
@@ -4,6 +4,7 @@ import { Resource } from '@bbp/nexus-sdk';
 import {
   AggregatedBucket,
   AggregationsResult,
+  NexusMultiFetchResponse,
 } from 'subapps/dataExplorer/DataExplorerUtils';
 
 export const getCompleteResources = (
@@ -16,26 +17,40 @@ export const dataExplorerPageHandler = (
   partialResources: Resource[] = defaultPartialResources,
   total: number = 300
 ) => {
-  return rest.get(deltaPath(`/resources`), (req, res, ctx) => {
-    if (req.url.searchParams.has('aggregations')) {
-      return res(ctx.status(200), ctx.json(mockAggregationsResult()));
-    }
-    const passedType = req.url.searchParams.get('type');
-    const mockResponse = {
-      '@context': [
-        'https://bluebrain.github.io/nexus/contexts/metadata.json',
-        'https://bluebrain.github.io/nexus/contexts/search.json',
-        'https://bluebrain.github.io/nexus/contexts/search-metadata.json',
-      ],
-      _total: total,
-      _results: passedType
-        ? partialResources.filter(res => res['@type'] === passedType)
-        : partialResources,
-      _next:
-        'https://bbp.epfl.ch/nexus/v1/resources?size=50&sort=@id&after=%5B1687269183553,%22https://bbp.epfl.ch/neurosciencegraph/data/31e22529-2c36-44f0-9158-193eb50526cd%22%5D',
-    };
-    return res(ctx.status(200), ctx.json(mockResponse));
-  });
+  return [
+    rest.get(deltaPath(`/resources`), (req, res, ctx) => {
+      if (req.url.searchParams.has('aggregations')) {
+        return res(ctx.status(200), ctx.json(mockAggregationsResult()));
+      }
+      const passedType = req.url.searchParams.get('type');
+      const mockResponse = {
+        '@context': [
+          'https://bluebrain.github.io/nexus/contexts/metadata.json',
+          'https://bluebrain.github.io/nexus/contexts/search.json',
+          'https://bluebrain.github.io/nexus/contexts/search-metadata.json',
+        ],
+        _total: total,
+        _results: passedType
+          ? partialResources.filter(res => res['@type'] === passedType)
+          : partialResources,
+        _next:
+          'https://bbp.epfl.ch/nexus/v1/resources?size=50&sort=@id&after=%5B1687269183553,%22https://bbp.epfl.ch/neurosciencegraph/data/31e22529-2c36-44f0-9158-193eb50526cd%22%5D',
+      };
+      return res(ctx.status(200), ctx.json(mockResponse));
+    }),
+    rest.post(deltaPath('/multi-fetch/resources'), (req, res, ctx) => {
+      const requestedIds = ((req.body as any)?.resources).map(
+        (res: { id: string }) => res.id
+      );
+      const response: NexusMultiFetchResponse = {
+        format: 'compacted',
+        resources: partialResources
+          .filter(res => requestedIds.includes(res['@id']))
+          .map(r => ({ value: { ...r, ...propertiesOnlyInSource } })),
+      };
+      return res(ctx.status(200), ctx.json(response));
+    }),
+  ];
 };
 
 export const graphAnalyticsTypeHandler = () => {
@@ -147,16 +162,17 @@ export const filterByProjectHandler = (
   });
 };
 
-export const elasticSearchQueryHandler = (ids: string[]) => {
+export const elasticSearchQueryHandler = (resources: Resource[]) => {
   return rest.post(
     deltaPath('/graph-analytics/:org/:project/_search'),
     (req, res, ctx) => {
       const esResponse = {
         hits: {
-          hits: ids.map(id => ({
-            _id: id,
+          hits: resources.map(resource => ({
+            _id: resource['@id'],
             _source: {
-              '@id': id,
+              '@id': resource['@id'],
+              _project: resource._project,
             },
           })),
           max_score: 0,

--- a/src/__mocks__/handlers/DataExplorer/handlers.ts
+++ b/src/__mocks__/handlers/DataExplorer/handlers.ts
@@ -60,12 +60,12 @@ export const graphAnalyticsTypeHandler = () => {
             _name: 'propertyAlwaysThere',
           },
           {
-            '@id': 'https://neuroshapes.org/nr__number_stems',
+            '@id': 'https://neuroshapes.org/createdBy',
             _count: 30,
             _name: '_createdBy',
           },
           {
-            '@id': 'https://neuroshapes.org/nr__number_stems',
+            '@id': 'https://neuroshapes.org/edition',
             _count: 30,
             _name: 'edition',
           },
@@ -145,6 +145,29 @@ export const filterByProjectHandler = (
     };
     return res(ctx.status(200), ctx.json(mockResponse));
   });
+};
+
+export const elasticSearchQueryHandler = (ids: string[]) => {
+  return rest.post(
+    deltaPath('/graph-analytics/:org/:project/_search'),
+    (req, res, ctx) => {
+      const esResponse = {
+        hits: {
+          hits: ids.map(id => ({
+            _id: id,
+            _source: {
+              '@id': id,
+            },
+          })),
+          max_score: 0,
+          total: {
+            value: 479,
+          },
+        },
+      };
+      return res(ctx.status(200), ctx.json(esResponse));
+    }
+  );
 };
 
 const mockAggregationsResult = (

--- a/src/subapps/dataExplorer/DataExplorer.spec.tsx
+++ b/src/subapps/dataExplorer/DataExplorer.spec.tsx
@@ -6,6 +6,7 @@ import userEvent from '@testing-library/user-event';
 import { UserEvent } from '@testing-library/user-event/dist/types/setup/setup';
 import {
   dataExplorerPageHandler,
+  elasticSearchQueryHandler,
   filterByProjectHandler,
   getCompleteResources,
   getMockResource,
@@ -24,6 +25,7 @@ import {
   DOES_NOT_CONTAIN,
   DOES_NOT_EXIST,
   EXISTS,
+  FRONTEND_PREDICATE_WARNING,
   getAllPaths,
 } from './PredicateSelector';
 import { createMemoryHistory } from 'history';
@@ -64,7 +66,12 @@ describe('DataExplorer', () => {
       fetch,
       uri: deltaPath(),
     });
-    const store = configureStore(history, { nexus }, {});
+
+    const store = configureStore(
+      history,
+      { nexus },
+      { config: { apiEndpoint: 'https://localhost:3000' } }
+    );
 
     dataExplorerPage = (
       <Provider store={store}>
@@ -109,9 +116,6 @@ describe('DataExplorer', () => {
   const expectRowCountToBe = async (expectedRowsCount: number) => {
     return await waitFor(() => {
       const rows = visibleTableRows();
-      rows.forEach(row => {
-        // console.log('MY ROW', row.innerHTML)
-      });
       expect(rows.length).toEqual(expectedRowsCount);
       return rows;
     });
@@ -141,6 +145,7 @@ describe('DataExplorer', () => {
       selector: 'th .ant-table-column-title',
       exact: false,
     });
+
     expect(header).toBeInTheDocument();
     return header;
   };
@@ -353,6 +358,19 @@ describe('DataExplorer', () => {
     await getRowsForNextPage(resources);
     await expectRowCountToBe(resources.length);
     server.use(filterByProjectHandler(mockResourcesForPage2));
+  };
+
+  const mockElasticSearchHits = (
+    path: string,
+    predicate: typeof EXISTS | typeof DOES_NOT_EXIST,
+    resources: Resource[]
+  ) => {
+    const matchingResources = resources.filter(res =>
+      predicate === EXISTS ? res[path] : !res[path]
+    );
+    server.use(
+      elasticSearchQueryHandler(matchingResources.map(res => res['@id']))
+    );
   };
 
   const getResetProjectButton = async () => {
@@ -673,12 +691,14 @@ describe('DataExplorer', () => {
   it('shows resources that have path missing', async () => {
     await updateResourcesShownInTable(mockResourcesForPage2);
 
+    mockElasticSearchHits('author', DOES_NOT_EXIST, mockResourcesForPage2);
     await selectPath('author');
     await selectOptionFromMenu(PredicateMenuLabel, DOES_NOT_EXIST);
     await expectRowCountToBe(1);
 
     await resetPredicate();
 
+    mockElasticSearchHits('edition', DOES_NOT_EXIST, mockResourcesForPage2);
     await selectPath('edition');
     await selectOptionFromMenu(PredicateMenuLabel, DOES_NOT_EXIST);
     await expectRowCountToBe(2);
@@ -718,11 +738,8 @@ describe('DataExplorer', () => {
   });
 
   it('shows resources that have a path when user selects exists predicate', async () => {
-    await updateResourcesShownInTable([
-      getMockResource('self1', { author: 'piggy', edition: 1 }),
-      getMockResource('self2', { author: ['iggy', 'twinky'] }),
-      getMockResource('self3', { year: 2013 }),
-    ]);
+    await updateResourcesShownInTable(mockResourcesForPage2);
+    mockElasticSearchHits('author', EXISTS, mockResourcesForPage2);
 
     await selectPath('author');
     await userEvent.click(container);
@@ -798,20 +815,61 @@ describe('DataExplorer', () => {
     expect(totalFromFrontend).toEqual(null);
   });
 
-  it('shows total filtered count if predicate is selected', async () => {
+  it('does not show total filtered count if backend predicate is selected', async () => {
     await expectRowCountToBe(10);
     await updateResourcesShownInTable(mockResourcesForPage2);
+    mockElasticSearchHits('author', EXISTS, mockResourcesForPage2);
 
     await selectPath('author');
     await userEvent.click(container);
     await selectOptionFromMenu(PredicateMenuLabel, EXISTS);
     await expectRowCountToBe(2);
-    const totalFromFrontendAfter = await getFilteredResultsCount(2);
-    expect(totalFromFrontendAfter).toBeVisible();
+    expect(await getFilteredResultsCount()).toBeFalsy();
+
+    mockElasticSearchHits('author', DOES_NOT_EXIST, mockResourcesForPage2);
+    await selectOptionFromMenu(PredicateMenuLabel, DOES_NOT_EXIST);
+    await expectRowCountToBe(1);
+    expect(await getFilteredResultsCount()).toBeFalsy();
+  });
+
+  it('shows filtered count if frontend predicate is selected', async () => {
+    await updateResourcesShownInTable(mockResourcesForPage2);
+
+    await selectPath('author');
+    await selectOptionFromMenu(PredicateMenuLabel, CONTAINS);
+    const valueInput = await screen.getByPlaceholderText('Search for...');
+    await userEvent.type(valueInput, 'twinky');
+    await expectRowCountToBe(1);
+
+    expect(await getFilteredResultsCount(1)).toBeVisible();
+  });
+
+  it('shows predicate warning if frontend predicate is selected', async () => {
+    await updateResourcesShownInTable(mockResourcesForPage2);
+
+    await selectPath('author');
+    await selectOptionFromMenu(PredicateMenuLabel, CONTAINS);
+
+    expect(await screen.getByText(FRONTEND_PREDICATE_WARNING)).toBeVisible();
+
+    await selectOptionFromMenu(PredicateMenuLabel, DOES_NOT_CONTAIN);
+    expect(await screen.getByText(FRONTEND_PREDICATE_WARNING)).toBeVisible();
+  });
+
+  it('does not show predicate warning if backend predicate is selected', async () => {
+    await updateResourcesShownInTable(mockResourcesForPage2);
+
+    await selectPath('author');
+    await selectOptionFromMenu(PredicateMenuLabel, EXISTS);
+
+    expect(await screen.queryByText(FRONTEND_PREDICATE_WARNING)).toBeFalsy();
+    await selectOptionFromMenu(PredicateMenuLabel, EXISTS);
+    expect(await screen.queryByText(FRONTEND_PREDICATE_WARNING)).toBeFalsy();
   });
 
   it('shows column for metadata path even if toggle for show metadata is off', async () => {
     const metadataProperty = '_createdBy';
+    mockElasticSearchHits(metadataProperty, EXISTS, mockResourcesOnPage1);
     await expectRowCountToBe(10);
 
     await expectColumHeaderToNotExist(metadataProperty);
@@ -820,6 +878,8 @@ describe('DataExplorer', () => {
 
     await selectPath(metadataProperty);
     await selectOptionFromMenu(PredicateMenuLabel, EXISTS);
+
+    await expectRowCountToBe(10);
 
     await expectColumHeaderToExist(metadataProperty);
     expect(getTotalColumns().length).toEqual(originalColumns + 1);
@@ -830,6 +890,7 @@ describe('DataExplorer', () => {
 
   it('resets predicate fields when reset predicate clicked', async () => {
     await updateResourcesShownInTable(mockResourcesForPage2);
+    mockElasticSearchHits('author', EXISTS, mockResourcesForPage2);
 
     await selectPath('author');
     await selectPredicate(EXISTS);
@@ -985,17 +1046,17 @@ describe('DataExplorer', () => {
     expect((valueInputAfter as HTMLInputElement).value).not.toEqual('iggy');
   });
 
-  it('does not show predicate selector if multiple types are selected', async () => {
+  it('disables predicate selector if multiple types are selected', async () => {
     await selectOptionFromMenu(ProjectMenuLabel, 'unhcr');
     await selectOptionFromMenu(TypeMenuLabel, 'file', TypeOptionSelector);
 
-    expect(await getInputForLabel(PathMenuLabel)).toBeVisible();
+    expect(await getInputForLabel(PathMenuLabel)).toBeEnabled();
 
     await selectOptionFromMenu(
       TypeMenuLabel,
       'StudioDashboard',
       TypeOptionSelector
     );
-    expect(getInputForLabel(PathMenuLabel)).rejects.toThrow();
+    expect(await getInputForLabel(PathMenuLabel)).toBeDisabled();
   });
 });

--- a/src/subapps/dataExplorer/DataExplorer.spec.tsx
+++ b/src/subapps/dataExplorer/DataExplorer.spec.tsx
@@ -47,7 +47,7 @@ describe('DataExplorer', () => {
   ];
 
   const server = setupServer(
-    dataExplorerPageHandler(undefined, defaultTotalResults),
+    ...dataExplorerPageHandler(undefined, defaultTotalResults),
     sourceResourceHandler(),
     filterByProjectHandler(),
     graphAnalyticsTypeHandler()
@@ -241,7 +241,7 @@ describe('DataExplorer', () => {
   ) => {
     server.use(
       sourceResourceHandler(resources),
-      dataExplorerPageHandler(resources, total)
+      ...dataExplorerPageHandler(resources, total)
     );
 
     const pageInput = await screen.getByRole('listitem', { name: '2' });
@@ -368,9 +368,7 @@ describe('DataExplorer', () => {
     const matchingResources = resources.filter(res =>
       predicate === EXISTS ? res[path] : !res[path]
     );
-    server.use(
-      elasticSearchQueryHandler(matchingResources.map(res => res['@id']))
-    );
+    server.use(elasticSearchQueryHandler(matchingResources));
   };
 
   const getResetProjectButton = async () => {
@@ -531,7 +529,7 @@ describe('DataExplorer', () => {
       mock100Resources.push(getMockResource(`self${i}`, {}));
     }
 
-    server.use(dataExplorerPageHandler(mock100Resources));
+    server.use(...dataExplorerPageHandler(mock100Resources));
 
     const pageSizeChanger = await screen.getByRole('combobox', {
       name: 'Page Size',
@@ -893,6 +891,7 @@ describe('DataExplorer', () => {
     mockElasticSearchHits('author', EXISTS, mockResourcesForPage2);
 
     await selectPath('author');
+
     await selectPredicate(EXISTS);
 
     const selectedPathBefore = await getSelectedValueInMenu(PathMenuLabel);

--- a/src/subapps/dataExplorer/DataExplorer.tsx
+++ b/src/subapps/dataExplorer/DataExplorer.tsx
@@ -40,7 +40,8 @@ export interface DataExplorerConfiguration {
   offset: number;
   orgAndProject?: [string, string];
   types?: TType[];
-  predicate: ((resource: Resource) => boolean) | null;
+  frontendPredicate: ((resource: Resource) => boolean) | null;
+  backendPredicateQuery: Object | null;
   selectedPath: string | null;
   deprecated: boolean;
   columns: TColumn[];
@@ -137,7 +138,11 @@ const DataExplorer: React.FC<{}> = () => {
       pageSize,
       offset,
       orgAndProject,
-      predicate,
+      // NOTE: Right now, the `EXISTS` and `DOES_NOT_EXIST` predicates run on the backend and update the `backendPredicateQuery` parameter.
+      // `CONTAINS` and `DOES_NOT_CONTAIN` predicates on the other hand, only run on frontend and update `frontendPredicate` parameter.
+      // When we implement running all the predicates on backend, we should discard `frontendPredicate` parameter completely.
+      frontendPredicate,
+      backendPredicateQuery,
       types,
       selectedPath,
       deprecated,
@@ -158,7 +163,8 @@ const DataExplorer: React.FC<{}> = () => {
       offset: 0,
       orgAndProject: undefined,
       types: [],
-      predicate: null,
+      frontendPredicate: null,
+      backendPredicateQuery: null,
       selectedPath: null,
       deprecated: false,
       columns: [],
@@ -173,12 +179,13 @@ const DataExplorer: React.FC<{}> = () => {
     deprecated,
     typeOperator,
     types: types?.map(t => t.value),
+    predicateQuery: backendPredicateQuery,
   });
 
   const currentPageDataSource: Resource[] = resources?._results || [];
 
-  const displayedDataSource = predicate
-    ? currentPageDataSource.filter(predicate)
+  const displayedDataSource = frontendPredicate
+    ? currentPageDataSource.filter(frontendPredicate)
     : currentPageDataSource;
 
   const buildColumns = useMemo(() => {
@@ -224,6 +231,7 @@ const DataExplorer: React.FC<{}> = () => {
     updateTableConfiguration({ columns: newColumns });
     updateSelectedColumnsCached(newColumns);
   };
+
   useEffect(() => {
     const selectedFilters = getSelectedFiltersCached();
     if (selectedFilters) {
@@ -286,8 +294,7 @@ const DataExplorer: React.FC<{}> = () => {
     return () => unlisten();
   }, []);
 
-  const shouldShowPredicateSelector =
-    orgAndProject?.length === 2 && types?.length === 1;
+  const shouldShowPredicateSelector = orgAndProject?.length === 2;
 
   return (
     <div className="data-explorer-contents" ref={containerRef}>
@@ -359,7 +366,7 @@ const DataExplorer: React.FC<{}> = () => {
                 onResetCallback={onResetPredicateCallback}
                 org={orgAndProject![0]}
                 project={orgAndProject![1]}
-                types={types!.map(type => type.value)}
+                types={types}
               />
             ) : null}
           </div>
@@ -380,7 +387,9 @@ const DataExplorer: React.FC<{}> = () => {
             types={types}
             nexusTotal={resources?._total ?? 0}
             totalOnPage={resources?._results?.length ?? 0}
-            totalFiltered={predicate ? displayedDataSource.length : undefined}
+            totalFiltered={
+              frontendPredicate ? displayedDataSource.length : undefined
+            }
           />
           <div className="data-explorer-toggles">
             <Switch

--- a/src/subapps/dataExplorer/DataExplorer.tsx
+++ b/src/subapps/dataExplorer/DataExplorer.tsx
@@ -123,6 +123,7 @@ export const columnsFromDataSource = (
     )
     .sort(sortColumns);
 };
+
 const DataExplorer: React.FC<{}> = () => {
   const history = useHistory();
   const [showMetadataColumns, setShowMetadataColumns] = useState(false);

--- a/src/subapps/dataExplorer/styles.less
+++ b/src/subapps/dataExplorer/styles.less
@@ -193,6 +193,20 @@
         width: max-content;
       }
     }
+
+    .flex {
+      display: flex;
+      flex-direction: column;
+      position: relative;
+    }
+
+    .predicate-warning {
+      font-size: 12px;
+      position: absolute;
+      top: 36px;
+      width: max-content;
+      color: #fa8c16;
+    }
   }
 
   .select-menu.greyed-out {


### PR DESCRIPTION
Runs the `EXISTS` and `DOES_NOT_EXIST` predicate on the backend. For now the `CONTAINS` and `DOES_NOT_CONTAIN` predicates only run in the frontend on the 50 resources loaded in the page. When the user selects these predicates a warning is shown.

![Screenshot from 2023-09-11 13-39-59](https://github.com/BlueBrain/nexus-web/assets/11242410/c1e48a62-cad1-480a-84b9-c6c1b07afcbb)

Warning shown when user selects CONTAINS (or DOES_NOT_CONTAIN) predicate.

![Screenshot from 2023-09-11 13-39-47](https://github.com/BlueBrain/nexus-web/assets/11242410/920b8e64-3ba3-479d-aed9-c309e8c8ba2e)

No warning shown when user selects EXISTS (or DOES_NOT_EXIST) predicate
Fixes #4083

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added necessary unit and integration tests.
- [X] I have added screenshots (if applicable), in the comment section.
