### PR TITLE
Load resource with tag/revision if it exists in self

### DIFF
--- a/src/shared/containers/DataTableContainer.spec.tsx
+++ b/src/shared/containers/DataTableContainer.spec.tsx
@@ -432,6 +432,7 @@ describe('DataTableContainer - Row Click', () => {
   let component: RenderResult;
   let nexus: ReturnType<typeof createNexusClient>;
   let nexusSpy: jest.SpyInstance;
+  let historySpy: jest.SpyInstance;
 
   beforeAll(() => {
     server = setupServer(
@@ -485,6 +486,7 @@ describe('DataTableContainer - Row Click', () => {
           ? Promise.resolve([getMockResource('doesnt-matter', {}, 'agents')])
           : Promise.resolve(getMockResource('doesnt-matter', {}, 'agents'))
       );
+    historySpy = jest.spyOn(history, 'push');
   });
 
   // reset any request handlers that are declared as a part of our tests
@@ -494,6 +496,7 @@ describe('DataTableContainer - Row Click', () => {
     queryClient.clear();
     localStorage.clear();
     nexusSpy.mockClear();
+    historySpy.mockClear();
   });
 
   afterAll(() => {
@@ -529,6 +532,8 @@ describe('DataTableContainer - Row Click', () => {
       path: `${selfWithRevision}&format=expanded`,
       headers: { Accept: 'application/json' },
     });
+    const navigateTo = historySpy.mock.calls[0][0];
+    expect(navigateTo).toContain('rev=30');
   });
 
   it('requests correct resource from delta when user clicks on row with tag in self', async () => {
@@ -547,11 +552,13 @@ describe('DataTableContainer - Row Click', () => {
       path: `${selfWithTag}&format=expanded`,
       headers: { Accept: 'application/json' },
     });
+    const navigateTo = historySpy.mock.calls[0][0];
+    expect(navigateTo).toContain('tag=30');
   });
 
   it('requests correct resource from delta when user clicks on row with tag and revision in self', async () => {
     const selfWithTagAndRev =
-      'https://localhost:3000/resources/bbp/agents/_/persons%2Fc3358e61-7650-4954-99b7-f7572cbf5d5g?tag=30&rev=2-';
+      'https://localhost:3000/resources/bbp/agents/_/persons%2Fc3358e61-7650-4954-99b7-f7572cbf5d5g?tag=30&rev=20';
 
     const resources = [getMockStudioResource('Malory', `${selfWithTagAndRev}`)];
 
@@ -565,6 +572,8 @@ describe('DataTableContainer - Row Click', () => {
       path: `${selfWithTagAndRev}&format=expanded`,
       headers: { Accept: 'application/json' },
     });
+    const navigateTo = historySpy.mock.calls[0][0];
+    expect(navigateTo).toContain('rev=20');
   });
 
   it('requests correct resource from delta when user clicks on row with no tag or revision in self', async () => {
@@ -585,6 +594,9 @@ describe('DataTableContainer - Row Click', () => {
       path: `${selfWithoutTagOrRev}?format=expanded`,
       headers: { Accept: 'application/json' },
     });
+    const navigateTo = historySpy.mock.calls[0][0];
+    expect(navigateTo).not.toContain('rev');
+    expect(navigateTo).not.toContain('tag');
   });
 });
 

--- a/src/shared/containers/DataTableContainer.tsx
+++ b/src/shared/containers/DataTableContainer.tsx
@@ -219,19 +219,32 @@ const DataTableContainer: React.FC<DataTableProps> = ({
         if (resource['@type'] === 'Project') {
           return;
         }
-        const url = new URL(selfUrl);
-        url.searchParams.set('format', 'expanded');
+        const resourceUrl = new URL(selfUrl);
+        resourceUrl.searchParams.set('format', 'expanded');
         nexus
           .httpGet({
-            path: `${url.toString()}`,
+            path: `${resourceUrl.toString()}`,
             headers: { Accept: 'application/json' },
           })
           .then((fullIdResponse: Resource) => {
             const [orgLabel, projectLabel] = parseProjectUrl(resource._project);
-            const hist = `/${orgLabel}/${projectLabel}/resources/${encodeURIComponent(
+
+            let fullResourceId = `/${orgLabel}/${projectLabel}/resources/${encodeURIComponent(
               fullIdResponse[0]['@id']
             )}`;
-            history.push(hist, { background: location });
+
+            const revision = resourceUrl.searchParams.get('rev');
+            const tag = resourceUrl.searchParams.get('tag');
+
+            if (revision) {
+              fullResourceId = `${fullResourceId}?rev=${revision}`;
+            } else if (tag) {
+              fullResourceId = `${fullResourceId}?tag=${tag}`;
+            }
+
+            history.push(`${fullResourceId.toString()}`, {
+              background: location,
+            });
           });
       })
       .catch(error => {


### PR DESCRIPTION
Fixes #4969

If row has a self with tag/revision, load that particular tag/revision in the resource drawer

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added necessary unit and integration tests.
- [ ] I have added screenshots (if applicable), in the comment section.
