### PR TITLE
fix: query fail when query string is not defined by the user

### DIFF
--- a/src/shared/containers/ResourceListContainer.tsx
+++ b/src/shared/containers/ResourceListContainer.tsx
@@ -1,11 +1,8 @@
 import * as React from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 import { useNexusContext } from '@bbp/react-nexus';
-import {
-  DEFAULT_ELASTIC_SEARCH_VIEW_ID,
-  ElasticSearchViewQueryResponse,
-  Resource,
-} from '@bbp/nexus-sdk';
+import { DEFAULT_ELASTIC_SEARCH_VIEW_ID, Resource } from '@bbp/nexus-sdk';
+import { isEmpty } from 'lodash';
 
 import ResourceListComponent, {
   ResourceBoardList,
@@ -152,7 +149,7 @@ const ResourceListContainer: React.FunctionComponent<{
                             '@id': list.query.q,
                           },
                         },
-                      ],
+                      ].filter(query => !isEmpty(query)),
                     },
                   },
                   {
@@ -168,7 +165,7 @@ const ResourceListContainer: React.FunctionComponent<{
                             _self: list.query.q,
                           },
                         },
-                      ],
+                      ].filter(query => !isEmpty(query)),
                     },
                   },
                 ],


### PR DESCRIPTION
when the  query of the resource is not present the _Search query will fail 
so not include the `'@id': list.query.q` nor `'_self': list.query.q` in the ES query 

<!--- Provide a general summary of your changes in the Title above -->


## Description

<!--- Describe your changes in detail -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
