### PR TITLE
Hotfix // Fix error when multi fetch is called with 0 resources

### DIFF
--- a/src/subapps/dataExplorer/DataExplorerUtils.tsx
+++ b/src/subapps/dataExplorer/DataExplorerUtils.tsx
@@ -131,10 +131,11 @@ export const fetchMultipleResources = async (
         project: `${org}/${project}`,
       };
     });
-  console.log(
-    'Going to multi fetch',
-    resourceData.map(r => r.id)
-  );
+
+  if (resourceData.length === 0) {
+    return [];
+  }
+
   const multipleResources: NexusMultiFetchResponse = await nexus
     .httpPost({
       path: `${apiEndpoint}/multi-fetch/resources`,


### PR DESCRIPTION
Fixes #
An error is shown to the user when we call multi-fetch api with empty array. (for example, in staging, choose bbp/mouselight project, `Dataset` type, `subject.species.label` path and `does not contain` predicate). 

We can remove this error from being displayed by simply not calling the api if no match was found to the predicate (i.e. when the ES search api returned 0 hits)

![Screenshot from 2023-10-04 13-55-20](https://github.com/BlueBrain/nexus-web/assets/11242410/26c5c361-ac03-406a-a944-da4b85c32fb8)


## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
