### PR TITLE
4262 // All revisions inside the list should be accessible (atleast t…

### DIFF
--- a/src/shared/containers/ResourceViewActionsContainer.tsx
+++ b/src/shared/containers/ResourceViewActionsContainer.tsx
@@ -281,7 +281,11 @@ const ResourceViewActionsContainer: React.FC<{
   return (
     <Row>
       <Col>
-        <Dropdown overlay={revisionMenuItems}>
+        <Dropdown
+          overlay={revisionMenuItems}
+          placement="bottom"
+          overlayStyle={{ overflowY: 'scroll', maxHeight: '500px' }}
+        >
           <Button>
             Revision {resource._rev}{' '}
             {revisionLabels(resource._rev).length > 0 &&


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes [#4667](https://app.zenhub.com/workspaces/blue-brain-nexus-60ace035034cae00105c9307/issues/gh/bluebrain/nexus/4667)

### Before:
User cannot see versions that are outside viewport (in this case, they can't see version <=13 )

![Screenshot from 2024-01-17 11-51-30](https://github.com/BlueBrain/nexus-web/assets/11242410/c38473c0-1a2f-488f-8ea7-8e1f14314756)


### After:
User can scroll and access all versions

![Screenshot from 2024-01-17 11-53-04](https://github.com/BlueBrain/nexus-web/assets/11242410/380683a6-374c-4367-947d-1108512bbbad)

## How has this been tested?
I showed a couple different solutions to Sarah (original reporter of the bug). She settled on this one. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [X] I have added screenshots (if applicable), in the comment section.
