### PR TITLE
Remove loader when resource saving succeeds

### DIFF
--- a/src/shared/containers/ResourceViewContainer.tsx
+++ b/src/shared/containers/ResourceViewContainer.tsx
@@ -271,11 +271,13 @@ const ResourceViewContainer: FC<{
         );
 
         const { _rev } = await updateFn();
+
         goToResource(orgLabel, projectLabel, resourceId, { revision: _rev });
         notification.success({
           message: 'Resource saved',
           description: getResourceLabel(resource),
         });
+        setResource({ resource, error: null, busy: false });
       } catch (error) {
         const potentiallyUpdatedResource = (await nexus.Resource.get(
           orgLabel,


### PR DESCRIPTION
Fixes issue reported by user on [slack message](https://bluebrainproject.slack.com/archives/C012YGNRW85/p1709631682304409) wrt to saving resources where the application appears to hang.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
