### PR TITLE
Hotfix // Remove double encoding of id to load resource correctly in search

### DIFF
--- a/cypress/e2e/ResourceContainer.cy.ts
+++ b/cypress/e2e/ResourceContainer.cy.ts
@@ -90,6 +90,17 @@ describe('Resource with id that contains URL encoded characters', () => {
     });
   });
 
+  it('resource with any id opens when user clicks on resource row in Search table', function() {
+    cy.visit(`/search?layout=Neuron%20Morphology`);
+
+    cy.findAllByTestId('search-table-row')
+      .first()
+      .click();
+
+    cy.findByText('Advanced View').click();
+    cy.contains(`"@id"`);
+  });
+
   it('resource opens when user directly navigates to resource page', function() {
     const resourcePage = `/${Cypress.env('ORG_LABEL')}/${
       this.projectLabel

--- a/src/subapps/search/containers/SearchContainer.tsx
+++ b/src/subapps/search/containers/SearchContainer.tsx
@@ -84,13 +84,15 @@ const SearchContainer: React.FC = () => {
       background: location,
     });
   };
-  const onRowClick = (record: any): { onClick: () => void } => {
+  const onRowClick = (
+    record: any
+  ): { onClick: () => void; 'data-testid': string } => {
     return {
       onClick: () => {
         const [orgLabel, projectLabel] = record.project.label.split('/');
-        const resourceId = encodeURIComponent(record['@id']);
-        goToResource(orgLabel, projectLabel, resourceId);
+        goToResource(orgLabel, projectLabel, record['@id']);
       },
+      'data-testid': 'search-table-row',
     };
   };
   const {


### PR DESCRIPTION
When a row is clicked in search table, a double encoded id is incorrectly pushed to `history`. Since we are [now pinning v4.5]() of `history` dependency, these doubly encoded characters are not decoded during the push (which is correct and expected - details in the linked PR). The solution I've implemented here simply removes the double encoding.

## How has this been tested?
1. With fusion using production delta, I've verified that resources in [search page](http://localhost:8000/search?layout=Neuron%20Morphology) load correctly when the row is clicked.
2. Resources in my-data table, data-explorer, and project list view continue to load correctly
3. Resources with encoded characters in their id (like [this](http://localhost:8000/copies/sscx/resources/https%3A%2F%2Fdev.nise.bbp.epfl.ch%2Fnexus%2Fv1%2Fresources%2Fcopies%2Fsscx%2F_%2F1bd3d9a5-7533-4033-b575-1823862c7b8c)) load correctly (verified through e2e tests).
4. Resources download correctly

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
