### PR TITLE
Don't show linter issues when `showMetadata` toggling

### DIFF
--- a/src/shared/components/ResourceActions/ResourceActions.scss
+++ b/src/shared/components/ResourceActions/ResourceActions.scss
@@ -2,7 +2,7 @@
 
 .resource-actions {
   display: flex;
-  padding: $default-pad 0;
+  padding: 0 0 $default-pad 0;
   font-size: 0.8rem;
 
   button {

--- a/src/shared/components/ResourceEditor/ResourceEditor.scss
+++ b/src/shared/components/ResourceEditor/ResourceEditor.scss
@@ -6,6 +6,14 @@
   color: #0070c9;
 }
 
+.ant-tabs-nav-list {
+  padding: 0 20px;
+}
+
+button.cancel {
+  margin-right: 5px;
+}
+
 .CodeMirror {
   pre {
     color: #333333;

--- a/src/shared/components/ResourceEditor/ResourceEditor.scss
+++ b/src/shared/components/ResourceEditor/ResourceEditor.scss
@@ -47,10 +47,10 @@ button.cancel {
 
 .control-panel {
   display: flex;
-  padding: 1rem;
-  height: 52px;
   justify-content: space-between;
   background-color: #f0efef;
+  padding: 1rem;
+  height: 52px;
 }
 
 ._positive {
@@ -62,36 +62,36 @@ button.cancel {
 }
 
 .CodeMirror-url-copy {
-  cursor: pointer !important;
   display: flex;
-  align-items: center;
   justify-content: center;
+  align-items: center;
   z-index: 999 !important;
+  cursor: pointer !important;
+  box-shadow: 0 2px 12px 0 rgba(#333, 0.12) !important;
+  border: 1px solid rgba(#333, 0.12) !important;
+  border-radius: 4px !important;
+  background-color: #fff !important;
+  padding: 0px !important;
   width: 25px !important;
   height: 25px !important;
-  border-radius: 4px !important;
-  padding: 0px !important;
-  background-color: #fff !important;
-  border: 1px solid rgba(#333, 0.12) !important;
-  box-shadow: 0 2px 12px 0 rgba(#333, 0.12) !important;
   &.copied {
-    width: max-content !important;
     padding: 2px 4px !important;
+    width: max-content !important;
   }
   .copied {
-    color: #333 !important;
     margin-left: 3px;
+    color: #333 !important;
   }
 }
 
 .code-mirror-editor {
   .cm-fusion-resource-link:not(.cm-property) {
-    color: #0974ca !important;
     cursor: pointer !important;
-    background-color: rgba(#0974ca, 0.12);
-    border-radius: 4px;
-    padding: 1px;
     border: 0.5px solid rgba(#0974ca, 0.14);
+    border-radius: 4px;
+    background-color: rgba(#0974ca, 0.12);
+    padding: 1px;
+    color: #0974ca !important;
 
     &.wait-for-tooltip {
       cursor: progress !important;
@@ -123,18 +123,18 @@ button.cancel {
 
 .CodeMirror-hover-tooltip-popover,
 .CodeMirror-hover-tooltip {
-  background-color: white;
-  border: 1px solid 333;
-  box-shadow: 0 2px 12px rgba(#333, 0.12);
-  border-radius: 4px;
-  font-size: 10pt;
-  overflow: hidden;
   position: fixed;
   z-index: 9999;
-  max-width: 600px;
-  white-space: pre-wrap;
   transition: all 0.4s ease-in-out;
+  box-shadow: 0 2px 12px rgba(#333, 0.12);
+  border: 1px solid 333;
+  border-radius: 4px;
+  background-color: white;
   padding: 4px 0;
+  max-width: 600px;
+  overflow: hidden;
+  font-size: 10pt;
+  white-space: pre-wrap;
 
   &.popover {
     background-color: white !important;
@@ -142,15 +142,15 @@ button.cancel {
     .CodeMirror-hover-tooltip-resources-content {
       display: flex;
       flex-direction: column;
-      align-items: flex-start;
       justify-content: flex-start;
+      align-items: flex-start;
 
       .CodeMirror-hover-tooltip-item {
-        width: 100%;
-        padding: 4px;
-        align-items: center;
         justify-content: flex-start;
+        align-items: center;
         cursor: pointer;
+        padding: 4px;
+        width: 100%;
 
         .tag {
           background-color: #0083cb;
@@ -171,10 +171,10 @@ button.cancel {
 
   &-content {
     display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    justify-content: flex-start;
     row-gap: 2px;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: flex-start;
 
     &.error {
       .tag {
@@ -204,18 +204,18 @@ button.cancel {
 
   &-item {
     display: flex;
-    align-items: center;
     justify-content: center;
+    align-items: center;
     padding: 2px 10px 2px 5px;
     overflow: hidden;
     user-select: none;
 
     .tag {
-      color: white;
-      padding: 2px 5px;
-      border-radius: 4px;
       margin-right: 5px;
       box-shadow: 0 2px 12px rgba(#333, 0.12);
+      border-radius: 4px;
+      padding: 2px 5px;
+      color: white;
     }
 
     .title {
@@ -224,11 +224,11 @@ button.cancel {
     }
 
     .download-icon {
+      cursor: pointer;
+      margin-left: 10px;
       width: 24px;
       height: 24px;
-      margin-left: 10px;
       color: #0083cb;
-      cursor: pointer;
     }
 
     .key-binding {
@@ -240,48 +240,48 @@ button.cancel {
 
 .editor-controls-panel {
   display: flex;
-  align-items: center;
   justify-content: space-between;
+  align-items: center;
   gap: 20px;
   width: 100%;
 }
 
 kbd {
-  background-color: #eee;
-  border-radius: 3px;
-  border: 1px solid #b4b4b4;
+  display: inline-block;
   box-shadow: 0 1px 1px rgba(0, 0, 0, 0.2),
     0 2px 0 0 rgba(255, 255, 255, 0.7) inset;
-  color: #333;
-  display: inline-block;
-  font-size: 0.85em;
-  font-weight: 700;
-  line-height: 1;
+  border: 1px solid #b4b4b4;
+  border-radius: 3px;
+  background-color: #eee;
   padding: 2px 4px;
+  color: #333;
+  font-weight: 700;
+  font-size: 0.85em;
+  line-height: 1;
   white-space: nowrap;
 }
 
 .CodeMirror-hover-tooltip-warning {
   .warning-text {
-    background-color: rgba(red, 0.12);
     margin-top: -4px;
-    padding: 5px 10px;
-    border-top-left-radius: 4px;
     border-top-right-radius: 4px;
+    border-top-left-radius: 4px;
+    background-color: rgba(red, 0.12);
+    padding: 5px 10px;
     font-weight: 600;
   }
 
   .warning-info {
+    display: flex;
+    justify-content: flex-start;
+    align-items: flex-start;
+    gap: 5px;
+    margin-bottom: 5px;
+    border-bottom: 1px solid #f0efef;
     padding: 4px 10px;
+    color: #0974ca;
     font-size: 13px;
     line-height: 18px;
-    color: #0974ca;
-    display: flex;
-    align-items: flex-start;
-    justify-content: flex-start;
-    gap: 5px;
-    border-bottom: 1px solid #f0efef;
-    margin-bottom: 5px;
     .warning-info-icon {
       margin-top: 3px;
       width: 16px;

--- a/src/shared/components/ResourceEditor/index.tsx
+++ b/src/shared/components/ResourceEditor/index.tsx
@@ -255,7 +255,7 @@ const ResourceEditor: React.FC<ResourceEditorProps> = props => {
       )}
 
       {/* Show to the user if there's a custom linter issue */}
-      {isValidJSON && linterIssues.length > 0 && (
+      {isValidJSON && linterIssues.length > 0 && !showMetadata && (
         <Alert
           message={
             <>

--- a/src/shared/components/ResourceListBoard/ListBoard.scss
+++ b/src/shared/components/ResourceListBoard/ListBoard.scss
@@ -1,24 +1,26 @@
 @import '../../lib.scss';
 
 .list-board {
+  padding: $default-pad $default-pad 0;
   height: calc(100vh - 150px);
   overflow: hidden;
   overflow-x: scroll;
-  padding: $default-pad $default-pad 0;
   & > .wrapper {
     display: flex;
-    width: fit-content;
     padding-bottom: $default-pad;
+    width: fit-content;
     height: 100%;
   }
   & > .wrapper > .resource-list {
+    margin: 0 0.5em;
     &:first-child {
       margin-left: 0;
     }
     &:last-child {
-      // necessary beause the queries board padding doesn't contain last element
       margin-right: $default-pad;
+      background-color: rgba(0, 0, 0, 0.3);
+      // Necessary because the queries board padding doesn't contain last element
+      color: white;
     }
-    margin: 0 0.5em;
   }
 }

--- a/src/shared/containers/AdminPluginContainer.tsx
+++ b/src/shared/containers/AdminPluginContainer.tsx
@@ -71,23 +71,6 @@ const AdminPlugin: React.FunctionComponent<AdminProps> = ({
 
   const content = (
     <>
-      <AccessControl
-        path={`/${orgLabel}/${projectLabel}`}
-        permissions={['resources/write']}
-        noAccessComponent={() => <></>}
-      >
-        {editable && (
-          <Alert
-            message={
-              <>
-                <EditOutlined /> You can edit this resource.
-              </>
-            }
-            type="success"
-          />
-        )}
-      </AccessControl>
-
       <ResourceActionsContainer
         editable={editable}
         resource={resource}

--- a/src/shared/containers/ResourceEditor.tsx
+++ b/src/shared/containers/ResourceEditor.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
   ExpandedResource,
   ResourceSource,
@@ -23,36 +23,36 @@ import {
 } from '../utils';
 
 const ResourceEditorContainer: React.FunctionComponent<{
-  resourceId: string;
-  orgLabel: string;
-  projectLabel: string;
   rev: number;
+  orgLabel: string;
+  resourceId: string;
+  tabChange?: boolean;
+  projectLabel: string;
+  showExpanded?: boolean;
+  showFullScreen: boolean;
   defaultExpanded?: boolean;
   defaultEditable?: boolean;
+  showControlPanel?: boolean;
+  showMetadataToggle?: boolean;
   onSubmit: (value: object) => void;
   onExpanded?: (expanded: boolean) => void;
-  tabChange?: boolean;
-  showMetadataToggle?: boolean;
-  showFullScreen: boolean;
-  showExpanded?: boolean;
-  showControlPanel?: boolean;
 }> = ({
-  resourceId,
-  orgLabel,
-  projectLabel,
   rev,
-  defaultEditable = false,
-  defaultExpanded = false,
-  onSubmit,
-  onExpanded,
+  orgLabel,
   tabChange,
+  resourceId,
+  projectLabel,
+  showExpanded,
   showMetadataToggle,
   showFullScreen = false,
+  defaultEditable = false,
+  defaultExpanded = false,
   showControlPanel = true,
-  showExpanded,
+  onSubmit,
+  onExpanded,
 }) => {
-  const nexus = useNexusContext();
   const dispatch = useDispatch();
+  const nexus = useNexusContext();
   const navigate = useHistory();
   const location = useLocation();
   const notification = useNotification();
@@ -69,7 +69,7 @@ const ResourceEditorContainer: React.FunctionComponent<{
     error: null,
   });
 
-  React.useEffect(() => {
+  useEffect(() => {
     setResource({
       resource,
       error: null,
@@ -153,13 +153,13 @@ const ResourceEditorContainer: React.FunctionComponent<{
     }
   };
 
-  async function getResourceSource(
+  const getResourceSource = async (
     nexus: NexusClient,
     orgLabel: string,
     projectLabel: string,
     resourceId: string,
     rev: number
-  ) {
+  ) => {
     try {
       return await nexus.Resource.getSource(
         orgLabel,
@@ -171,7 +171,7 @@ const ResourceEditorContainer: React.FunctionComponent<{
     } catch {
       return {} as ResourceSource;
     }
-  }
+  };
 
   const getNewResource = async () => {
     if (expanded) {

--- a/src/shared/containers/ResourceEditor.tsx
+++ b/src/shared/containers/ResourceEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { FC, useEffect, useState } from 'react';
 import {
   ExpandedResource,
   ResourceSource,
@@ -22,7 +22,7 @@ import {
   getResourceLabel,
 } from '../utils';
 
-const ResourceEditorContainer: React.FunctionComponent<{
+const ResourceEditorContainer: FC<{
   rev: number;
   orgLabel: string;
   resourceId: string;
@@ -56,10 +56,10 @@ const ResourceEditorContainer: React.FunctionComponent<{
   const navigate = useHistory();
   const location = useLocation();
   const notification = useNotification();
-  const [expanded, setExpanded] = React.useState(defaultExpanded);
-  const [editable, setEditable] = React.useState(defaultEditable);
-  const [showMetadata, setShowMetadata] = React.useState<boolean>(false);
-  const [{ busy, resource }, setResource] = React.useState<{
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  const [editable, setEditable] = useState(defaultEditable);
+  const [showMetadata, setShowMetadata] = useState<boolean>(false);
+  const [{ busy, resource }, setResource] = useState<{
     busy: boolean;
     resource: ResourceSource | ExpandedResource | Resource | null;
     error: Error | null;


### PR DESCRIPTION
Issue found by Bilal. Fixing the problem where the linter issues are not shown when the `showMetaData` toggle is set to true, as it then displays linter errors caused by the underscores in the metadata.

Also:
- I removed the "You can edit this resource" information as I actually removed this in a PR before the migration
- I changed and cleaned some styles that I used to change and adjust in the original PR #1443

## Description

## How has this been tested?

- Local dev and prod builds pointing to `staging`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
