### PR TITLE
fix: data explorer header has too much height

### DIFF
--- a/src/shared/molecules/DataExplorerGraphFlowMolecules/styles.scss
+++ b/src/shared/molecules/DataExplorerGraphFlowMolecules/styles.scss
@@ -1,5 +1,3 @@
-
-
 .navigation-stack-item {
   display: flex;
   align-items: flex-start;
@@ -44,7 +42,6 @@
     }
 
     .title {
-      font-family: 'Titillium Web';
       font-style: normal;
       font-weight: 600;
       font-size: 12px;
@@ -68,7 +65,6 @@
     }
 
     .types {
-      font-family: 'Titillium Web';
       font-style: normal;
       font-weight: 300;
       font-size: 12px;

--- a/src/shared/organisms/DataPanel/styles.scss
+++ b/src/shared/organisms/DataPanel/styles.scss
@@ -165,7 +165,7 @@
       font-style: normal;
       font-weight: 400;
       font-size: 12px;
-      line-height: 130%;
+      line-height: 110%;
       letter-spacing: 0.04em;
       text-transform: uppercase;
       color: white;

--- a/src/subapps/dataExplorer/styles.scss
+++ b/src/subapps/dataExplorer/styles.scss
@@ -290,10 +290,10 @@ td.ant-table-cell.data-explorer-column {
     font-style: normal;
     font-weight: 400;
     font-size: 12px;
-    line-height: 130%;
+    line-height: 110%;
     letter-spacing: 0.04em;
     color: #8c8c8c;
-    height: 52px;
+    height: 32px;
     min-width: 72px;
     max-width: fit-content;
     box-sizing: content-box !important;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Data explorer header has too big height 

## Description

<!--- Describe your changes in detail -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
