### PR TITLE
fix: use replace to redirect

### DIFF
--- a/src/pages/IDResolutionPage/IDResolveRedirectionPage.tsx
+++ b/src/pages/IDResolutionPage/IDResolveRedirectionPage.tsx
@@ -34,6 +34,7 @@ const IDResolveRedirectionPage = () => {
   // we should encode it again due oidc returning the url not encoded
   const redirectUri = `${basePath}/resolve/${encodeURIComponent(resourceId)}`;
 
+  const ACInstance = new AbortController();
   useEffect(() => {
     if (resourceId && apiEndpoint) {
       (async () => {
@@ -43,18 +44,18 @@ const IDResolveRedirectionPage = () => {
             Authorization: `Bearer ${localStorage.getItem('nexus__token')}`,
           },
           redirect: 'manual',
+          signal: ACInstance.signal,
         })
           .then(res => {
-            setResolutionError(prev => ({ ...prev, isError: false }));
-            if (res.redirected) {
-              window.location.href = res.url;
-            }
+            window.location.replace(res.url);
           })
           .catch(error => {
             setResolutionError({ error, isError: true });
+            ACInstance.abort();
           });
       })();
     }
+    return () => ACInstance.abort();
   }, [apiEndpoint, resourceId]);
 
   const handleReconnection = () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

the fetch specification mentioned that when redirection happening we should get `redirected: true` but i actually not the case for us, so removing the check and using `replace` in the history navigation fix the issue

## Description

<!--- Describe your changes in detail -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
