### PR TITLE
Studio // Dont override column config when one aleady exists

### DIFF
--- a/src/shared/hooks/useAccessDataForTable.tsx
+++ b/src/shared/hooks/useAccessDataForTable.tsx
@@ -633,6 +633,7 @@ export const useAccessDataForTable = (
         );
         return result;
       }
+
       return {};
     },
     {


### PR DESCRIPTION
Same [PR as this](https://github.com/BlueBrain/nexus-web/pull/1506) but rebased on top of `migration-merge`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
