### PR TITLE
Revert "Use backslashes in file paths for windows"

### DIFF
--- a/src/shared/organisms/DataPanel/DataPanel.tsx
+++ b/src/shared/organisms/DataPanel/DataPanel.tsx
@@ -65,7 +65,6 @@ import {
 } from '../../molecules/MyDataTable/MyDataTable';
 import {
   distributionMatchesTypes,
-  getPathSeparator,
   getSizeOfResourcesToDownload,
   pathForChildDistributions,
   pathForTopLevelResources,
@@ -154,7 +153,6 @@ export async function downloadArchive({
   const resourcesForDownload = resourcesPayload.filter(
     item => item.localStorageType === 'resource'
   );
-  const slash = getPathSeparator();
 
   const resourcesNotFetched: Error[] = [];
   const { results } = await PromisePool.withConcurrency(4)
@@ -176,7 +174,7 @@ export async function downloadArchive({
         item,
         existingPaths
       );
-      const parentPath = `${path}${slash}${filename}.${extension}`;
+      const parentPath = `${path}/${filename}.${extension}`;
       // For resources with distribution(s), we want to download both, the metadata as well as all its distribution(s).
       // To do that, first prepare the metadata for download.
       topLevelResources.push({
@@ -209,7 +207,7 @@ export async function downloadArchive({
             ...item,
             // @ts-ignore
             '@type': childResource['@type'] ?? 'File',
-            path: `${childPath.path}${slash}${childPath.fileName}`,
+            path: `${childPath.path}/${childPath.fileName}`,
             _self: childResource._self ?? item._self,
             resourceId: childResource['@id'],
           });

--- a/src/shared/utils/__tests__/datapanel.spec.ts
+++ b/src/shared/utils/__tests__/datapanel.spec.ts
@@ -12,18 +12,10 @@ import {
   pathForTopLevelResources,
   toLocalStorageResources,
 } from '../datapanel';
-import * as deviceMock from 'react-device-detect';
-
-jest.mock('react-device-detect', () => ({
-  __esModule: true,
-  isWindows: false,
-}));
 
 describe('datapanel utilities', () => {
   const orgName = 'orgA';
   const projectName = 'projectA';
-
-  const getDeviceMock = () => (deviceMock as unknown) as { isWindows: boolean };
 
   it('serializes resources with no distribution correctly to local storage object', () => {
     const actualLSResources = toLocalStorageResources(
@@ -408,26 +400,6 @@ describe('datapanel utilities', () => {
     const expectPathProps = {
       path: `${parentPath}/${namePrefix}${nameSuffix}`,
       fileName: `${namePrefix}${nameSuffix}.asc`,
-    };
-
-    expect(actualPathProps).toEqual(expectPathProps);
-  });
-
-  it('uses backslashes as separator when user has windows device', () => {
-    getDeviceMock().isWindows = true;
-
-    const parentPath = `\\${orgName}\\${projectName}\\parentPath`;
-    const filename = 'awesome-file.asc';
-    const mockResource = getMockDistribution(filename);
-    const actualPathProps = pathForChildDistributions(
-      mockResource,
-      parentPath,
-      new Map()
-    );
-
-    const expectPathProps = {
-      path: `${parentPath}\\awesome-file`,
-      fileName: filename,
     };
 
     expect(actualPathProps).toEqual(expectPathProps);

--- a/src/shared/utils/datapanel.ts
+++ b/src/shared/utils/datapanel.ts
@@ -7,7 +7,6 @@ import isValidUrl from '../../utils/validUrl';
 import { ResourceObscured } from 'shared/organisms/DataPanel/DataPanel';
 import { getResourceLabel, uuidv4 } from '.';
 import { parseURL } from './nexusParse';
-import { isWindows } from 'react-device-detect';
 
 const baseLocalStorageObject = (
   resource: Resource,
@@ -267,20 +266,13 @@ export function pathForTopLevelResources(
   };
 }
 
-export const getPathSeparator = () => {
-  if (isWindows) {
-    return '\\';
-  }
-  return '/';
-};
-
 export function pathForChildDistributions(
   distItem: any,
   parentPath: string,
   existingPaths: Map<string, number>
 ) {
   const defaultUniqueName = uuidv4().substring(0, 10); // TODO use last part of child self or id
-  const slash = getPathSeparator();
+
   const fullFileName = fileNameForDistributionItem(distItem, defaultUniqueName);
   const fileNameWithoutExtension = fullFileName.slice(
     0,
@@ -289,7 +281,7 @@ export function pathForChildDistributions(
   const extension = fullFileName.slice(fullFileName.lastIndexOf('.') + 1);
 
   const childDir = fileNameWithoutExtension; // Max Length 20
-  const pathToChildFile = `${parentPath}${slash}${childDir}`; // Max Length 60 + 1 + 20 = 80
+  const pathToChildFile = `${parentPath}/${childDir}`; // Max Length 60 + 1 + 20 = 80
   let uniquePath: string; // TODO de-deuplicate
   if (existingPaths.has(pathToChildFile)) {
     const count = existingPaths.get(pathToChildFile)!;


### PR DESCRIPTION
Reverts BlueBrain/nexus-web#1511

Reverting because the issue with download is with windows being unable to extract zip files with with the in-built utility. It works on windows with third party utils like 7-zip
