### PR TITLE
Download of resources with tags in their ids should work

### DIFF
--- a/src/shared/containers/ResourceViewActionsContainer.tsx
+++ b/src/shared/containers/ResourceViewActionsContainer.tsx
@@ -69,7 +69,8 @@ const ResourceViewActionsContainer: React.FC<{
     } else {
       const localStorageObjects = toLocalStorageResources(
         resource,
-        'resource-view'
+        'resource-view',
+        recordKey
       );
 
       selectedRowKeys = uniq([...selectedRowKeys, recordKey]);

--- a/src/shared/hooks/useAccessDataForTable.tsx
+++ b/src/shared/hooks/useAccessDataForTable.tsx
@@ -499,13 +499,15 @@ export const useAccessDataForTable = (
           return;
         })
         .process(async row => {
+          const recordKey = getStudioLocalStorageKey(row);
           const fetchedRow = await fetchResourceForDownload(
             getStudioLocalStorageKey(row),
             nexus
           );
           const localStorageResources = toLocalStorageResources(
             fetchedRow,
-            'studios'
+            'studios',
+            recordKey
           );
           rowKeysForLS.push(getStudioLocalStorageKey(row));
 
@@ -544,7 +546,8 @@ export const useAccessDataForTable = (
       const deltaResource = await fetchResourceForDownload(recordKey, nexus);
       const localStorageResource = toLocalStorageResources(
         deltaResource,
-        'studios'
+        'studios',
+        recordKey
       );
       localStorageRowKeys = [...localStorageRowKeys, recordKey];
       localStorageRows = [...localStorageRows, ...localStorageResource];

--- a/src/shared/molecules/MyDataTable/MyDataTable.tsx
+++ b/src/shared/molecules/MyDataTable/MyDataTable.tsx
@@ -414,11 +414,16 @@ const MyDataTable: React.FC<TProps> = ({
       setFetchingResources(true);
       const expandedResource = await fetchResourceForDownload(recordKey, nexus);
       setFetchingResources(false);
-      localStorageRows = toLocalStorageResources(expandedResource, 'my-data');
+      localStorageRows = toLocalStorageResources(
+        expandedResource,
+        'my-data',
+        recordKey
+      );
     } else {
-      localStorageRows = toLocalStorageResources(record, 'my-data');
+      localStorageRows = toLocalStorageResources(record, 'my-data', recordKey);
     }
-    toLocalStorageResources(record, 'my-data');
+    // TODO: Check if needed
+    toLocalStorageResources(record, 'my-data', recordKey);
     let selectedRowKeys = dataPanelLS?.selectedRowKeys || [];
     let selectedRows = dataPanelLS?.selectedRows || [];
 
@@ -488,10 +493,15 @@ const MyDataTable: React.FC<TProps> = ({
             const fetchedRow = await fetchResourceForDownload(row._self, nexus);
             localStorageResources = toLocalStorageResources(
               fetchedRow,
-              'my-data'
+              'my-data',
+              row._self
             );
           } else {
-            localStorageResources = toLocalStorageResources(row, 'my-data');
+            localStorageResources = toLocalStorageResources(
+              row,
+              'my-data',
+              row._self
+            );
           }
           return localStorageResources;
         });

--- a/src/shared/utils/__tests__/datapanel.spec.ts
+++ b/src/shared/utils/__tests__/datapanel.spec.ts
@@ -20,7 +20,8 @@ describe('datapanel utilities', () => {
   it('serializes resources with no distribution correctly to local storage object', () => {
     const actualLSResources = toLocalStorageResources(
       resourceWithoutDistrition,
-      'studios'
+      'studios',
+      resourceWithoutDistrition._self
     );
     const expectedParentDistributionValue = {
       hasDistribution: false,
@@ -49,7 +50,8 @@ describe('datapanel utilities', () => {
   it('serializes resource of type file with no distribution correctly', () => {
     const actualLSResources = toLocalStorageResources(
       fileResourceWithNoDistribution,
-      'my-data'
+      'my-data',
+      fileResourceWithNoDistribution._self
     );
     expect(actualLSResources.length).toEqual(1);
     const expectedParentDistributionValue = {
@@ -66,7 +68,11 @@ describe('datapanel utilities', () => {
 
   it('serializes resources with distribution array correctly to local storage object', () => {
     const resource = resourceWithDistributionArray;
-    const serializedItems = toLocalStorageResources(resource, 'studios');
+    const serializedItems = toLocalStorageResources(
+      resource,
+      'studios',
+      resource._self
+    );
 
     expect(serializedItems.length).toEqual(5);
     const actualParentDistributionValue = serializedItems[0].distribution;
@@ -88,7 +94,11 @@ describe('datapanel utilities', () => {
       label: undefined,
       name: ['Sterling', 'Malory', 'Archer'],
     };
-    const serializedItems = toLocalStorageResources(resource, 'studios');
+    const serializedItems = toLocalStorageResources(
+      resource,
+      'studios',
+      resource._self
+    );
 
     expect(serializedItems.length).toEqual(5);
     expect(serializedItems[0].name).toEqual('Sterling-Malory-Archer');
@@ -96,7 +106,11 @@ describe('datapanel utilities', () => {
 
   it('serializes correct distribution value for each distribution item in array', () => {
     const resource = resourceWithDistributionArray;
-    const serializedItems = toLocalStorageResources(resource, 'studios');
+    const serializedItems = toLocalStorageResources(
+      resource,
+      'studios',
+      resource._self
+    );
 
     const originalDistItems = resource.distribution;
     const serializedDistItems = serializedItems.slice(1);
@@ -119,7 +133,11 @@ describe('datapanel utilities', () => {
 
   it('serializes resources with distribution objects correctly', () => {
     const resource = resourceWithDistributionObject;
-    const actualSerializedItems = toLocalStorageResources(resource, 'studios');
+    const actualSerializedItems = toLocalStorageResources(
+      resource,
+      'studios',
+      resource._self
+    );
 
     expect(actualSerializedItems.length).toEqual(2);
 
@@ -158,7 +176,11 @@ describe('datapanel utilities', () => {
         contentSize: 123,
       },
     };
-    const actualSerializedItems = toLocalStorageResources(resource, 'studios');
+    const actualSerializedItems = toLocalStorageResources(
+      resource,
+      'studios',
+      resource._self
+    );
 
     expect(actualSerializedItems[1].distribution?.contentSize).toEqual(123);
   });
@@ -171,14 +193,22 @@ describe('datapanel utilities', () => {
         contentSize: [10, 20],
       },
     };
-    const actualSerializedItems = toLocalStorageResources(resource, 'studios');
+    const actualSerializedItems = toLocalStorageResources(
+      resource,
+      'studios',
+      resource._self
+    );
 
     expect(actualSerializedItems[1].distribution?.contentSize).toEqual(30);
   });
 
   it('serializes resources when distribution is empty array', () => {
     const resource = { ...resourceWithoutDistrition, distribution: [] };
-    const actualSerializedItems = toLocalStorageResources(resource, 'studios');
+    const actualSerializedItems = toLocalStorageResources(
+      resource,
+      'studios',
+      resource._self
+    );
 
     expect(actualSerializedItems.length).toEqual(1);
     const expectedDistributionValue = {
@@ -195,7 +225,11 @@ describe('datapanel utilities', () => {
 
   it('serializes resources when distribution is empty object', () => {
     const resource = { ...resourceWithoutDistrition, distribution: {} };
-    const actualSerializedItems = toLocalStorageResources(resource, 'studios');
+    const actualSerializedItems = toLocalStorageResources(
+      resource,
+      'studios',
+      resource._self
+    );
 
     expect(actualSerializedItems.length).toEqual(2);
     expect(actualSerializedItems[0].distribution).toBeDefined();

--- a/src/shared/utils/datapanel.ts
+++ b/src/shared/utils/datapanel.ts
@@ -11,11 +11,12 @@ import { parseURL } from './nexusParse';
 const baseLocalStorageObject = (
   resource: Resource,
   source: string,
+  key: string,
   keySuffix?: string
 ): Omit<TDataSource, 'distribution'> => {
   return {
     source,
-    key: keySuffix ? `${resource._self}-${keySuffix}` : resource._self,
+    key: keySuffix ? `${key}-${keySuffix}` : key,
     _self: resource._self,
     id: resource['@id'],
     name: getResourceLabel(resource),
@@ -31,7 +32,8 @@ const baseLocalStorageObject = (
 
 export const toLocalStorageResources = (
   resource: Resource,
-  source: string
+  source: string,
+  key: string
 ): TDataSource[] => {
   const resourceName = getResourceLabel(resource);
   try {
@@ -39,7 +41,7 @@ export const toLocalStorageResources = (
     if (isNil(resource.distribution)) {
       return [
         {
-          ...baseLocalStorageObject(resource, source),
+          ...baseLocalStorageObject(resource, source, key),
           localStorageType: 'resource',
           distribution: {
             hasDistribution: false,
@@ -63,7 +65,7 @@ export const toLocalStorageResources = (
 
       // First store an object for the parent resource.
       localStorageObjs.push({
-        ...baseLocalStorageObject(resource, source),
+        ...baseLocalStorageObject(resource, source, key),
         localStorageType: 'resource',
         distributionItemsLength: resource.distribution.length,
         distribution: {
@@ -79,7 +81,7 @@ export const toLocalStorageResources = (
       // Now store an object for each distribution item
       resource.distribution.forEach((distItem, index) => {
         localStorageObjs.push({
-          ...baseLocalStorageObject(resource, source, `${index}`),
+          ...baseLocalStorageObject(resource, source, key, `${index}`),
           localStorageType: 'distribution',
           distribution: {
             hasDistribution: true, // So, we don't download the distribution twice
@@ -100,7 +102,7 @@ export const toLocalStorageResources = (
     return [
       // First store an object for the parent resource.
       {
-        ...baseLocalStorageObject(resource, source),
+        ...baseLocalStorageObject(resource, source, key),
         localStorageType: 'resource',
         distribution: {
           hasDistribution: true,
@@ -113,7 +115,7 @@ export const toLocalStorageResources = (
       },
       // Now store an object for the distribution item.
       {
-        ...baseLocalStorageObject(resource, source, '1'),
+        ...baseLocalStorageObject(resource, source, key, '1'),
         localStorageType: 'distribution',
         distribution: {
           hasDistribution: true,

--- a/src/subapps/dataExplorer/DataExplorerTable.tsx
+++ b/src/subapps/dataExplorer/DataExplorerTable.tsx
@@ -127,7 +127,8 @@ export const DataExplorerTable = forwardRef<AntdTableRef, TDataExplorerTable>(
 
       const localStorageRows = toLocalStorageResources(
         record,
-        DATA_EXPLORER_NAMESPACE
+        DATA_EXPLORER_NAMESPACE,
+        recordKey
       );
       let selectedRowKeys = dataPanelLS?.selectedRowKeys || [];
       let selectedRows = dataPanelLS?.selectedRows || [];
@@ -178,7 +179,7 @@ export const DataExplorerTable = forwardRef<AntdTableRef, TDataExplorerTable>(
 
       if (selected) {
         const results = changeRows.map(row =>
-          toLocalStorageResources(row, DATA_EXPLORER_NAMESPACE)
+          toLocalStorageResources(row, DATA_EXPLORER_NAMESPACE, row._self)
         );
         selectedRows = [...selectedRows, ...results.flat()];
         selectedRowKeys = [...selectedRowKeys, ...changeRows.map(t => t._self)];

--- a/src/subapps/search/containers/SearchContainer.tsx
+++ b/src/subapps/search/containers/SearchContainer.tsx
@@ -149,8 +149,8 @@ const SearchContainer: React.FC = () => {
     resetAll();
   };
   const handleSelect = (record: Resource, selected: any) => {
-    const newRecords = toLocalStorageResources(record, layout);
     const recordKey = record._self;
+    const newRecords = toLocalStorageResources(record, layout, recordKey);
     const dataPanelLS: TResourceTableData = JSON.parse(
       localStorage.getItem(DATA_PANEL_STORAGE)!
     );
@@ -195,7 +195,7 @@ const SearchContainer: React.FC = () => {
   ) => {
     const changedRowsLS: TDataSource[] = [];
     changeRows.forEach(row => {
-      const localStorageRows = toLocalStorageResources(row, layout);
+      const localStorageRows = toLocalStorageResources(row, layout, row._self);
       changedRowsLS.push(...localStorageRows);
     });
 


### PR DESCRIPTION
Same as [this PR](https://github.com/BlueBrain/nexus-web/pull/1505) but rebased on `migration-merge` branch.

How to test

1. Start frontend pointing to delta prod
2. Go to [this resource](http://localhost:8000/studios/bbp-external/seu/studios/https%3A%2F%2Fbbp.epfl.ch%2Fdata%2Fbbp-external%2Fseu%2F434b4165-6ab7-4900-bc03-b3fadf07e874?workspaceId=https%3A%2F%2Fbbp.epfl.ch%2Fdata%2Fbbp-external%2Fseu%2F9404baff-c6e5-43f6-8820-47ffc6dea321&dashboardId=https%3A%2F%2Fbbp.epfl.ch%2Fdata%2Fbbp-external%2Fseu%2F66ad9b53-e8e7-41a9-b5e6-848e00319260) locally
3. Add 2 resources to data download - this should work
4. Remove one resource - data panel should update (this is the part that was broken) 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
