### PR TITLE
F4643 project query tab style

### DIFF
--- a/src/pages/ProjectPage/ProjectPage.tsx
+++ b/src/pages/ProjectPage/ProjectPage.tsx
@@ -264,6 +264,7 @@ const ProjectView: React.FunctionComponent = () => {
           )}
           <div className="tabs-container">
             <Tabs
+              className="project-tabs"
               onChange={handleTabChange}
               activeKey={activeKey}
               items={[

--- a/src/pages/ProjectPage/styles.scss
+++ b/src/pages/ProjectPage/styles.scss
@@ -7,6 +7,11 @@
   }
 
   .tabs-container {
+    .project-tabs {
+      .ant-tabs-nav {
+        padding: 0 1rem;
+      }
+    }
     .ant-tabs-top > .ant-tabs-nav {
       margin: 0 !important;
     }
@@ -17,7 +22,6 @@
     }
 
     .ant-tabs-nav {
-      padding: 0 1rem;
       box-shadow: 0 4px 6px -1px #0000001a, 0 2px 4px -2px #0000001a;
       z-index: 10;
 

--- a/src/subapps/admin/components/Projects/QueryEditor.scss
+++ b/src/subapps/admin/components/Projects/QueryEditor.scss
@@ -3,3 +3,18 @@
     flex-grow: 1;
   }
 }
+
+.query-editor__header {
+  padding: 1.5rem 0;
+  h3 {
+    font-size: 1.25rem;
+    font-weight: bold;
+    margin-bottom: .25rem;
+  }
+}
+
+.query-tabs {
+  .ant-tabs-nav {
+    padding: 0 !important;
+  }
+}

--- a/src/subapps/admin/components/Projects/QueryEditor.tsx
+++ b/src/subapps/admin/components/Projects/QueryEditor.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useEffect, useState } from 'react';
 import { Tabs } from 'antd';
 import { useHistory, useRouteMatch } from 'react-router';
 import {
@@ -16,7 +16,7 @@ const QueryEditor: React.FC<{
   orgLabel: string;
   projectLabel: string;
   onUpdate: () => void;
-}> = ({ orgLabel, projectLabel, onUpdate }) => {
+}> = ({ orgLabel, projectLabel }) => {
   const subapp = useOrganisationsSubappContext();
   const history = useHistory();
   const match = useRouteMatch<{
@@ -26,10 +26,10 @@ const QueryEditor: React.FC<{
   }>();
   const nexus = useNexusContext();
   const notification = useNotification();
-  const [activeKey, setActiveKey] = React.useState('sparql');
-  const [loading, setLoading] = React.useState(true);
+  const [activeKey, setActiveKey] = useState('sparql');
+  const [loading, setLoading] = useState(true);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (match.params.viewId) {
       nexus.View.get(orgLabel, projectLabel, match.params.viewId)
         .then(result => {
@@ -65,12 +65,15 @@ const QueryEditor: React.FC<{
   }
   return (
     <div className="query-editor">
-      <h3>Query Browser</h3>
-      <p>
-        View resources in your project using pre-defined query-helper lists.
-      </p>
+      <div className="query-editor__header">
+        <h3>Query Browser</h3>
+        <p>
+          View resources in your project using pre-defined query-helper lists.
+        </p>
+      </div>
       <div className="project-menu__controls">
         <Tabs
+          className="query-tabs"
           onChange={tab => {
             setActiveKey(tab);
             history.replace(

--- a/src/subapps/admin/components/ViewForm/ElasticSearchQueryForm.tsx
+++ b/src/subapps/admin/components/ViewForm/ElasticSearchQueryForm.tsx
@@ -115,7 +115,9 @@ const ElasticSearchQueryForm: React.FunctionComponent<{
             }}
             onChange={handleChange}
             editorDidMount={editorElement => {
-              (editor as React.MutableRefObject<codemirror.Editor>).current = editorElement;
+              (editor as React.MutableRefObject<
+                codemirror.Editor
+              >).current = editorElement;
             }}
             editorWillUnmount={() => {
               const editorWrapper = (editor as React.MutableRefObject<

--- a/src/subapps/admin/components/ViewForm/ElasticSearchQueryForm.tsx
+++ b/src/subapps/admin/components/ViewForm/ElasticSearchQueryForm.tsx
@@ -20,7 +20,7 @@ const ListItem = List.Item;
  *
  * In the case of ES, the reason message is nested within an error object
  */
-type NexusESError = {
+export type NexusESError = {
   reason?: string;
   error?: {
     reason?: string;
@@ -30,7 +30,7 @@ type NexusESError = {
 // TODO this needs to be broken into Input, Result, and Form components.
 const ElasticSearchQueryForm: React.FunctionComponent<{
   query: object;
-  response: ElasticSearchViewQueryResponse<any> | null;
+  response?: ElasticSearchViewQueryResponse<any> | null;
   busy: boolean;
   error: NexusESError | null;
   from: number;
@@ -159,7 +159,7 @@ const ElasticSearchQueryForm: React.FunctionComponent<{
               current,
               pageSize,
               onChange: onPaginationChange,
-              position: 'both',
+              position: 'bottom',
               showSizeChanger: true,
               onShowSizeChange: changePageSize,
             }}
@@ -167,11 +167,13 @@ const ElasticSearchQueryForm: React.FunctionComponent<{
               <ListItem>
                 {(result && (
                   <ReactJson
+                    collapsed
                     src={result}
                     name={null}
                     enableClipboard={false}
                     displayObjectSize={false}
                     displayDataTypes={false}
+                    style={{ width: '100%' }}
                   />
                 )) ||
                   ''}

--- a/src/subapps/admin/components/ViewForm/SparqlQueryForm.tsx
+++ b/src/subapps/admin/components/ViewForm/SparqlQueryForm.tsx
@@ -1,5 +1,4 @@
-import { FC, useState } from 'react';
-import { Button } from 'antd';
+import { FC } from 'react';
 import { SparqlViewQueryResponse } from '@bbp/nexus-sdk/es';
 
 import SparqlQueryResults, { NexusSparqlError } from './SparqlQueryResults';
@@ -9,11 +8,11 @@ import './view-form.scss';
 
 const SparqlQueryForm: FC<{
   query: string;
-  response: SparqlViewQueryResponse | null;
+  response?: SparqlViewQueryResponse | null;
   busy: boolean;
   error: NexusSparqlError | null;
   resultsComponent?(props: {
-    response: SparqlViewQueryResponse | null;
+    response?: SparqlViewQueryResponse | null;
     busy: boolean;
     error: NexusSparqlError | null;
   }): React.ReactElement;
@@ -26,20 +25,9 @@ const SparqlQueryForm: FC<{
   onQueryChange,
   resultsComponent = SparqlQueryResults,
 }): JSX.Element => {
-  const [input, setInput] = useState<string>(query);
-  const onChange = (text: string) => setInput(text);
-
   return (
     <div className="view-form">
-      <SparqlQueryInput value={input} onChange={onChange} />
-      <Button
-        type="primary"
-        onClick={() => {
-          onQueryChange(input);
-        }}
-      >
-        Execute SPARQL query
-      </Button>
+      <SparqlQueryInput value={query} onChange={onQueryChange} />
       {resultsComponent({ error, busy, response })}
     </div>
   );

--- a/src/subapps/admin/components/ViewForm/SparqlQueryResults.tsx
+++ b/src/subapps/admin/components/ViewForm/SparqlQueryResults.tsx
@@ -1,17 +1,17 @@
 import { Card, Table, Tooltip } from 'antd';
 import Column from 'antd/lib/table/Column';
 import hash from 'object-hash';
-import { matchResultUrls } from '../../../../shared/utils';
 import {
   AskQueryResponse,
   SelectQueryResponse,
   SparqlViewQueryResponse,
 } from '@bbp/nexus-sdk/es';
 
+import { matchResultUrls } from 'shared/utils';
+import useNotification from 'shared/hooks/useNotification';
+import { ErrorComponent } from 'shared/components/ErrorComponent';
+import { TError } from 'utils/types';
 import './view-form.scss';
-import useNotification from '../../../../shared/hooks/useNotification';
-import { ErrorComponent } from '../../../../shared/components/ErrorComponent';
-import { TError } from '../../../../utils/types';
 
 export type NexusSparqlError =
   | string
@@ -28,7 +28,7 @@ export type Entry = {
 };
 
 const SparqlQueryResults: React.FunctionComponent<{
-  response: SparqlViewQueryResponse | null;
+  response?: SparqlViewQueryResponse | null;
   busy: boolean;
   error: NexusSparqlError | null;
 }> = ({ response, busy, error }): JSX.Element => {
@@ -72,7 +72,7 @@ const SparqlQueryResults: React.FunctionComponent<{
       {!error && (
         <Table
           dataSource={data}
-          pagination={{ position: ['topLeft', 'bottomRight'] }}
+          pagination={{ position: ['bottomRight'] }}
           rowKey={record => hash(record)}
           loading={busy}
         >

--- a/src/subapps/admin/components/ViewForm/SparqlQueryResults.tsx
+++ b/src/subapps/admin/components/ViewForm/SparqlQueryResults.tsx
@@ -86,7 +86,7 @@ const SparqlQueryResults: React.FunctionComponent<{
                   return <span className="empty">no value</span>;
                 }
 
-                // TODO: Improve sparql repsonse types visuall
+                // TODO: Improve sparql response types visual
                 // https://github.com/BlueBrain/nexus/issues/756
                 return (
                   <Tooltip title={entry.datatype}>

--- a/src/subapps/admin/components/ViewForm/view-form.scss
+++ b/src/subapps/admin/components/ViewForm/view-form.scss
@@ -20,3 +20,7 @@
     overflow-x: scroll;
   }
 }
+
+.react-json-view .object-key-val .pushed-content.object-container {
+  width: 100% !important;
+}

--- a/src/subapps/admin/containers/ElasticSearchQuery.tsx
+++ b/src/subapps/admin/containers/ElasticSearchQuery.tsx
@@ -70,19 +70,17 @@ const ElasticSearchQueryContainer: FC<{
     });
 
   return (
-    <>
-      <ElasticSearchQueryForm
-        query={query}
-        response={data}
-        busy={isLoading}
-        error={error}
-        from={from}
-        size={size}
-        onPaginationChange={onPaginationChange}
-        onQueryChange={onQueryChange}
-        onChangePageSize={onChangePageSize}
-      />
-    </>
+    <ElasticSearchQueryForm
+      query={query}
+      response={data}
+      busy={isLoading}
+      error={error}
+      from={from}
+      size={size}
+      onPaginationChange={onPaginationChange}
+      onQueryChange={onQueryChange}
+      onChangePageSize={onChangePageSize}
+    />
   );
 };
 

--- a/src/subapps/admin/containers/SettingsContainer.scss
+++ b/src/subapps/admin/containers/SettingsContainer.scss
@@ -13,5 +13,19 @@
   }
   .ant-menu-item-selected {
     border-right: 3px solid #0985a4 !important;
+    width: 100%;
   }
+}
+
+.query-control-panel {
+  width: 100%;
+  padding: .75rem;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  background-color: #f0efef;
+}
+
+.execute-sparql-query-btn {
+  align-self: flex-end;
 }

--- a/src/subapps/admin/views/ElasticSearchQueryView.tsx
+++ b/src/subapps/admin/views/ElasticSearchQueryView.tsx
@@ -9,7 +9,6 @@ import {
 import { useNexusContext } from '@bbp/react-nexus';
 import { Button, Col, Row, Select } from 'antd';
 import queryString from 'query-string';
-
 import { useOrganisationsSubappContext } from '..';
 import { getResourceLabel } from 'shared/utils';
 import useNotification from 'shared/hooks/useNotification';

--- a/src/subapps/admin/views/SparqlQueryView.tsx
+++ b/src/subapps/admin/views/SparqlQueryView.tsx
@@ -5,7 +5,6 @@ import { Link } from 'react-router-dom';
 import { ViewList, DEFAULT_SPARQL_VIEW_ID, View } from '@bbp/nexus-sdk/es';
 import { useNexusContext } from '@bbp/react-nexus';
 import queryString from 'query-string';
-
 import { useOrganisationsSubappContext } from '..';
 import SparqlQueryContainer from '../containers/SparqlQuery';
 import { getResourceLabel } from 'shared/utils';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

1. Fix some bad use of `useEffect` both in ES/SparQL query tabs. (use events instead)
2. use `useQuery/useMutation` instead of `useEffect` (bad use of useEffect on mutation the query editor).
3. Fix style of query editor and query results (remove duplicate pagination components).

**NOTE** both components need refactoring in next part of migration.

## Description

<!--- Describe your changes in detail -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
