### PR TITLE
Migration/fix Query Editor line jumping

### DIFF
--- a/src/shared/components/ResourceEditor/ResourceEditor.scss
+++ b/src/shared/components/ResourceEditor/ResourceEditor.scss
@@ -45,12 +45,21 @@ button.cancel {
   }
 }
 
+.ant-card.ant-card-bordered.results {
+  margin-top: 2rem !important;
+}
+
+.ant-form-item {
+  margin-bottom: 0;
+}
+
 .control-panel {
   display: flex;
   justify-content: space-between;
+  align-items: center;
   background-color: #f0efef;
-  padding: 1rem;
-  height: 52px;
+  padding: 0.75rem;
+  height: 56px;
 }
 
 ._positive {

--- a/src/subapps/admin/components/Projects/QueryEditor.tsx
+++ b/src/subapps/admin/components/Projects/QueryEditor.tsx
@@ -63,6 +63,7 @@ const QueryEditor: React.FC<{
   if (loading) {
     return null;
   }
+
   return (
     <div className="query-editor">
       <div className="query-editor__header">

--- a/src/subapps/admin/components/Projects/QueryEditor.tsx
+++ b/src/subapps/admin/components/Projects/QueryEditor.tsx
@@ -1,23 +1,23 @@
-import { useEffect, useState } from 'react';
-import { Tabs } from 'antd';
-import { useHistory, useRouteMatch } from 'react-router';
 import {
   DEFAULT_ELASTIC_SEARCH_VIEW_ID,
   DEFAULT_SPARQL_VIEW_ID,
 } from '@bbp/nexus-sdk/es';
 import { useNexusContext } from '@bbp/react-nexus';
-import SparqlQueryView from '../../views/SparqlQueryView';
-import ElasticSearchQueryView from '../../views/ElasticSearchQueryView';
-import useNotification from '../../../../shared/hooks/useNotification';
+import { Tabs } from 'antd';
+import { FC, useEffect, useState } from 'react';
+import { useHistory, useRouteMatch } from 'react-router';
 import { useOrganisationsSubappContext } from '../..';
+import useNotification from '../../../../shared/hooks/useNotification';
+import ElasticSearchQueryView from '../../views/ElasticSearchQueryView';
+import SparqlQueryView from '../../views/SparqlQueryView';
 import './QueryEditor.scss';
 
-const QueryEditor: React.FC<{
+const QueryEditor: FC<{
   orgLabel: string;
   projectLabel: string;
   onUpdate: () => void;
 }> = ({ orgLabel, projectLabel }) => {
-  const subapp = useOrganisationsSubappContext();
+  const subApp = useOrganisationsSubappContext();
   const history = useHistory();
   const match = useRouteMatch<{
     orgLabel: string;
@@ -52,7 +52,7 @@ const QueryEditor: React.FC<{
       setLoading(false);
       history.replace(
         `/${
-          subapp.namespace
+          subApp.namespace
         }/${orgLabel}/${projectLabel}/query/${encodeURIComponent(
           DEFAULT_SPARQL_VIEW_ID
         )}`
@@ -79,7 +79,7 @@ const QueryEditor: React.FC<{
             setActiveKey(tab);
             history.replace(
               `/${
-                subapp.namespace
+                subApp.namespace
               }/${orgLabel}/${projectLabel}/query/${encodeURIComponent(
                 tab === 'sparql'
                   ? DEFAULT_SPARQL_VIEW_ID

--- a/src/subapps/admin/components/ViewForm/ElasticSearchQueryForm.tsx
+++ b/src/subapps/admin/components/ViewForm/ElasticSearchQueryForm.tsx
@@ -50,23 +50,22 @@ const ElasticSearchQueryForm: FC<{
   onChangePageSize,
 }): JSX.Element => {
   const [_initialQuery, setInitialQuery] = useState('');
-  const [valid, setValid] = useState(true);
   // TODO Clean multiple states
   const [value, _setValue] = useState<string>();
-  const [pageSize, setPageSize] = useState<number>(size);
-  const editor = useRef<codemirror.Editor>();
   const wrapper = useRef(null);
 
-  const [editorValue, setEditorValue] = useState(''); // New state to manage the editor content
+  const [editorValue, setEditorValue] = useState('');
+  const [valid, setValid] = useState(true);
+  const [pageSize, setPageSize] = useState<number>(size);
+  const editor = useRef<codemirror.Editor>();
 
   useEffect(() => {
     const formattedInitialQuery = JSON.stringify(query, null, 2);
-    setInitialQuery(formattedInitialQuery);
-    setEditorValue(formattedInitialQuery); // Initialize the editor value with the formatted query
-  }, [query]); // Dependency on `query` to update initial value when the prop changes
+    setEditorValue(formattedInitialQuery);
+  }, [query]);
 
   const handleChange = (_: any, __: any, value: string) => {
-    setEditorValue(value); // Update editor value directly
+    setEditorValue(value);
     try {
       JSON.parse(value);
       setValid(true);
@@ -96,9 +95,9 @@ const ElasticSearchQueryForm: FC<{
   return (
     <div className="view-form">
       <Form
-        onFinish={() => {
-          value && onQueryChange(JSON.parse(value));
-        }}
+        // onFinish={() => {
+        //   editorValue && onQueryChange(JSON.parse(editorValue));
+        // }}
         layout="vertical"
       >
         <>
@@ -115,6 +114,7 @@ const ElasticSearchQueryForm: FC<{
             </div>
           </div>
           <CodeMirror
+            autoCursor={false}
             value={editorValue}
             options={{
               mode: { name: 'javascript', json: true },
@@ -140,7 +140,12 @@ const ElasticSearchQueryForm: FC<{
           />
         </>
         <FormItem>
-          <Button type="primary" htmlType="submit" disabled={!valid}>
+          <Button
+            type="primary"
+            htmlType="submit"
+            disabled={!valid}
+            style={{ marginTop: '10px' }}
+          >
             Execute ElasticSearch query
           </Button>
         </FormItem>

--- a/src/subapps/admin/components/ViewForm/ElasticSearchQueryForm.tsx
+++ b/src/subapps/admin/components/ViewForm/ElasticSearchQueryForm.tsx
@@ -65,11 +65,6 @@ const ElasticSearchQueryForm: FC<{
     setEditorValue(formattedInitialQuery);
   }, [query]);
 
-  useEffect(() => {
-    const formattedInitialQuery = JSON.stringify(query, null, 2);
-    setInitialQuery(formattedInitialQuery);
-  }, []);
-
   const handleChange = (_: any, __: any, value: string) => {
     setEditorValue(value);
     try {

--- a/src/subapps/admin/components/ViewForm/ElasticSearchQueryForm.tsx
+++ b/src/subapps/admin/components/ViewForm/ElasticSearchQueryForm.tsx
@@ -1,15 +1,15 @@
-import { useEffect, useRef, useState } from 'react';
-import { Form, Button, Card, List, Empty } from 'antd';
 import {
   CheckCircleOutlined,
   ExclamationCircleOutlined,
 } from '@ant-design/icons';
-import ReactJson from 'react-json-view';
 import { ElasticSearchViewQueryResponse } from '@bbp/nexus-sdk/es';
+import { Button, Card, Empty, Form, List } from 'antd';
 import * as codemirror from 'codemirror';
-import { UnControlled as CodeMirror } from 'react-codemirror2';
 import 'codemirror/addon/display/placeholder';
 import 'codemirror/mode/javascript/javascript';
+import { useEffect, useRef, useState } from 'react';
+import { UnControlled as CodeMirror } from 'react-codemirror2';
+import ReactJson from 'react-json-view';
 
 import './view-form.scss';
 

--- a/src/subapps/admin/components/ViewForm/SparqlQueryInput.tsx
+++ b/src/subapps/admin/components/ViewForm/SparqlQueryInput.tsx
@@ -1,15 +1,15 @@
-import React, { useRef } from 'react';
 import * as codemirror from 'codemirror';
-import { UnControlled as UnControlledCodeMirror } from 'react-codemirror2';
-import 'codemirror/mode/javascript/javascript';
 import 'codemirror/addon/display/autorefresh';
 import 'codemirror/addon/display/placeholder';
+import 'codemirror/lib/codemirror.css';
+import 'codemirror/mode/javascript/javascript';
 import 'codemirror/mode/sparql/sparql';
 import 'codemirror/theme/base16-light.css';
-import 'codemirror/lib/codemirror.css';
+import { FC, useRef } from 'react';
+import { UnControlled as UnControlledCodeMirror } from 'react-codemirror2';
 import './SparqlQueryInput.scss';
 
-const SparqlQueryInput: React.FunctionComponent<{
+const SparqlQueryInput: FC<{
   value?: string;
   onChange?: (query: string) => void;
 }> = ({ value = '', onChange }) => {
@@ -25,8 +25,8 @@ const SparqlQueryInput: React.FunctionComponent<{
       <div className="code">
         <UnControlledCodeMirror
           ref={wrapper}
+          autoCursor={false}
           value={value}
-          autoCursor={true}
           autoScroll={true}
           options={{
             mode: { name: 'sparql' },

--- a/src/subapps/admin/components/ViewForm/view-form.scss
+++ b/src/subapps/admin/components/ViewForm/view-form.scss
@@ -6,9 +6,9 @@
     margin: 0 auto;
   }
   .code {
+    margin-bottom: $default-pad;
     max-height: 600;
     overflow: 'scroll';
-    margin-bottom: $default-pad;
   }
   .ant-card-body {
     overflow: scroll;

--- a/src/subapps/admin/containers/ElasticSearchQuery.tsx
+++ b/src/subapps/admin/containers/ElasticSearchQuery.tsx
@@ -1,14 +1,14 @@
-import { useState, FC } from 'react';
-import { useNexusContext } from '@bbp/react-nexus';
 import {
   DEFAULT_ELASTIC_SEARCH_VIEW_ID,
   ElasticSearchViewQueryResponse,
 } from '@bbp/nexus-sdk/es';
+import { useNexusContext } from '@bbp/react-nexus';
+import { FC, useState } from 'react';
 
+import { useQuery } from 'react-query';
 import ElasticSearchQueryForm, {
   NexusESError,
 } from '../components/ViewForm/ElasticSearchQueryForm';
-import { useQuery } from 'react-query';
 
 const DEFAULT_PAGE_SIZE = 5;
 const DEFAULT_QUERY = {


### PR DESCRIPTION
When trying to edit a query or create a new one, the active line jumps to the last line if you type. This PR fixes this issue.

![comparison](https://github.com/BlueBrain/nexus-web/assets/34251194/eecc6fe8-58cd-4d3d-b31c-d31442d2d0e1)

Additionally:
- Cleaned and refactored touched components.
- Adjusted styles a bit.
- Moved the "Execute Elasticsearch query" button to the top right, as is the case with other code editor buttons in the Fusion app.

## How has this been tested?

- Tested locally with dev server and prod build on my MacBook.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added screenshots (if applicable), in the comment section.
