### PR TITLE
Fail test to check slack notification

### DIFF
--- a/cypress/e2e/PublicStudios.cy.ts
+++ b/cypress/e2e/PublicStudios.cy.ts
@@ -30,7 +30,7 @@ describe('Public Studios', () => {
       cy.get('table').scrollIntoView(); // Scrolling the table into view triggers the request to fetch rows for the table.
 
       cy.wait('@studioQueryResult', { timeout: 30000 }).then(interception => {
-        expect(interception.response.statusCode).to.equal(200);
+        expect(interception.response.statusCode).to.equal(300);
         expect(interception.response.body.head.vars.length).to.be.equal(
           publicStudio.defaultDashboardColumnsCount
         );


### PR DESCRIPTION
I am purposefully making a test fail so that the github action triggers a slack notification job (which is only triggered in case of failures). [HERE](https://github.com/BlueBrain/nexus-web/blob/main/.github/workflows/monitor-studios.yml#L27)

Fixes #

## Description

<!--- Describe your changes in detail -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
