### PR TITLE
Fix fetch identities to allow the user select projects

### DIFF
--- a/src/authManager.tsx
+++ b/src/authManager.tsx
@@ -15,7 +15,9 @@ import { fetchIdentitiesFulfilledAction } from 'shared/store/actions/auth';
 
 const userManagerCache: Map<string, UserManager> = new Map();
 
-export const getUserManager = (state: RootState): UserManager | undefined => {
+export const getUserManager = (
+  state: Pick<RootState, 'config' | 'auth'>
+): UserManager | undefined => {
   const {
     auth: { realms },
     config: { clientId, redirectHostName, preferredRealm },
@@ -62,10 +64,6 @@ export const setupUserSession = async (userManager: UserManager) => {
   userManager.events.addUserLoaded(async user => {
     loadUser(store, userManager);
     localStorage.setItem('nexus__token', user.access_token);
-    const identities = await (
-      await fetch(`${store.getState().config.apiEndpoint}/identities`)
-    ).json();
-    store.dispatch(fetchIdentitiesFulfilledAction(identities));
   });
 
   // Raised prior to the access token expiring.

--- a/src/shared/App.tsx
+++ b/src/shared/App.tsx
@@ -46,7 +46,6 @@ const App: React.FC = () => {
       queryFn: () => nexus.Identity.list(),
       refetchOnWindowFocus: false,
       onSuccess: (data: IdentityList) => {
-        console.log('@@onSuccess', data);
         store.dispatch(fetchIdentitiesFulfilledAction(data));
       },
     },

--- a/src/shared/layouts/FusionMainLayout.tsx
+++ b/src/shared/layouts/FusionMainLayout.tsx
@@ -36,7 +36,7 @@ const FusionMainLayout: React.FC<{
   const [consent, setConsent] = useLocalStorage<ConsentType>(
     'consentToTracking'
   );
-  const state = useSelector((state: RootState) => state);
+  const auth = useSelector((state: RootState) => state.auth);
   const oidc = useSelector((state: RootState) => state.oidc);
   const config = useSelector((state: RootState) => state.config);
 
@@ -44,7 +44,7 @@ const FusionMainLayout: React.FC<{
   const token = oidc && oidc.user && !!oidc.user.access_token;
   const name =
     oidc.user && oidc.user.profile && oidc.user.profile.preferred_username;
-  const userManager = getUserManager(state);
+  const userManager = getUserManager({ config, auth });
   const authenticated = !isEmpty(oidc.user);
 
   const handleLogout: MenuItemProps['onClick'] = e => {
@@ -52,6 +52,7 @@ const FusionMainLayout: React.FC<{
     localStorage.removeItem('nexus__state');
     userManager && userManager.signoutRedirect();
   };
+
   return (
     <>
       <SeoHeaders />

--- a/src/shared/modals/CreateProject/CreateProject.tsx
+++ b/src/shared/modals/CreateProject/CreateProject.tsx
@@ -117,6 +117,7 @@ const CreateProject: React.FC<{}> = ({}) => {
   const nexus = useNexusContext();
   const history = useHistory();
   const { identities } = useSelector((state: RootState) => state.auth);
+
   const userUri = identities?.data?.identities.find(
     t => t['@type'] === 'User'
   )?.['@id'];
@@ -162,6 +163,7 @@ const CreateProject: React.FC<{}> = ({}) => {
         deprecated: false,
       }),
   });
+
   const { mutateAsync, status } = useMutation(createProjectMutation);
   const handleSubmit = ({
     organization,

--- a/src/shared/store/actions/auth.ts
+++ b/src/shared/store/actions/auth.ts
@@ -4,7 +4,6 @@ import { getUserManager } from '../../../authManager';
 import { RootState } from '../reducers';
 import { ThunkAction } from '..';
 import { FetchAction, FetchFulfilledAction, FetchFailedAction } from './utils';
-import { TLocationState } from '../../../pages/IdentityPage/IdentityPage';
 
 export enum AuthActionTypes {
   IDENTITY_FETCHING = '@@nexus/AUTH_IDENTITY_FETCHING',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

the issue was in home page/create-project 
when the user want to create a project, he must specify the organization, the organization fetched based on the user identifier by filtering the identities object by `User` type 

the solution: moved fetching the identities when the app complete reneder and push it to the store, 
used `useQueries` to group the version api and the identities api in the `App.tsx`
## Description

<!--- Describe your changes in detail -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
