### PR TITLE
update: table ref is not the same as v4

### DIFF
--- a/src/subapps/dataExplorer/DataExplorer.tsx
+++ b/src/subapps/dataExplorer/DataExplorer.tsx
@@ -5,12 +5,11 @@ import { useHistory } from 'react-router';
 import { matchPath } from 'react-router-dom';
 import { Spin, Switch } from 'antd';
 import { find, merge, unionWith } from 'lodash';
-import { DataExplorerTable } from './DataExplorerTable';
+import { AntdTableRef, DataExplorerTable } from './DataExplorerTable';
 import {
   columnFromPath,
   isUserColumn,
   sortColumns,
-  useGraphAnalyticsPath,
   usePaginatedExpandedResources,
 } from './DataExplorerUtils';
 import {
@@ -130,7 +129,7 @@ const DataExplorer: React.FC<{}> = () => {
   const [showEmptyDataCells, setShowEmptyDataCells] = useState(true);
   const [headerHeight, setHeaderHeight] = useState<number>(0);
   const containerRef = useRef<HTMLDivElement>(null);
-  const tableRef = useRef<HTMLDivElement>(null);
+  const tableRef = useRef<AntdTableRef>(null);
   const [typeFilterFocused, setTypeFilterFocused] = useState(false);
   const handleTypeFilterFocused = (open: boolean) => setTypeFilterFocused(open);
 

--- a/src/subapps/dataExplorer/DataExplorerTable.tsx
+++ b/src/subapps/dataExplorer/DataExplorerTable.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useReducer, forwardRef } from 'react';
+import React, { useEffect, useReducer, forwardRef, ElementRef } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 import { Resource } from '@bbp/nexus-sdk/es';
 import { Empty, Table, Tooltip } from 'antd';
@@ -53,9 +53,10 @@ type TDateExplorerTableData = {
   selectedRows: TDataSource[];
 };
 
+export type AntdTableRef = ElementRef<typeof Table>;
 type TColumnNameToConfig = Map<string, ColumnType<Resource>>;
 const DATA_EXPLORER_NAMESPACE = 'data-explorer';
-export const DataExplorerTable = forwardRef<HTMLDivElement, TDataExplorerTable>(
+export const DataExplorerTable = forwardRef<AntdTableRef, TDataExplorerTable>(
   (
     {
       isLoading,

--- a/src/subapps/dataExplorer/DateExplorerScrollArrows.tsx
+++ b/src/subapps/dataExplorer/DateExplorerScrollArrows.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useReducer, useRef } from 'react';
+import { useEffect, useReducer } from 'react';
+import { clsx } from 'clsx';
 import RightSpeedArrow, {
   RightArrow,
 } from '../../shared/components/Icons/RightSpeedArrow';
@@ -6,7 +7,7 @@ import LeftSpeedArrow, {
   LeftArrow,
 } from '../../shared/components/Icons/LeftSpeedArrow';
 import { TType } from '../../shared/molecules/TypeSelector/types';
-import { clsx } from 'clsx';
+import { AntdTableRef } from './DataExplorerTable';
 
 type TArrowsDisplay = {
   returnToStart: boolean;
@@ -22,7 +23,7 @@ type TArrowsDisplay = {
 type TDateExplorerScrollArrowsProps = {
   isLoading: boolean;
   container: HTMLDivElement | null;
-  table: HTMLDivElement | null;
+  table: AntdTableRef | null;
   orgAndProject: [string, string] | undefined;
   types: TType[] | undefined;
   showEmptyDataCells: boolean;
@@ -64,7 +65,7 @@ const DateExplorerScrollArrows = ({
     window.scrollTo({ left: 0, behavior: 'smooth' });
   };
   const onRightArrowClick = () => {
-    const tableRect = table?.getBoundingClientRect();
+    const tableRect = table?.nativeElement.getBoundingClientRect();
     const tableWidth = tableRect?.width || 0;
     window.scrollTo({ left: tableWidth, behavior: 'smooth' });
   };
@@ -95,7 +96,7 @@ const DateExplorerScrollArrows = ({
   useEffect(() => {
     const onScroll = (ev?: Event) => {
       const containerRect = container?.getBoundingClientRect();
-      const tableRect = table?.getBoundingClientRect();
+      const tableRect = table?.nativeElement.getBoundingClientRect();
       const x = containerRect?.x || 0;
       const width = containerRect?.width || 0;
       const tableWidth = tableRect?.width || 0;
@@ -136,7 +137,7 @@ const DateExplorerScrollArrows = ({
     });
   }, [orgAndProject, types, showEmptyDataCells, showMetadataColumns]);
 
-  const tableRect = table?.getBoundingClientRect();
+  const tableRect = table?.nativeElement.getBoundingClientRect();
   const hideRightArrows = tableRect
     ? tableRect.width + tableRect.x - window.innerWidth < 60
     : false;

--- a/src/subapps/dataExplorer/styles.scss
+++ b/src/subapps/dataExplorer/styles.scss
@@ -270,6 +270,10 @@
   }
 }
 
+td.ant-table-cell.data-explorer-column {
+  box-sizing: content-box !important;
+}
+
 .data-explorer-table {
   margin-bottom: 60px;
 
@@ -292,8 +296,8 @@
     color: #8c8c8c;
     height: 52px;
     min-width: 72px;
-    width: 100%;
     max-width: fit-content;
+    box-sizing: content-box !important;
   }
 
   .ant-table-thead > tr > th::before {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Apparently the last version of ANTD is not passing the table container element which is `div` as `ref`, so it breaks some use of it, I change the type of the ref using `ElementRef<typeof Table>` that contains `{ nativeElemet, scrollTo }` 
everything else stay the same, also fixed some style regression which is not perfect too but will create another ticket 

## Description

<!--- Describe your changes in detail -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
