### PR TITLE
Undeprecate other resource types (`schemas`, `views` and `storages`)

### DIFF
--- a/src/shared/containers/ResourceViewContainer.tsx
+++ b/src/shared/containers/ResourceViewContainer.tsx
@@ -78,10 +78,10 @@ function constructUnDeprecateUrl(
     Schema: 'schemas',
   };
 
-  const determineResourcePathSegment = (types: string | string[]): string => {
-    if (!Array.isArray(types)) {
-      types = [types];
-    }
+  const determineResourcePathSegment = (
+    inputTypes: string | string[]
+  ): string => {
+    const types = Array.isArray(inputTypes) ? inputTypes : [inputTypes];
 
     // Check each type and select the most specific one that has a mapping
     for (const type of types) {

--- a/src/shared/containers/ResourceViewContainer.tsx
+++ b/src/shared/containers/ResourceViewContainer.tsx
@@ -68,6 +68,7 @@ function constructUnDeprecateUrl(
   orgLabel: string,
   projectLabel: string
 ) {
+  // TODO Make this function more generic
   return `${apiEndpoint}/${
     resource!['@type']?.includes('File')
       ? 'files'
@@ -801,6 +802,7 @@ const ResourceViewContainer: FC<{
                                       marginBottom: '5px',
                                     }}
                                     onClick={() => {
+                                      // TODO Component doesn't reload after undoing deprecation when on side-panel view
                                       unDeprecateResource();
                                     }}
                                   >

--- a/src/shared/containers/ResourceViewContainer.tsx
+++ b/src/shared/containers/ResourceViewContainer.tsx
@@ -69,9 +69,16 @@ function constructUnDeprecateUrl(
   projectLabel: string
 ) {
   return `${apiEndpoint}/${
-    resource!['@type'] === 'File' ? 'files' : 'resources'
+    resource!['@type']?.includes('File')
+      ? 'files'
+      : resource!['@type']?.includes('Storage')
+      ? 'storages'
+      : 'resources'
   }/${orgLabel}/${projectLabel}/${
-    resource!['@type'] === 'File' ? '' : '_/'
+    resource!['@type']?.includes('Storage') ||
+    resource!['@type']?.includes('File')
+      ? ''
+      : '_/'
   }${encodeURIComponent(resource!['@id'])}/undeprecate?rev=${
     latestResource!._rev
   }`;

--- a/src/shared/containers/ResourceViewContainer.tsx
+++ b/src/shared/containers/ResourceViewContainer.tsx
@@ -73,10 +73,16 @@ function constructUnDeprecateUrl(
       ? 'files'
       : resource!['@type']?.includes('Storage')
       ? 'storages'
+      : resource!['@type']?.includes('View')
+      ? 'views'
+      : resource!['@type']?.includes('Schema')
+      ? 'schemas'
       : 'resources'
   }/${orgLabel}/${projectLabel}/${
     resource!['@type']?.includes('Storage') ||
-    resource!['@type']?.includes('File')
+    resource!['@type']?.includes('File') ||
+    resource!['@type']?.includes('View') ||
+    resource!['@type']?.includes('Schema')
       ? ''
       : '_/'
   }${encodeURIComponent(resource!['@id'])}/undeprecate?rev=${

--- a/src/shared/containers/ResourceViewContainer.tsx
+++ b/src/shared/containers/ResourceViewContainer.tsx
@@ -772,9 +772,7 @@ const ResourceViewContainer: FC<{
                             {// Don't show the undo deprecated button if the resource is
                             // of any unsupported resource. However, it needs to be shown
                             // e.g. for custom types of resources.
-                            !resource['@type']?.includes(
-                              'View' || 'Resolver' || 'Storage' || 'Schema'
-                            ) ? (
+                            !resource['@type']?.includes('Resolver') ? (
                               <>
                                 <br />
                                 {// If not newest revision, then don't show the button

--- a/src/shared/containers/ResourceViewContainer.tsx
+++ b/src/shared/containers/ResourceViewContainer.tsx
@@ -777,9 +777,13 @@ const ResourceViewContainer: FC<{
                             <DeleteOutlined /> This resource is deprecated and
                             not modifiable.
                             {// Don't show the undo deprecated button if the resource is
-                            // of any unsupported resource. However, it needs to be shown
-                            // e.g. for custom types of resources.
-                            !resource['@type']?.includes('Resolver') ? (
+                            // of any unsupported resource (e.g. Resolver). However, it needs
+                            // to be shown e.g. for custom types of resources.
+                            !resource['@type']?.includes(
+                              'Resolver' ||
+                                'AggregateElasticSearchView' ||
+                                'AggregateSparqlView'
+                            ) ? (
                               <>
                                 <br />
                                 {// If not newest revision, then don't show the button
@@ -791,7 +795,6 @@ const ResourceViewContainer: FC<{
                                       marginBottom: '5px',
                                     }}
                                     onClick={() => {
-                                      // TODO Shows the button correctly, but the undoing of the deprecation doesn't work
                                       unDeprecateResource();
                                     }}
                                   >

--- a/src/shared/containers/ResourceViewContainer.tsx
+++ b/src/shared/containers/ResourceViewContainer.tsx
@@ -784,6 +784,7 @@ const ResourceViewContainer: FC<{
                                       marginBottom: '5px',
                                     }}
                                     onClick={() => {
+                                      // TODO Shows the button correctly, but the undoing of the deprecation doesn't work
                                       unDeprecateResource();
                                     }}
                                   >

--- a/src/shared/containers/ResourceViewContainer.tsx
+++ b/src/shared/containers/ResourceViewContainer.tsx
@@ -95,12 +95,10 @@ function constructUnDeprecateUrl(
   const primaryResourceType = resource['@type'] || '';
   const resourcePathSegment = determineResourcePathSegment(primaryResourceType);
   const slashPrefix = Array.isArray(primaryResourceType)
-    ? primaryResourceType.some(type =>
-        Object.keys(typePathMapping).includes(type)
-      )
+    ? primaryResourceType.some(type => type in typePathMapping)
       ? ''
       : '_/'
-    : Object.keys(typePathMapping).includes(primaryResourceType)
+    : primaryResourceType in typePathMapping
     ? ''
     : '_/';
 

--- a/src/shared/containers/ResourceViewContainer.tsx
+++ b/src/shared/containers/ResourceViewContainer.tsx
@@ -83,7 +83,6 @@ function constructUnDeprecateUrl(
   ): string => {
     const types = Array.isArray(inputTypes) ? inputTypes : [inputTypes];
 
-    // Check each type and select the most specific one that has a mapping
     for (const type of types) {
       if (type in typePathMapping) {
         return typePathMapping[type];


### PR DESCRIPTION
Fixes [#4586](https://github.com/BlueBrain/nexus/issues/4586)

This PR enables undoing the deprecation of other resource types: schemas, views and storages. `Views` also means types such as `SparqlView`, `CompositeView,` and `ElasticSearchView`.

## Description

- Removed the part that hid the "undo deprecation" button from unsupported but now supported types.
- Extended the function that constructs the undeprecation endpoint.

## How has this been tested?

- Tested the undeprecation of various types of resources via the local dev server and prod build. 

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

