### PR TITLE
Fix custom linter in `CodeEditor` component

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install Dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
-        run: yarn install --frozen-lockfile 
+        run: yarn install --frozen-lockfile
 
   prettify:
     runs-on: ubuntu-latest
@@ -49,7 +49,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.10.0
-          
+
       - name: Install Dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ coverage/
 cypress/screenshots/
 cypress/videos/
 cypress.env.json
+cypress/downloads/
 
 # Editor-specific files
 .vscode/

--- a/package.json
+++ b/package.json
@@ -28,8 +28,6 @@
     "test:ui": "vitest --ui",
     "knip": "knip",
     "lint": "tslint --project tsconfig.json",
-    "start": "NODE_ENV=development DEBUG=* webpack --mode development --config-name server && node dist/server.js",
-    "start:storybook": "start-storybook -p 6006",
     "style": "prettier --check \"./src/**/*.{ts,tsx,js,jsx,less}\"",
     "style:fix": "prettier --write \"./src/**/*.{ts,tsx,js,jsx,less}\"",
     "e2e:open": "cypress open",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "@testing-library/react": "^14.0.0",
     "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/user-event": "^14.5.2",
-    "@types/codemirror": "^5.60.7",
+    "@types/codemirror": "^5.60.15",
     "@types/compression": "^1.7.3",
     "@types/cookie-parser": "^1.4.1",
     "@types/cytoscape": "^3.19.16",

--- a/src/shared/components/Header/Header.tsx
+++ b/src/shared/components/Header/Header.tsx
@@ -20,7 +20,7 @@ import { updateAboutModalVisibility } from '../../store/actions/modals';
 import { triggerCopy as copyCmd } from '../../utils/copy';
 import { AdvancedModeToggle } from '../../molecules';
 import useNotification from '../../hooks/useNotification';
-import fusionLogo from '../../images/EPFL_BBP_logo.svg';
+import fusionLogo from '../../images/fusion_logo.svg';
 
 import './Header.scss';
 

--- a/src/shared/components/ResourceEditor/CodeEditor.tsx
+++ b/src/shared/components/ResourceEditor/CodeEditor.tsx
@@ -92,6 +92,7 @@ const CodeEditor = forwardRef<codemirror.Editor | undefined, TCodeEditor>(
             (editor as React.MutableRefObject<
               codemirror.Editor
             >).current = editorElement;
+            editor?.current?.setValue(value);
           }}
           editorWillUnmount={() => {
             const editorWrapper = (editor as React.MutableRefObject<

--- a/src/shared/components/ResourceEditor/CodeEditor.tsx
+++ b/src/shared/components/ResourceEditor/CodeEditor.tsx
@@ -5,10 +5,9 @@ import codemirror from 'codemirror';
 import 'codemirror/addon/lint/lint.css';
 import 'codemirror/addon/lint/lint.js';
 import 'codemirror/mode/javascript/javascript'; // Ensure you have the JavaScript mode
-import React, { forwardRef, useCallback, useRef, useState } from 'react';
+import React, { forwardRef, useCallback, useRef } from 'react';
 import { UnControlled as CodeMirror } from 'react-codemirror2';
-import { INDENT_UNIT, highlightUrlOverlay } from './editorUtils';
-import ts from 'typescript';
+import { INDENT_UNIT } from './editorUtils';
 
 type TCodeEditor = {
   busy: boolean;
@@ -26,18 +25,15 @@ type TEditorConfiguration = codemirror.EditorConfiguration & {
 };
 
 const CodeEditor = forwardRef<codemirror.Editor | undefined, TCodeEditor>(
-  (
-    {
-      busy,
-      value,
-      editable,
-      fullscreen,
-      keyFoldCode,
-      handleChange,
-      onLintError,
-    },
-    ref
-  ) => {
+  ({
+    busy,
+    value,
+    editable,
+    fullscreen,
+    keyFoldCode,
+    handleChange,
+    onLintError,
+  }) => {
     const prevLinterErrorsRef = useRef<LinterIssue[]>([]);
     const handleLintErrors = useCallback((text: string) => {
       const linterErrors = customLinter(text);

--- a/src/shared/components/ResourceEditor/CodeEditor.tsx
+++ b/src/shared/components/ResourceEditor/CodeEditor.tsx
@@ -5,9 +5,10 @@ import codemirror from 'codemirror';
 import 'codemirror/addon/lint/lint.css';
 import 'codemirror/addon/lint/lint.js';
 import 'codemirror/mode/javascript/javascript'; // Ensure you have the JavaScript mode
-import React, { forwardRef, useCallback, useRef } from 'react';
+import React, { forwardRef, useCallback, useRef, useState } from 'react';
 import { UnControlled as CodeMirror } from 'react-codemirror2';
 import { INDENT_UNIT, highlightUrlOverlay } from './editorUtils';
+import ts from 'typescript';
 
 type TCodeEditor = {
   busy: boolean;
@@ -50,6 +51,9 @@ const CodeEditor = forwardRef<codemirror.Editor | undefined, TCodeEditor>(
       return linterErrors;
     }, []);
 
+    const editor = useRef<codemirror.Editor>();
+    const wrapper = useRef(null);
+
     return (
       <Spin spinning={busy}>
         <CodeMirror
@@ -88,9 +92,19 @@ const CodeEditor = forwardRef<codemirror.Editor | undefined, TCodeEditor>(
             fullscreen && 'full-screen-mode'
           )}
           onChange={handleChange}
-          editorDidMount={editor => {
-            highlightUrlOverlay(editor);
-            (ref as React.MutableRefObject<codemirror.Editor>).current = editor;
+          editorDidMount={editorElement => {
+            (editor as React.MutableRefObject<
+              codemirror.Editor
+            >).current = editorElement;
+          }}
+          editorWillUnmount={() => {
+            const editorWrapper = (editor as React.MutableRefObject<
+              CodeMirror.Editor
+            >).current.getWrapperElement();
+            if (editor) editorWrapper.remove();
+            if (wrapper.current) {
+              (wrapper.current as { hydrated: boolean }).hydrated = false;
+            }
           }}
         />
       </Spin>

--- a/src/shared/components/ResourceEditor/index.tsx
+++ b/src/shared/components/ResourceEditor/index.tsx
@@ -110,7 +110,7 @@ const ResourceEditor: React.FC<ResourceEditorProps> = props => {
     onMetadataChange?.(checked);
   };
 
-  const handleChange = (editor: any, data: any, value: any) => {
+  const handleChange = (editor: any, _data: any, value: any) => {
     editor;
     if (!editable) {
       return;

--- a/src/shared/components/ResourceEditor/index.tsx
+++ b/src/shared/components/ResourceEditor/index.tsx
@@ -67,6 +67,7 @@ const ResourceEditor: React.FC<ResourceEditorProps> = props => {
   const [stringValue, setStringValue] = useState(
     JSON.stringify(rawData, null, 2)
   );
+
   const {
     dataExplorer: { fullscreen },
   } = useSelector((state: RootState) => ({

--- a/src/shared/containers/DataTableContainer.spec.tsx
+++ b/src/shared/containers/DataTableContainer.spec.tsx
@@ -418,9 +418,11 @@ describe(
 
       await user.click(secondRowCheckbox!);
 
-      await screen.findByText(
+      const notifications = await screen.findAllByText(
         '2 other resources with same metadata have also been automatically selected for download.'
       );
+
+      expect(notifications.length).toBeGreaterThan(0);
     });
   },
 
@@ -467,7 +469,7 @@ export const invalidSparqlHandler = rest.post(
       'https://bluebrain.github.io/nexus/vocabulary/defaultSparqlIndex'
     )}/sparql`
   ),
-  (req, res, ctx) => {
+  (_req, res, ctx) => {
     return res(ctx.status(400), ctx.json(invalidSparqlQueryResponse));
   }
 );

--- a/src/shared/containers/DataTableContainer.tsx
+++ b/src/shared/containers/DataTableContainer.tsx
@@ -584,7 +584,7 @@ const DataTableContainer: React.FC<DataTableProps> = ({
             }}
             rowKey={r => r.tableKey!}
             data-testid="dashboard-table"
-            onChange={(page, fileter, sorter, extra) => {
+            onChange={(_page, _fileter, _sorter, extra) => {
               setDisplayedRows(extra.currentDataSource?.length ?? 0);
             }}
           />

--- a/src/shared/containers/ResourcePlugins.tsx
+++ b/src/shared/containers/ResourcePlugins.tsx
@@ -22,7 +22,6 @@ const ResourcePlugins: React.FunctionComponent<{
 }> = ({
   resource,
   goToResource,
-  empty = null,
   openPlugins,
   studioDefinedPluginsToInclude,
   builtInPlugins,
@@ -137,7 +136,7 @@ const ResourcePlugins: React.FunctionComponent<{
             >
               <Collapse
                 key={pluginData.name}
-                onChange={e => handleCollapseChange(pluginData.name)}
+                onChange={() => handleCollapseChange(pluginData.name)}
                 activeKey={
                   openPlugins.includes(pluginData.name)
                     ? pluginData.name

--- a/src/shared/containers/ResourceViewContainer.tsx
+++ b/src/shared/containers/ResourceViewContainer.tsx
@@ -636,7 +636,7 @@ const ResourceViewContainer: React.FunctionComponent<{
   }, []);
   return (
     <>
-      <div className="resource-details">
+      <div className="resource-details" data-testid="resource-details">
         <Helmet
           title={`${
             resource ? getResourceLabel(resource) : resourceId

--- a/src/subapps/studioLegacy/containers/__tests__/WorkSpaceMenuContainerHandlers.ts
+++ b/src/subapps/studioLegacy/containers/__tests__/WorkSpaceMenuContainerHandlers.ts
@@ -29,7 +29,7 @@ export const workspaceHandler = rest.get(
 
 export const dashboardHandler = rest.get(
   deltaPath('/resources/org/project/_/d1'),
-  (req, res, ctx) => {
+  (_req, res, ctx) => {
     const mockResponse = {
       '@context': [
         'https://bluebrain.github.io/nexus/contexts/metadata.json',
@@ -53,7 +53,7 @@ export const dashboardHandler = rest.get(
 
 export const tableHandler = rest.get(
   deltaPath('/resources/org/project/_/dataTable1'),
-  (req, res, ctx) => {
+  (_req, res, ctx) => {
     const mockResponse = {
       '@context': [
         'https://bluebrain.github.io/nexus/contexts/metadata.json',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2582,7 +2582,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/codemirror@^5.60.7":
+"@types/codemirror@^5.60.15":
   version "5.60.15"
   resolved "https://registry.yarnpkg.com/@types/codemirror/-/codemirror-5.60.15.tgz#0f82be6f4126d1e59cf4c4830e56dcd49d3c3e8a"
   integrity sha512-dTOvwEQ+ouKJ/rE9LT1Ue2hmP6H1mZv5+CCnNWu2qtiOe2LQa9lCprEY20HxiDmV/Bxh+dXjywmy5aKvoGjULA==


### PR DESCRIPTION
The custom linter for the `CodeComponent` was broken due to the new migration changes. This PR fixes this. Additionally, there was the wrong logo on the nav bar on the top left – I also reverted these changes.

## Description

## How has this been tested?

Manual testing.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

