### PR TITLE
Studio // Dont override column config when one aleady exists

### DIFF
--- a/src/shared/components/EditTableForm.tsx
+++ b/src/shared/components/EditTableForm.tsx
@@ -273,14 +273,18 @@ const EditTableForm: React.FC<{
           return Object.assign(result, current);
         }, {});
 
-        return Object.keys(mergedItem).map(title => ({
-          '@type': '',
-          name: title,
-          format: '',
-          enableSearch: false,
-          enableSort: false,
-          enableFilter: false,
-        }));
+        return Object.keys(mergedItem).map(title => {
+          const currentItemConfig = findCurrentColumnConfig(title);
+          return {
+            '@type': '',
+            name: title,
+            format: '',
+            enableSearch: false,
+            enableSort: false,
+            enableFilter: false,
+            ...currentItemConfig,
+          };
+        });
       }
 
       const result = await querySparql(
@@ -295,14 +299,19 @@ const EditTableForm: React.FC<{
             .sort((a, b) => {
               return a.title > b.title ? 1 : -1;
             })
-            .map(x => ({
-              '@type': 'text',
-              name: x.dataIndex,
-              format: '',
-              enableSearch: false,
-              enableSort: false,
-              enableFilter: false,
-            }));
+            .map(header => {
+              const currentHeaderConfig =
+                findCurrentColumnConfig(header.dataIndex) ?? {};
+              return {
+                '@type': 'text',
+                name: header.dataIndex,
+                format: '',
+                enableSearch: false,
+                enableSort: false,
+                enableFilter: false,
+                ...currentHeaderConfig,
+              };
+            });
         })
         .catch(error => {
           // Sometimes delta's error message can be in `name` or `reason` field.
@@ -322,12 +331,7 @@ const EditTableForm: React.FC<{
     {
       onSuccess: data => {
         updateTableDataError(null);
-        if (
-          isNil(configuration) ||
-          (configuration as TableColumn[]).length === 0
-        ) {
-          setConfiguration(data);
-        }
+        setConfiguration(data);
       },
       onError: (error: Error) => {
         updateTableDataError(error);
@@ -338,6 +342,16 @@ const EditTableForm: React.FC<{
       retry: false,
     }
   );
+
+  const findCurrentColumnConfig = (name: string) => {
+    if (Array.isArray(configuration)) {
+      return configuration.find(column => column.name === name);
+    }
+    if (configuration?.name === name) {
+      return { ...configuration };
+    }
+    return undefined;
+  };
 
   const onChangeName = (event: any) => {
     setName(event.target.value);

--- a/src/shared/hooks/useAccessDataForTable.tsx
+++ b/src/shared/hooks/useAccessDataForTable.tsx
@@ -634,6 +634,7 @@ export const useAccessDataForTable = (
         );
         return result;
       }
+
       return {};
     },
     {


### PR DESCRIPTION
This is a hotfix for [this bug](https://bluebrainproject.slack.com/archives/G013010870B/p1708528986899869?thread_ts=1708441294.600089&cid=G013010870B) in production. 

## How to test

Two scenarios should be tested.

1. Create a new  dashboard with a long query like this one. On clicking "Configure Columns", you should see 16 columns.

```
PREFIX nxv: <https://bluebrain.github.io/nexus/vocabulary/>
PREFIX nsg: <https://neuroshapes.org/>
PREFIX schema: <http://schema.org/>
PREFIX prov: <http://www.w3.org/ns/prov#>
PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
PREFIX skos: <http://www.w3.org/2004/02/skos/core#> 

PREFIX bmo: <https://bbp.epfl.ch/ontologies/core/bmo/>

SELECT DISTINCT (CONCAT(STR(?self_wo_tag), '?tag=20240219') AS ?self) ?name ?brainRegion ?subjectName ?subjectSpecies ?subjectStrain ?xCoordinate ?yCoordinate ?zCoordinate ?somaNumberOfPoints (CONCAT(STR(?length), " (", ?unit, ")") AS ?totalAxonLength) ?reconstructionSystem ?paperCitation (STRAFTER(?atlas_identifier_, "data/") AS ?atlasIdentifier) ?contributor (STRAFTER(?registered_by_str, "users/") AS ?registeredBy) ?registeredAt
WHERE { 
  GRAPH ?g0 {
?entity nxv:self ?self_wo_tag ;
        a nsg:NeuronMorphology ;
        nxv:deprecated false ;
        schema:name ?name ;
        nxv:createdBy ?registered_by ;
        nxv:createdAt ?registeredAt .
OPTIONAL { ?entity nsg:contribution / prov:agent ?contributor_id } .
OPTIONAL { ?entity nsg:subject / schema:name ?subjectName } .
OPTIONAL { ?entity nsg:subject / nsg:species / rdfs:label ?subjectSpecies } .
OPTIONAL { ?entity nsg:subject / nsg:strain / rdfs:label ?subjectStrain } .
OPTIONAL { ?entity nsg:brainLocation / nsg:coordinatesInBrainAtlas / nsg:valueX ?xCoordinate ;
         		   nsg:brainLocation / nsg:coordinatesInBrainAtlas / nsg:valueY ?yCoordinate ;
         		   nsg:brainLocation / nsg:coordinatesInBrainAtlas / nsg:valueZ ?zCoordinate} .
OPTIONAL { ?entity  nsg:isRegisteredIn ?atlas_identifier } .
OPTIONAL { ?entity  nsg:generation / prov:activity / nsg:hadProtocol / schema:keywords ?reconstructionSystem } .
OPTIONAL { ?entity  nsg:generation / prov:activity / nsg:hadProtocol / schema:citation ?paperCitation } .
BIND (STR(?registered_by) AS ?registered_by_str) . 
BIND (STR(?atlas_identifier) AS ?atlas_identifier_) . 
 }
 OPTIONAL { ?contributor_id schema:name ?contributor } .
 GRAPH ?g {
    OPTIONAL {
      ?entity nsg:brainLocation / nsg:brainRegion / rdfs:label ?brainRegion .
    }
  }
      OPTIONAL { 
 GRAPH ?g1 {
  ?somaAnnotation a nsg:Annotation ;
                  nsg:hasTarget / nsg:hasSource ?entity ;
                  bmo:compartment "Soma" ;
                  nsg:hasBody ?somaBody .
          ?somaBody nsg:isMeasurementOf / rdfs:label "Soma Number Of Points" ;
                schema:value / nsg:series ?soma_mean_stat .
          ?soma_mean_stat nsg:statistic "N" ;
                     schema:value ?somaNumberOfPoints } .
  }
     OPTIONAL { 
   GRAPH ?g2 {
        ?axonAnnotation a nsg:Annotation ;
           nsg:hasTarget / nsg:hasSource ?entity ;
             bmo:compartment "Axon" ;
                      nsg:hasBody ?axonBody .
          ?axonBody nsg:isMeasurementOf / rdfs:label "Total Length" ;
                schema:value / nsg:series ?axon_mean_stat .
          ?axon_mean_stat nsg:statistic "raw" ;
                     schema:value ?length ;
         			 schema:unitCode ?unit } .
  }
 FILTER (?registeredAt > "2023-09-01T00:00:00+00:00"^^xsd:dateTime)
}   
LIMIT 1000 
```

2. Create a simple dashboard. Enable some settings (like searching, sorting etc). Refresh page, and open the dialog again. The settings should have been preserved.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
