### PR TITLE
Improve slack notification for public studios cron job

### DIFF
--- a/.github/workflows/monitor-studios.yml
+++ b/.github/workflows/monitor-studios.yml
@@ -23,7 +23,7 @@ jobs:
       - name: run cypress tests
         id: e2eTests
         run: |
-          yarn cy:publicstudios
+          export CYPRESS_RECORD_KEY=${{ secrets.CYPRESS_RECORD_KEY }}; yarn cy:publicstudios
       - name: Send error notification
         id: slack
         if: ${{ failure() && steps.e2eTests.conclusion == 'failure' }}

--- a/.github/workflows/monitor-studios.yml
+++ b/.github/workflows/monitor-studios.yml
@@ -45,6 +45,7 @@ jobs:
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
       - name: Cleanup Docker Containers
         if: ${{ always() }}
         run: docker-compose -f ci/docker-compose.yml down --rmi "local" --volumes

--- a/cypress-public-studios.config.ts
+++ b/cypress-public-studios.config.ts
@@ -1,7 +1,6 @@
 const { defineConfig } = require('cypress');
 
 module.exports = defineConfig({
-  projectId: '1iihco',
   e2e: {
     video: true,
     screenshotOnRunFailure: false,

--- a/cypress-public-studios.config.ts
+++ b/cypress-public-studios.config.ts
@@ -1,6 +1,7 @@
 const { defineConfig } = require('cypress');
 
 module.exports = defineConfig({
+  projectId: '1iihco',
   e2e: {
     video: true,
     screenshotOnRunFailure: false,

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "cy:open": "cypress open",
     "cy:run": "cypress run",
     "cy:ci": "echo | sudo docker exec --user=$UID -t cypress cypress run --config-file cypress.config.ts --browser chrome",
-    "cy:publicstudios": "echo | cypress run --config-file cypress-public-studios.config.ts --browser chrome --spec \"cypress/e2e/PublicStudios.cy.ts\"",
+    "cy:publicstudios": "echo | cypress run --config-file cypress-public-studios.config.ts --browser chrome --record --spec \"cypress/e2e/PublicStudios.cy.ts\"",
     "test-ui": "API_ENDPOINT=http://test start-server-and-test start http://localhost:8000 cy:run",
     "codecov": "codecov",
     "lint": "tslint --project tsconfig.json",


### PR DESCRIPTION
According to [this solution to the issue](https://github.com/slackapi/slack-github-action/issues/261#issuecomment-1836435861) on the github repo of the plugin we use for slack-github notificate, the blocks sub field can be ignored if the `SLACK_WEBHOOK_TYPE` environment variable is not set. 
In this PR I also (try to) enable the uploading of recorded cypress video to the cypress cloud.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
