### PR TITLE
fix: remove duplicated tag resource button

### DIFF
--- a/src/shared/containers/ResourceViewActionsContainer.tsx
+++ b/src/shared/containers/ResourceViewActionsContainer.tsx
@@ -453,62 +453,6 @@ const ResourceViewActionsContainer: React.FC<{
           <Button>Tag Resource</Button>
         </Popover>
       </Col>
-      <Col>
-        <Popover
-          destroyTooltipOnHide
-          showArrow={false}
-          key={resource._rev}
-          trigger={['click']}
-          title={
-            <div>
-              <div style={{ fontSize: 16 }}>Tag Resource</div>
-              <i style={{ fontSize: 12 }}>
-                The tag will be applied to revision{' '}
-                <strong>{resource._rev}</strong>
-              </i>
-            </div>
-          }
-          content={
-            <Form<{ tag: string }>
-              autoComplete="off"
-              name="tag-resource-form"
-              initialValues={{ tag: '' }}
-              onFinish={handleTagResource}
-              style={{ width: 300, padding: '8px 8px O' }}
-            >
-              <Form.Item
-                name="tag"
-                rules={[
-                  {
-                    required: true,
-                    whitespace: true,
-                    pattern: /^\S+$/g,
-                    message: 'Tag must not contains spaces',
-                  },
-                  {
-                    pattern: /^[a-zA-Z0-9_-]+$/,
-                    message:
-                      'Tag should include only letters, numbers, underscores, and dashes.',
-                  },
-                ]}
-                style={{ marginBottom: 8 }}
-              >
-                <Input placeholder="Resource tag" style={{ width: '100%' }} />
-              </Form.Item>
-              <Form.Item
-                wrapperCol={{ offset: 8, span: 8 }}
-                style={{ marginBottom: 0 }}
-              >
-                <Button type="primary" htmlType="submit">
-                  Confirm
-                </Button>
-              </Form.Item>
-            </Form>
-          }
-        >
-          <Button>Tag Resource</Button>
-        </Popover>
-      </Col>
       {view && (
         <Col>
           <Link to={redirectToQueryTab()}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Double Tag resource Button 
<img width="705" alt="Screenshot 2024-01-09 at 16 50 18" src="https://github.com/BlueBrain/nexus-web/assets/2632473/cdcf75b4-ec53-41d5-94a7-7732a0371f74">

## Description

<!--- Describe your changes in detail -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
