### PR TITLE
fix: omit the resource metadata from the update endpoint

### DIFF
--- a/src/pages/StudiosPage/StudiosPage.tsx
+++ b/src/pages/StudiosPage/StudiosPage.tsx
@@ -124,7 +124,7 @@ const StudioItem = ({
               )}
             </h3>
           </Link>
-          <p>{description}</p>
+          <p className="description">{description}</p>
         </div>
         <div className="statistics studios-list-item">
           <div className="statistics_item">

--- a/src/shared/styles/route-layout.less
+++ b/src/shared/styles/route-layout.less
@@ -132,6 +132,7 @@
                   text-align: center;
                   vertical-align: middle;
                 }
+
                 .depreacted-tag {
                   font-family: 'Titillium Web';
                   font-style: normal;
@@ -143,6 +144,7 @@
                   margin: 0 3px;
                   vertical-align: middle;
                 }
+
                 .deletion-tag {
                   font-family: 'Titillium Web';
                   font-style: normal;
@@ -166,6 +168,14 @@
                 color: @fusion-daybreak-9;
                 max-width: 80%;
               }
+            }
+
+            .description {
+              overflow: hidden;
+              display: -webkit-box;
+              -webkit-box-orient: vertical;
+              -webkit-line-clamp: 2;
+              line-clamp: 2;
             }
 
             .statistics {

--- a/src/subapps/studioLegacy/containers/StudioContainer.tsx
+++ b/src/subapps/studioLegacy/containers/StudioContainer.tsx
@@ -2,7 +2,9 @@ import * as React from 'react';
 import { Resource } from '@bbp/nexus-sdk';
 import { useNexusContext, AccessControl } from '@bbp/react-nexus';
 import { Empty, message } from 'antd';
+import { omitBy } from 'lodash';
 import { useHistory } from 'react-router';
+
 import EditStudio from '../components/EditStudio';
 import StudioHeader from '../components/StudioHeader';
 import StudioReactContext from '../contexts/StudioContext';
@@ -114,7 +116,9 @@ const StudioContainer: React.FunctionComponent = () => {
         studioId,
         studioResource._rev,
         {
-          ...studioResource,
+          // remove the metadata from the payload, delta do full update
+          // and not accept the metadata fields to be in the payload
+          ...omitBy(studioResource, (_, key) => key.trim().startsWith('_')),
           label,
           description,
           plugins,
@@ -145,7 +149,7 @@ const StudioContainer: React.FunctionComponent = () => {
       onSave={updateStudio}
       onSaveImage={saveImage(nexus, orgLabel, projectLabel)}
       markdownViewer={MarkdownViewerContainer}
-    ></EditStudio>
+    />
   );
   return (
     <>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

fix update studio details

reproduction: 
1. select studio
2. click on edit studio
3. try to update at least one field as title, or description

fix: the payload of the update resource endpoint must only contains the relative data without the metadata 
either way delta will fail

extra: I update the description of the studio in the studio listing view to show only 2 lines of the description, I noticed that many studio has a big description 

## Description

<!--- Describe your changes in detail -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
