### PR TITLE
Fix: CodeEditor duplication in Dev mode

### DIFF
--- a/src/shared/components/ResourceEditor/CodeEditor.tsx
+++ b/src/shared/components/ResourceEditor/CodeEditor.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useRef } from 'react';
 import { EditorConfiguration } from 'codemirror';
 import { UnControlled as CodeMirror } from 'react-codemirror2';
 import { INDENT_UNIT, highlightUrlOverlay } from './editorUtils';
@@ -24,6 +24,7 @@ type TEditorConfiguration = EditorConfiguration & {
 
 const CodeEditor = forwardRef<CodeMirror.Editor | undefined, TCodeEditor>(
   ({ busy, value, editable, fullscreen, keyFoldCode, handleChange }, ref) => {
+    const wrapperRef = useRef(null);
     return (
       <Spin spinning={busy}>
         <CodeMirror
@@ -53,10 +54,19 @@ const CodeEditor = forwardRef<CodeMirror.Editor | undefined, TCodeEditor>(
             'code-mirror-editor',
             fullscreen && 'full-screen-mode'
           )}
+          ref={wrapperRef}
           onChange={handleChange}
           editorDidMount={editor => {
             highlightUrlOverlay(editor);
             (ref as React.MutableRefObject<CodeMirror.Editor>).current = editor;
+          }}
+          editorWillUnmount={() => {
+            const editor = (ref as React.MutableRefObject<
+              CodeMirror.Editor
+            >).current.getWrapperElement();
+            if (editor) editor.remove();
+            if (wrapperRef.current)
+              (wrapperRef.current as { hydrated: boolean }).hydrated = false;
           }}
         />
       </Spin>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Code editor is render twice in develop mode due react 18 state restoration feature
In Build version everything will work just fine

## Description

<!--- Describe your changes in detail -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
