### PR TITLE
F4349/id resolution page

### DIFF
--- a/src/pages/IDResolutionPage/IDResolveRedirectionPage.tsx
+++ b/src/pages/IDResolutionPage/IDResolveRedirectionPage.tsx
@@ -43,7 +43,7 @@ const IDResolveRedirectionPage = () => {
 
   const { error, isError, isLoading } = useQuery({
     enabled: isAuthenticated,
-    queryKey: ['resolver', { apiEndpoint, resourceId }],
+    queryKey: ['resource-id-resolver', { apiEndpoint, resourceId }],
     queryFn: () =>
       nexus.httpGet({
         path: `${apiEndpoint}/resolve/${resourceId}`,
@@ -54,7 +54,6 @@ const IDResolveRedirectionPage = () => {
     onSuccess: data => console.log('@@dataResolution', data),
     onError: error => console.log('@@errorResolution', error),
   });
-  console.log('@@isError', isError, error, JSON.stringify(error, null, 2));
 
   const handleReconnection = () => {
     localStorage.removeItem('nexus__state');

--- a/src/pages/IDResolutionPage/IDResolveRedirectionPage.tsx
+++ b/src/pages/IDResolutionPage/IDResolveRedirectionPage.tsx
@@ -1,0 +1,105 @@
+import { CSSProperties } from 'react';
+import { useQuery } from 'react-query';
+import { useSelector } from 'react-redux';
+import { useHistory, useParams } from 'react-router';
+import { useNexusContext } from '@bbp/react-nexus';
+import { Button, Modal } from 'antd';
+import { isEmpty } from 'lodash';
+
+import { RootState } from '../../shared/store/reducers';
+import { ResourceJSONPrettify } from './IDResolvedManyPage';
+
+const modalStyle = {
+  display: 'flex',
+  alignItems: 'flex-start',
+  justifyContent: 'center',
+  flexDirection: 'column',
+} as CSSProperties;
+
+const calloutStyle = {
+  margin: 10,
+  width: '100%',
+  border: '1px solid #c11b1b3b',
+  padding: '4px',
+  borderRadius: '4px',
+  fontSize: 14,
+  fontWeight: 'bold',
+} as CSSProperties;
+
+const IDResolveRedirectionPage = () => {
+  const nexus = useNexusContext();
+  const oidc = useSelector((state: RootState) => state.oidc);
+
+  const { push: navigate } = useHistory();
+  const { apiEndpoint } = useSelector((state: RootState) => state.config);
+  const { resourceId } = useParams<{ resourceId: string }>();
+
+  const token = oidc && oidc.user && !!oidc.user.access_token;
+  const authenticated = !isEmpty(oidc.user);
+  const isAuthenticated = authenticated && token;
+
+  // we should encode it again due oidc returning the url not encoded
+  const redirectUri = `/resolve/${encodeURIComponent(resourceId)}`;
+
+  const { error, isError, isLoading } = useQuery({
+    enabled: isAuthenticated,
+    queryKey: ['resolver', { apiEndpoint, resourceId }],
+    queryFn: () =>
+      nexus.httpGet({
+        path: `${apiEndpoint}/resolve/${resourceId}`,
+        // headers: { Accept: 'text/html' }
+      }),
+    retry: false,
+    refetchOnWindowFocus: false,
+    onSuccess: data => console.log('@@dataResolution', data),
+    onError: error => console.log('@@errorResolution', error),
+  });
+  console.log('@@isError', isError, error, JSON.stringify(error, null, 2));
+
+  const handleReconnection = () => {
+    localStorage.removeItem('nexus__state');
+    navigate(`/login?destination=${redirectUri}`);
+  };
+
+  if (!isLoading && isError) {
+    return (
+      <Modal open centered footer={null} closable={false} closeIcon={null}>
+        <div style={modalStyle}>
+          <h2 style={{ fontWeight: 'bold' }}>Error when resolving ID</h2>
+          <ResourceJSONPrettify
+            showHeader
+            data={error}
+            header={`Resolved ID: ${decodeURIComponent(resourceId)}`}
+          />
+          {(error as any)['@type'] === 'AuthorizationFailed' ? (
+            <p style={calloutStyle}>
+              Do you want to proceed for logout for new realm authentication
+            </p>
+          ) : (
+            <p style={calloutStyle}>
+              The redirection performance is suboptimal; further investigation
+              is required, Please check again
+            </p>
+          )}
+          {(error as any)['@type'] === 'AuthorizationFailed' && (
+            <Button
+              type="primary"
+              style={{ alignSelf: 'flex-end' }}
+              onClick={handleReconnection}
+            >
+              Reconnect
+            </Button>
+          )}
+        </div>
+      </Modal>
+    );
+  }
+
+  if (!isAuthenticated) {
+    navigate(`/login?destination=${redirectUri}`);
+  }
+
+  return null;
+};
+
+export default IDResolveRedirectionPage;

--- a/src/pages/IDResolutionPage/IDResolvedManyPage.tsx
+++ b/src/pages/IDResolutionPage/IDResolvedManyPage.tsx
@@ -1,0 +1,111 @@
+import { useState } from 'react';
+import { Collapse } from 'antd';
+import { isEmpty } from 'lodash';
+import { match } from 'ts-pattern';
+import { useQuery } from 'react-query';
+import { useSelector } from 'react-redux';
+import { useParams } from 'react-router';
+import { useNexusContext } from '@bbp/react-nexus';
+import ReactJson from 'react-json-view';
+
+import { RootState } from '../../shared/store/reducers';
+
+const style = { marginTop: 80 };
+const containerStyle = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '100%',
+  height: '100%',
+  minHeight: '100vh',
+};
+
+export const ResourceJSONPrettify = ({
+  data,
+  showHeader = false,
+  header = '',
+}: {
+  data: any;
+  header?: string;
+  showHeader?: boolean;
+}) => {
+  return (
+    <ReactJson
+      collapsed
+      name={showHeader ? header : undefined}
+      src={data as object}
+      enableClipboard={false}
+      displayObjectSize={false}
+      displayDataTypes={false}
+    />
+  );
+};
+
+const IDResolvedManyPage = () => {
+  const nexus = useNexusContext();
+  const oidc = useSelector((state: RootState) => state.oidc);
+
+  const { apiEndpoint } = useSelector((state: RootState) => state.config);
+  const { resourceId } = useParams<{ resourceId: string }>();
+  const [expandedItem, setExpandedItem] = useState<string | string[]>();
+  const token = oidc && oidc.user && !!oidc.user.access_token;
+  const authenticated = !isEmpty(oidc.user);
+  const isAuthenticated = authenticated && token;
+
+  const { data, error, isLoading: resolving, isSuccess: resolved } = useQuery({
+    retry: false,
+    refetchOnWindowFocus: false,
+    enabled: isAuthenticated,
+    queryKey: ['resolver', { apiEndpoint, resourceId }],
+    queryFn: () =>
+      nexus.httpGet({
+        path: `${apiEndpoint}/resolve/${resourceId}`,
+      }),
+    onSuccess: data => console.log('@@dataResolved', data),
+    onError: error => console.log('@@errorResolved', error),
+  });
+
+  const onChangeKey = (key: string | string[]) => setExpandedItem(key);
+  const decodedId = decodeURIComponent(resourceId);
+
+  return match({ resolving, resolved, error })
+    .with({ resolving: true }, () => {
+      return <div style={style}>Resolving...</div>;
+    })
+    .with({ resolving: false, resolved: true }, () => {
+      if (error) {
+        return (
+          <div style={containerStyle}>
+            <strong style={style}>Temporary resoultion failed</strong>
+            <ResourceJSONPrettify
+              showHeader
+              header={`Error/Resolved ID: ${decodedId}`}
+              data={error}
+            />
+          </div>
+        );
+      }
+      if ('_results' in data && Boolean(data._total)) {
+        return (
+          <div style={containerStyle}>
+            <Collapse onChange={onChangeKey} defaultActiveKey={expandedItem}>
+              {data._results.map((resource: any, index: number) => (
+                <Collapse.Panel header={resource} key={`${decodedId}-${index}`}>
+                  <ResourceJSONPrettify data={data} />
+                </Collapse.Panel>
+              ))}
+            </Collapse>
+          </div>
+        );
+      }
+      return (
+        <div style={containerStyle}>
+          <strong style={style}>Temporary resoultion page</strong>
+          <ResourceJSONPrettify showHeader data={data} />
+        </div>
+      );
+    })
+    .otherwise(() => <></>);
+};
+
+export default IDResolvedManyPage;

--- a/src/pages/IDResolutionPage/IDResolvedManyPage.tsx
+++ b/src/pages/IDResolutionPage/IDResolvedManyPage.tsx
@@ -87,7 +87,8 @@ const IDResolvedManyPage = () => {
       }
       if (data._total === 0) {
         return <div style={containerStyle}>No result found</div>;
-      } else if ('_results' in data && Boolean(data._total)) {
+      }
+      if ('_results' in data && Boolean(data._total)) {
         return (
           <div style={containerStyle}>
             <Collapse onChange={onChangeKey} defaultActiveKey={expandedItem}>

--- a/src/pages/IDResolutionPage/IDResolvedManyPage.tsx
+++ b/src/pages/IDResolutionPage/IDResolvedManyPage.tsx
@@ -85,7 +85,9 @@ const IDResolvedManyPage = () => {
           </div>
         );
       }
-      if ('_results' in data && Boolean(data._total)) {
+      if (data._total === 0) {
+        return <div style={containerStyle}>No result found</div>;
+      } else if ('_results' in data && Boolean(data._total)) {
         return (
           <div style={containerStyle}>
             <Collapse onChange={onChangeKey} defaultActiveKey={expandedItem}>

--- a/src/pages/IDResolutionPage/index.ts
+++ b/src/pages/IDResolutionPage/index.ts
@@ -1,0 +1,2 @@
+export { default as IDResolveRedirectionPage } from './IDResolveRedirectionPage';
+export { default as IDResolvedManyPage } from './IDResolvedManyPage';

--- a/src/shared/routes.ts
+++ b/src/shared/routes.ts
@@ -8,6 +8,10 @@ import StudioRedirectView from './views/StudioRedirectView';
 import MyDataPage from '../pages/MyDataPage/MyDataPage';
 import DataExplorerGraphFlowPage from '../pages/DataExplorerGraphFlowPage/DataExplorerGraphFlowPage';
 import DataExplorerPage from '../pages/DataExplorerPage/DataExplorerPage';
+import {
+  IDResolveRedirectionPage,
+  IDResolvedManyPage,
+} from '../pages/IDResolutionPage';
 
 type TRoutePropsExtended = RouteProps & { protected: boolean };
 
@@ -32,6 +36,18 @@ const routes: TRoutePropsExtended[] = [
   {
     path: '/projects',
     component: ProjectsPage,
+    exact: true,
+    protected: true,
+  },
+  {
+    path: '/resolve/:resourceId',
+    component: IDResolveRedirectionPage,
+    exact: true,
+    protected: true,
+  },
+  {
+    path: '/resolved/:resourceId',
+    component: IDResolvedManyPage,
     exact: true,
     protected: true,
   },

--- a/src/shared/store/actions/auth.ts
+++ b/src/shared/store/actions/auth.ts
@@ -146,10 +146,14 @@ function performLogin(state: TLocationState) {
     try {
       // default Redirect is home page so to avoid double slash '//' in the route (may it be temporary solution)
       // use baseURl instead of window location to get the real location
-      const redirectUri =
-        state.from && state.from !== '/'
-          ? `${window.location.origin}/${baseURl}${state.from}${state.searchQuery}`
-          : undefined;
+      const destination = new URL(window.location.href).searchParams.get(
+        'destination'
+      );
+
+      const redirectUri = destination
+        ? `${window.location.origin}/${destination}`
+        : null;
+
       userManager &&
         (await userManager.signinRedirect({
           redirect_uri: redirectUri,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #https://github.com/BlueBrain/nexus/issues/4349

### Test scenarios: 
> **NOTE:** It may be hard to really test the redirection due `http header redirect (30x)`  will not work due `CORS` issue between Delta and localhost

**1. User has access to the resource, user is authenticated, and the resolution result is one single resource**
-  User access `{fusionBaseUrl}/resolve/{encodedResourceId}`.
-  The user will be redirected to the resource page.

**2. User has access to the resource, the user is not authenticated, and the the resolution result is one single resource**
-  User access `{fusionBaseUrl}/resolve/{encodedResourceId}`.
-  The user will be redirected to the login page.
-  If the user successfully authenticated will be redirected to the resource page.

**3. User has not access to the resource**
-  User access `{fusionBaseUrl}/resolve/{encodedResourceId}`.
- A modal will be opened to the user to ask him to logout and choose another realm

**4. User has access to the resource, and the resolution result is `NoneOrMany` resources**
> _(Note: This is part not yet can be tested due Delta not support it at this moment)_
> _(Note: The design may change in the future, the current one just for test)_
- User access `{fusionBaseUrl}/resolve/{encodedResourceId}`.
- The user will be redirected to the login page if not authenticated.
- If the user successfully authenticated will be redirected to the `/resolved/{encodedResourceId}`.
- If empty result -> A simple message 'No result found'
- If Many resources has been resolved, A collapsible Item with different resources 





## Description

<!--- Describe your changes in detail -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
