### PR TITLE
4912/validation error when updating resources

### DIFF
--- a/src/shared/components/IDResolution/ResponseViewer.tsx
+++ b/src/shared/components/IDResolution/ResponseViewer.tsx
@@ -4,12 +4,20 @@ type Props = {
   data: any;
   header?: string;
   showHeader?: boolean;
+  collapsed?: boolean;
+  style?: React.CSSProperties;
 };
 
-const ResponseViewer = ({ data, showHeader = false, header = '' }: Props) => {
+const ResponseViewer = ({
+  data,
+  showHeader = false,
+  header = '',
+  collapsed = false,
+  style = {},
+}: Props) => {
   return (
     <ReactJson
-      collapsed
+      collapsed={collapsed}
       name={showHeader ? header : undefined}
       src={data as object}
       indentWidth={3}
@@ -17,7 +25,7 @@ const ResponseViewer = ({ data, showHeader = false, header = '' }: Props) => {
       enableClipboard={false}
       displayObjectSize={false}
       displayDataTypes={false}
-      style={{ maxWidth: 'inherit', width: '600px' }}
+      style={{ maxWidth: 'inherit', width: '600px', ...style }}
     />
   );
 };

--- a/src/shared/containers/ResourceViewContainer.tsx
+++ b/src/shared/containers/ResourceViewContainer.tsx
@@ -44,6 +44,7 @@ import {
   TErrorWithType,
   TUpdateResourceFunctionError,
 } from '../../utils/types';
+import ResponseViewer from '../../shared/components/IDResolution/ResponseViewer';
 
 export type PluginMapping = {
   [pluginKey: string]: object;
@@ -255,6 +256,7 @@ const ResourceViewContainer: React.FunctionComponent<{
         notification.error({
           message: 'An error occurred whilst updating the resource',
         });
+
         if ((error as TUpdateResourceFunctionError).wasUpdated) {
           const expandedResources = (await nexus.Resource.get(
             orgLabel,
@@ -655,56 +657,75 @@ const ResourceViewContainer: React.FunctionComponent<{
 
         <Spin spinning={busy}>
           {!!error ? (
-            <Alert
-              message={
-                error.wasUpdated ? 'Resource updated with errors' : 'Error'
-              }
-              showIcon
-              closable
-              style={{ marginTop: 40 }}
-              type="error"
-              description={
-                <>
-                  <Typography.Paragraph
-                    ellipsis={{ rows: 2, expandable: true }}
-                  >
-                    {error.message}
-                  </Typography.Paragraph>
-                  {error.rejections && (
-                    <Collapse
-                      bordered={false}
-                      ghost
-                      items={[
-                        {
-                          key: '1',
-                          label: 'More detail...',
-                          children: (
-                            <>
-                              <ul>
-                                {error.rejections.map((el, ix) => (
-                                  <li key={ix}>{el.reason}</li>
-                                ))}
-                              </ul>
+            <>
+              <Alert
+                message={
+                  error.wasUpdated ? 'Resource updated with errors' : 'Error'
+                }
+                showIcon
+                closable
+                style={{ marginTop: 40 }}
+                type="error"
+                description={
+                  <>
+                    <Typography.Paragraph
+                      ellipsis={{ rows: 2, expandable: true }}
+                    >
+                      {error.message}
+                    </Typography.Paragraph>
+                    {error.rejections && (
+                      <Collapse
+                        bordered={false}
+                        ghost
+                        items={[
+                          {
+                            key: '1',
+                            label: 'More detail...',
+                            children: (
+                              <>
+                                <ul>
+                                  {error.rejections.map((el, ix) => (
+                                    <li key={ix}>{el.reason}</li>
+                                  ))}
+                                </ul>
 
-                              <p>
-                                For further information please refer to the API
-                                documentation,{' '}
-                                <a
-                                  target="_blank"
-                                  href="https://bluebrainnexus.io/docs/delta/api/"
-                                >
-                                  https://bluebrainnexus.io/docs/delta/api/
-                                </a>
-                              </p>
-                            </>
-                          ),
-                        },
-                      ]}
-                    />
-                  )}
-                </>
-              }
-            />
+                                <p>
+                                  For further information please refer to the
+                                  API documentation,{' '}
+                                  <a
+                                    target="_blank"
+                                    href="https://bluebrainnexus.io/docs/delta/api/"
+                                  >
+                                    https://bluebrainnexus.io/docs/delta/api/
+                                  </a>
+                                </p>
+                              </>
+                            ),
+                          },
+                        ]}
+                      />
+                    )}
+                  </>
+                }
+              />
+              <div
+                style={{
+                  display: 'flex',
+                  justifyContent: 'center',
+                  marginTop: '28px',
+                }}
+              >
+                <ResponseViewer
+                  data={error}
+                  showHeader={false}
+                  style={{
+                    width: '1000px',
+                    background: 'white',
+                    padding: '10px',
+                  }}
+                />
+              </div>
+            </>
           ) : (
             <>
               {resource && (

--- a/src/subapps/studioLegacy/containers/StudioContainer.tsx
+++ b/src/subapps/studioLegacy/containers/StudioContainer.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { Resource } from '@bbp/nexus-sdk/es';
 import { useNexusContext, AccessControl } from '@bbp/react-nexus';
 import { Empty, message } from 'antd';
-import { omitBy } from 'lodash';
 import { useHistory } from 'react-router';
 import omitBy from 'lodash/omitBy';
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #[4912](https://github.com/BlueBrain/nexus/issues/4912)

Adds error details in json 
![Screenshot from 2024-05-01 17-27-07](https://github.com/BlueBrain/nexus-web/assets/11242410/79eac106-da8f-4bb2-a2e6-0e297c64d295)

At the moment I've not implemented this second part or "icing on the cake" mentioned in the issue mostly because right now I only get the schema `https://neuroshapes.org/dash/cellcompositionvolume?rev=122` as a substring of the value `error.message` returned by nexus. I'm not sure if it's a good idea to parse this string (using regexp) to find the second link that kinda looks like an href and try to resolve it. It sounds flaky to me to do that. I want to discuss if `schema.contentUrl.@id` can be used instead:

> Icing on the cake, presenting a validation specific output that provides links to the relevant schema so the user can navigate to it without losing the vlaidation report currently on screen (e.g. opening a new tab).

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary unit and integration tests.
- [x] I have added screenshots (if applicable), in the comment section.
